### PR TITLE
Feat: add section build details

### DIFF
--- a/dashboard/src/components/LinkWithIcon/LinkWithIcon.tsx
+++ b/dashboard/src/components/LinkWithIcon/LinkWithIcon.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 
-interface ILinkWithIcon {
+export interface ILinkWithIcon {
   title?: string | ReactElement;
   linkText?: string | ReactElement;
   link?: string;
@@ -14,7 +14,7 @@ const LinkWithIcon = ({
   link,
 }: ILinkWithIcon): JSX.Element => {
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 text-sm">
       <span className="font-bold">{title}</span>
       <a
         className="flex flex-row gap-1 items-center"

--- a/dashboard/src/components/Section/Section.tsx
+++ b/dashboard/src/components/Section/Section.tsx
@@ -1,0 +1,55 @@
+import { ReactElement, useMemo } from 'react';
+
+import LinkWithIcon, { ILinkWithIcon } from '../LinkWithIcon/LinkWithIcon';
+
+export interface ISection {
+  title: string;
+  subsections?: ISubsection[];
+  eyebrow?: string | ReactElement;
+}
+
+export interface ISubsection {
+  infos: ILinkWithIcon[];
+}
+
+const Subsection = ({ infos }: ISubsection): JSX.Element => {
+  const items = useMemo(
+    () =>
+      infos.map(info => (
+        <LinkWithIcon
+          key={info.link}
+          title={info.title}
+          link={info.link}
+          linkText={info.linkText}
+          icon={info.icon}
+        />
+      )),
+    [infos],
+  );
+  return (
+    <div className="grid grid-cols-2 py-8 border-t border-darkGray gap-8">
+      {items}
+    </div>
+  );
+};
+
+const Section = ({ title, subsections, eyebrow }: ISection): JSX.Element => {
+  const sections = useMemo(
+    () =>
+      subsections?.map(subsection => (
+        <Subsection key={subsection.infos[0].link} infos={subsection.infos} />
+      )),
+    [subsections],
+  );
+  return (
+    <div className="flex flex-col gap-4 text-dimGray">
+      <div className="flex flex-col gap-2">
+        <span className="text-sm">{eyebrow}</span>
+        <span className="text-2xl font-bold">{title}</span>
+      </div>
+      {sections}
+    </div>
+  );
+};
+
+export default Section;

--- a/dashboard/src/components/Section/SectionGroup.tsx
+++ b/dashboard/src/components/Section/SectionGroup.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+import Section, { ISection } from './Section';
+
+interface ISectionGroup {
+  sections: ISection[];
+}
+
+const SectionGroup = ({ sections }: ISectionGroup): JSX.Element => {
+  const groupSections = useMemo(
+    () =>
+      sections.map(section => (
+        <Section
+          key={section.title}
+          title={section.title}
+          subsections={section.subsections}
+          eyebrow={section.eyebrow}
+        />
+      )),
+    [sections],
+  );
+  return <div className="flex flex-col gap-8">{groupSections}</div>;
+};
+
+export default SectionGroup;

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -18,6 +18,7 @@ import './index.css';
 import Root from './routes/Root/Root';
 import Trees from './routes/Trees/Trees';
 import TreeDetails from './routes/TreeDetails/TreeDetails';
+import BuildDetails from './routes/BuildDetails/BuildDetails';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -47,6 +48,7 @@ const router = createBrowserRouter([
         path: '/tree/:treeId',
         element: <TreeDetails />,
       },
+      { path: '/build/:buildId', element: <BuildDetails /> },
     ],
   },
 ]);

--- a/dashboard/src/routes/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/routes/BuildDetails/BuildDetails.tsx
@@ -1,0 +1,121 @@
+import { ImTree } from 'react-icons/im';
+
+import { MdClose } from 'react-icons/md';
+
+import { ISection } from '@/components/Section/Section';
+import SectionGroup from '@/components/Section/SectionGroup';
+
+const BuildDetails = (): JSX.Element => {
+  return <SectionGroup sections={mockedData} />;
+};
+
+const mockedData: ISection[] = [
+  {
+    title: 'next-20240510',
+    eyebrow: 'Build Details',
+    subsections: [
+      {
+        infos: [
+          {
+            title: 'Tree',
+            linkText: 'next',
+            icon: <ImTree className="text-lightBlue" />,
+          },
+          {
+            title: 'Git Branch',
+            linkText: 'master',
+            icon: <ImTree className="text-lightBlue" />,
+          },
+          {
+            title: 'Git Describe',
+            linkText: 'next-20240510',
+          },
+          {
+            title: 'Defconfig',
+            linkText: 'decstation_64_defconfig',
+          },
+          {
+            title: 'Architecture',
+            linkText: 'arm64',
+          },
+          {
+            title: 'Build time',
+            linkText: '108 sec',
+          },
+          {
+            title: 'Git URL',
+            linkText:
+              'https://linux.kernelci.org/build/id/6683c5ecce30ba42d47e70a4/',
+          },
+          {
+            title: 'Git commit',
+            linkText: '82e4255305c554b0bb18b7ccf2db86041b4c8b6e',
+          },
+          {
+            title: 'Date',
+            linkText: '2024-07-02 09:18:36 UTC',
+          },
+          {
+            title: 'Status',
+            icon: <MdClose className="text-red" />,
+          },
+          {
+            title: 'Build Errors',
+            linkText: '3',
+          },
+          {
+            title: 'Build warnings',
+            linkText: '28',
+          },
+        ],
+      },
+      {
+        infos: [
+          {
+            title: 'Date',
+            linkText: '2024-07-02 09:18:36 UTC',
+          },
+          {
+            title: 'Status',
+            icon: <MdClose className="text-red" />,
+          },
+          {
+            title: 'Build Errors',
+            linkText: '3',
+          },
+          {
+            title: 'Build warnings',
+            linkText: '28',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Build Platform',
+    subsections: [
+      {
+        infos: [
+          {
+            title: 'System',
+            linkText: 'linux',
+          },
+          {
+            title: 'Machine type',
+            linkText: 'x86_64',
+          },
+          {
+            title: 'Node name',
+            linkText: 'build-j252325-sparc-gcc-10-tinyconfig-8dtb5',
+          },
+          {
+            title: 'CPU',
+            linkText: 'AMD EPYC 7B12',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export default BuildDetails;


### PR DESCRIPTION
- Add build details section component
- Add navigation to build details
- Add mocked build details section

## How to test it
- Run the docker compose
- Other option is to run `pnpm run dev` in dashboard
- Go to `http://localhost/build/aaaa` or `http://localhost:5173/build/aaaa`

## Visual reference
![image](https://github.com/user-attachments/assets/412247c5-e25c-43d9-816d-5fea70c636a0)
