### PR TITLE
feat: add buildDetails endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -30,3 +30,6 @@ Finnaly execute the server with:
 ```sh
 poetry run python3 manage.py runserver
 ```
+
+# Requests
+In the `/requests` directory we have scripts that execute requests to endpoints using [httpie](https://httpie.io/)

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -4,5 +4,6 @@ from kernelCI_app import views
 
 urlpatterns = [
     path('tree/', views.TreeView.as_view(), name='tree'),
-    path('tree/<str:commit_hash>', views.TreeDetails.as_view(), name='treeDetails')
+    path('tree/<str:commit_hash>', views.TreeDetails.as_view(), name='treeDetails'),
+    path('build/<str:build_id>', views.BuildDetails.as_view(), name='buildDetails')
 ]

--- a/backend/kernelCI_app/views/TreeDetailsView.py
+++ b/backend/kernelCI_app/views/TreeDetailsView.py
@@ -1,51 +1,7 @@
 from django.http import JsonResponse
 from django.views import View
 from querybuilder.query import Query
-from kernelCI_app.models import Checkouts, Builds
-from kernelCI_app.serializers import TreeSerializer
-from kernelCI_app.utils import get_visible_record_identifiers
-
-
-class TreeView(View):
-
-    def get(self, _):
-        commit_hashs = get_visible_record_identifiers('checkouts')
-        placeholders = ','.join(['%s'] * len(commit_hashs))
-
-        checkouts = Checkouts.objects.raw(
-            f"""
-            SELECT
-                checkouts.git_commit_hash AS id,
-                COUNT(DISTINCT CASE WHEN builds.valid = true THEN builds.id END) AS valid_builds,
-                COUNT(DISTINCT CASE WHEN builds.valid = false THEN builds.id END) AS invalid_builds,
-                COUNT(DISTINCT CASE WHEN builds.valid IS NULL AND builds.id IS NOT NULL THEN builds.id END)
-                    AS null_builds,
-                COUNT(DISTINCT builds.id) AS total_builds,
-                COUNT(CASE WHEN tests.status = 'FAIL' THEN 1 END) AS fail_tests,
-                COUNT(CASE WHEN tests.status = 'ERROR' THEN 1 END) AS error_tests,
-                COUNT(CASE WHEN tests.status = 'MISS' THEN 1 END) AS miss_tests,
-                COUNT(CASE WHEN tests.status = 'PASS' THEN 1 END) AS pass_tests,
-                COUNT(CASE WHEN tests.status = 'DONE' THEN 1 END) AS done_tests,
-                COUNT(CASE WHEN tests.status = 'SKIP' THEN 1 END) AS skip_tests,
-                SUM(CASE WHEN tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END)
-                    AS null_tests,
-                COUNT(tests.id) AS total_tests
-            FROM
-                checkouts
-            LEFT JOIN
-                builds ON builds.checkout_id = checkouts.id
-            LEFT JOIN
-                tests ON tests.build_id = builds.id
-            WHERE checkouts.git_commit_hash IN ({placeholders})
-            GROUP BY
-                checkouts.git_commit_hash;
-            """,
-            commit_hashs
-        )
-
-        serializer = TreeSerializer(checkouts, many=True)
-        resp = JsonResponse(serializer.data, safe=False)
-        return resp
+from kernelCI_app.models import Builds
 
 
 class TreeDetails(View):

--- a/backend/kernelCI_app/views/TreeView.py
+++ b/backend/kernelCI_app/views/TreeView.py
@@ -1,0 +1,47 @@
+from django.http import JsonResponse
+from django.views import View
+from kernelCI_app.models import Checkouts
+from kernelCI_app.serializers import TreeSerializer
+from kernelCI_app.utils import get_visible_record_identifiers
+
+
+class TreeView(View):
+
+    def get(self, _):
+        commit_hashs = get_visible_record_identifiers('checkouts')
+        placeholders = ','.join(['%s'] * len(commit_hashs))
+
+        checkouts = Checkouts.objects.raw(
+            f"""
+            SELECT
+                checkouts.git_commit_hash AS id,
+                COUNT(DISTINCT CASE WHEN builds.valid = true THEN builds.id END) AS valid_builds,
+                COUNT(DISTINCT CASE WHEN builds.valid = false THEN builds.id END) AS invalid_builds,
+                COUNT(DISTINCT CASE WHEN builds.valid IS NULL AND builds.id IS NOT NULL THEN builds.id END)
+                    AS null_builds,
+                COUNT(DISTINCT builds.id) AS total_builds,
+                COUNT(CASE WHEN tests.status = 'FAIL' THEN 1 END) AS fail_tests,
+                COUNT(CASE WHEN tests.status = 'ERROR' THEN 1 END) AS error_tests,
+                COUNT(CASE WHEN tests.status = 'MISS' THEN 1 END) AS miss_tests,
+                COUNT(CASE WHEN tests.status = 'PASS' THEN 1 END) AS pass_tests,
+                COUNT(CASE WHEN tests.status = 'DONE' THEN 1 END) AS done_tests,
+                COUNT(CASE WHEN tests.status = 'SKIP' THEN 1 END) AS skip_tests,
+                SUM(CASE WHEN tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END)
+                    AS null_tests,
+                COUNT(tests.id) AS total_tests
+            FROM
+                checkouts
+            LEFT JOIN
+                builds ON builds.checkout_id = checkouts.id
+            LEFT JOIN
+                tests ON tests.build_id = builds.id
+            WHERE checkouts.git_commit_hash IN ({placeholders})
+            GROUP BY
+                checkouts.git_commit_hash;
+            """,
+            commit_hashs
+        )
+
+        serializer = TreeSerializer(checkouts, many=True)
+        resp = JsonResponse(serializer.data, safe=False)
+        return resp

--- a/backend/kernelCI_app/views/__init__.py
+++ b/backend/kernelCI_app/views/__init__.py
@@ -1,0 +1,20 @@
+import os
+import glob
+import importlib
+import sys
+
+
+current_dir = os.path.dirname(__file__)
+modules = glob.glob(os.path.join(current_dir, "*.py"))
+
+for module in modules:
+    module_name = os.path.basename(module)[:-3]
+    if module_name != "__init__":
+        imported_module = importlib.import_module(f'.{module_name}', package=__name__)
+
+        for attribute_name in dir(imported_module):
+            if not attribute_name.startswith('_'):
+                setattr(sys.modules[__name__], attribute_name, getattr(imported_module, attribute_name))
+
+
+del os, glob, importlib, sys, current_dir, modules, module_name, imported_module, attribute_name

--- a/backend/kernelCI_app/views/buildDetailsView.py
+++ b/backend/kernelCI_app/views/buildDetailsView.py
@@ -1,0 +1,29 @@
+from django.http import JsonResponse, HttpResponseNotFound
+from django.views import View
+from querybuilder.query import Query
+from kernelCI_app.models import Builds
+
+
+class BuildDetails(View):
+
+    def get(self, request, build_id):
+        build_fields = [
+            "id", "_timestamp", "checkout_id", "origin",
+            "comment", "start_time", "duration", "architecture",
+            "command", "compiler", "config_name", "config_url",
+            "log_url", "valid", "misc"]
+
+        query = Query().from_table(Builds, build_fields)
+        query.join(
+            'checkouts',
+            fields=[
+                'git_repository_branch', 'git_commit_name', 'git_repository_url', 'git_commit_hash'
+            ],
+            condition='checkouts.id = builds.checkout_id',
+        )
+        query.where(**{'builds.id__eq': build_id})
+
+        records = query.select()
+        if not records:
+            return HttpResponseNotFound('{}')
+        return JsonResponse(records[0])

--- a/backend/requests/build-details-get.sh
+++ b/backend/requests/build-details-get.sh
@@ -1,0 +1,34 @@
+http 'http://localhost:8000/api/build/0dayci:build:6681e0032e96c85bf5ad3a80'
+
+# HTTP/1.1 200 OK
+# Content-Length: 625
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Thu, 25 Jul 2024 17:27:16 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.0
+# Vary: origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "_timestamp": "2024-06-30T22:46:03.064Z",
+#     "architecture": "openrisc",
+#     "checkout_id": "0dayci:6681dfff2e96c85bf5ad3a7f",
+#     "command": null,
+#     "comment": null,
+#     "compiler": "gcc-13.2.0",
+#     "config_name": "allnoconfig",
+#     "config_url": null,
+#     "duration": null,
+#     "git_commit_hash": "22a40d14b572deb80c0648557f4bd502d7e83826",
+#     "git_commit_name": "v6.10-rc6",
+#     "git_repository_branch": "master",
+#     "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+#     "id": "0dayci:build:6681e0032e96c85bf5ad3a80",
+#     "log_url": null,
+#     "misc": null,
+#     "origin": "0dayci",
+#     "start_time": "2024-06-30T22:45:23.477Z",
+#     "valid": true
+# }


### PR DESCRIPTION
### Description
Add the `/api/build/<build_id>` endpoint which will be used in TreeDetails page


### How to test it

- run Django dev server with:
```sh
python manage.py runserver
```
- and make a request to `/api/build/<build_id>`, such as :
```sh
curl --location 'http://localhost:8000/api/build/0dayci:build:6681e0032e96c85bf5ad3a80'
```