### PR TITLE
feat(settings): enhance security and deployment settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Create a .env file in /dashboard (Do not forget to check and set the variables a
  cp ./dashboard/.env.example ./dashboard/.env
 ```
 
+Create a secret key for Django:
+```sh
+export DJANGO_SECRET_KEY=$(openssl rand -base64 22)
+```
+We are not using sessions or anything like that right now, so changing the secret key won't be a big deal.
+
+
 Add a `application_default_credentials.json` file with your ADC in the root of the project.
 ```sh
 gcloud auth application-default login

--- a/backend/README.md
+++ b/backend/README.md
@@ -31,5 +31,25 @@ Finnaly execute the server with:
 poetry run python3 manage.py runserver
 ```
 
+# Deploy instructions
+
+To check if it is ready for a deploy you can run 
+```sh
+poetry run python3 manage.py check --deploy
+```
+
+To generate a `DJANGO_SECRET_KEY` 
+you can use
+```sh
+openssl rand -base64 22
+```
+
+or
+```sh
+export DJANGO_SECRET_KEY=$(openssl rand -base64 22)
+```
+We are not using sessions or anything like that right now, so changing the secret key won't be a big deal.
+
+
 # Requests
 In the `/requests` directory we have scripts that execute requests to endpoints using [httpie](https://httpie.io/)

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
 from pathlib import Path
+from utils.validation import isBooleanOrStringTrue
 import os
 import json
 
@@ -35,14 +36,28 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure--!70an0r@i00)oqf!3uq_)9dx2^%)xs+(ade0aie+l#6*rh-%#"
+SECRET_KEY = get_json_env_var(
+    "DJANGO_SECRET_KEY", "django-insecure--!70an0r@i00)oqf!3uq_)9dx2^%)"
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = get_json_env_var('DEBUG', True)
+DEBUG = False
+
+ENV_DEBUG = get_json_env_var("DEBUG", False)
+
+if isBooleanOrStringTrue(ENV_DEBUG):
+    DEBUG = True
+
+
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SECURE_SSL_REDIRECT = False
+SECURE_HSTS_SECONDS = 31536000
+
 
 ALLOWED_HOSTS = get_json_env_var(
-    'ALLOWED_HOSTS',
-    ['localhost'],
+    "ALLOWED_HOSTS",
+    ["localhost"],
 )
 
 # Application definition
@@ -55,8 +70,8 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    'kernelCI_app',
-    'rest_framework'
+    "kernelCI_app",
+    "rest_framework",
 ]
 
 MIDDLEWARE = [
@@ -95,16 +110,19 @@ WSGI_APPLICATION = "kernelCI.wsgi.application"
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
 DATABASES = {
-    "default": get_json_env_var("DB_DEFAULT", {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": "kernelci",
-        "USER": "kernelci",
-        "PASSWORD": "kernelci-db-password",
-        "HOST": "127.0.0.1",
-        "OPTIONS": {
+    "default": get_json_env_var(
+        "DB_DEFAULT",
+        {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": "kernelci",
+            "USER": "kernelci",
+            "PASSWORD": "kernelci-db-password",
+            "HOST": "127.0.0.1",
+            "OPTIONS": {
                 "connect_timeout": 5,
+            },
         },
-    })
+    )
 }
 
 
@@ -166,3 +184,7 @@ if DEBUG:
     CORS_ALLOWED_ORIGIN_REGEXES = [
         r"^http://localhost",  # dashboard dev server
     ]
+    SESSION_COOKIE_SECURE = False
+    CSRF_COOKIE_SECURE = False
+    SECURE_SSL_REDIRECT = False
+    SECURE_HSTS_SECONDS = 3600

--- a/backend/utils/validation.py
+++ b/backend/utils/validation.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+
+def isBooleanOrStringTrue(value: Union[bool, str]) -> bool:
+    if isinstance(value, bool):
+        return value
+    elif isinstance(value, str):
+        return value.lower() == "true"
+    else:
+        raise ValueError("Value must be a boolean or string")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
             - DB_DEFAULT_PASSWORD_FILE=/run/secrets/postgres_password_secret
             - DB_DEFAULT_HOST=cloudsql-proxy
             - DB_DEFAULT_USER=${DB_DEFAULT_USER:-kernelci}
+            - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
             - DEBUG=False
 
     dashboard:


### PR DESCRIPTION
This PR introduces several changes to improve the security and
deployment settings of the application. The `SECRET_KEY` is now fetched
from environment variables, and the `DEBUG` setting is set to `False` by
default, but can be overridden by an environment variable.

Additionally, several security-related settings have been added, such as
`SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SECURE_SSL_REDIRECT`,
and `SECURE_HSTS_SECONDS`.

The README.md file has also been updated with instructions on how to
generate a `DJANGO_SECRET_KEY` and check if the application is ready for
deployment.
