### PR TITLE
Feat/add boots endpoint

### DIFF
--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -5,5 +5,6 @@ from kernelCI_app import views
 urlpatterns = [
     path('tree/', views.TreeView.as_view(), name='tree'),
     path('tree/<str:commit_hash>', views.TreeDetails.as_view(), name='treeDetails'),
-    path('build/<str:build_id>', views.BuildDetails.as_view(), name='buildDetails')
+    path('build/<str:build_id>', views.BuildDetails.as_view(), name='buildDetails'),
+    path('tree/<str:commit_hash>/boot/', views.Boots.as_view(), name='boots'),
 ]

--- a/backend/kernelCI_app/views/bootsView.py
+++ b/backend/kernelCI_app/views/bootsView.py
@@ -79,17 +79,15 @@ class Boots(View):
             translations=names_map,
         )
 
-        errorCounts = {}
-        configCounts = {}
+        errorCounts = defaultdict(int)
+        configCounts =  defaultdict(int)
         bootHistory = []
-        errorCountPerArchitecture = {}
+        errorCountPerArchitecture =  defaultdict(int)
         platforms = set()
-        compilersPerArchitecture = {}
-        errorMessageCounts = {}
+        compilersPerArchitecture = defaultdict(set)
+        errorMessageCounts = defaultdict(int)
         for record in query:
-            errorCounts = defaultdict(int)
             errorCounts[record.status] += 1
-            configCounts = defaultdict(int)
             configCounts[record.config_name] += 1
             bootHistory.append(
                 {"start_time": record.start_time, "status": record.status}
@@ -99,13 +97,11 @@ class Boots(View):
                 or record.status == "ERROR"
                 or record.status == "FAIL"
             ):
-                errorCountPerArchitecture = defaultdict(int)
                 errorCountPerArchitecture[record.architecture] += 1
-                compilersPerArchitecture = defaultdict(set)
                 compilersPerArchitecture[record.architecture].add(record.compiler)
                 platforms.add(self.extract_platform(record.environment_misc))
                 currentErrorMessage = self.extract_error_message(record.misc)
-                errorMessageCounts = defaultdict(int)
+                errorMessageCounts[currentErrorMessage] += 1
                 errorMessageCounts[currentErrorMessage] += 1
         for architecture in compilersPerArchitecture:
             compilersPerArchitecture[architecture] = list(

--- a/backend/kernelCI_app/views/bootsView.py
+++ b/backend/kernelCI_app/views/bootsView.py
@@ -8,10 +8,12 @@ import json
 class Boots(View):
     # TODO misc_environment is not stable and should be used as a POC only
     # use the standardized field when that gets available
-    def extract_platform(self, misc_environment: Union[str, dict]):
+    def extract_platform(self, misc_environment: Union[str, dict, None]):
         parsedEnvMisc = None
         if isinstance(misc_environment, dict):
             parsedEnvMisc = misc_environment
+        elif misc_environment is None:
+            return "unknown"
         else:
             parsedEnvMisc = json.loads(misc_environment)
         platform = parsedEnvMisc.get("platform")
@@ -21,9 +23,11 @@ class Boots(View):
         return "unknown"
 
     # TODO misc is not stable and should be used as a POC only
-    def extract_error_message(self, misc: Union[str, dict]):
+    def extract_error_message(self, misc: Union[str, dict, None]):
         parsedEnv = None
-        if isinstance(misc, dict):
+        if misc is None:
+            return "unknown error"
+        elif isinstance(misc, dict):
             parsedEnv = misc
         else:
             parsedEnv = json.loads(misc)
@@ -31,7 +35,7 @@ class Boots(View):
         if error_message:
             return error_message
         print("unknown error_msg in misc", misc)
-        return "unknown"
+        return "unknown error"
 
     def get(self, request, commit_hash: str | None):
         print("commit_hash", commit_hash)
@@ -114,6 +118,7 @@ class Boots(View):
                 compilersPerArchitecture[architecture]
             )
 
+        # TODO Validate output
         return JsonResponse(
             {
                 "errorCounts": errorCounts,

--- a/backend/kernelCI_app/views/bootsView.py
+++ b/backend/kernelCI_app/views/bootsView.py
@@ -80,9 +80,9 @@ class Boots(View):
         )
 
         errorCounts = defaultdict(int)
-        configCounts =  defaultdict(int)
+        configCounts = defaultdict(int)
         bootHistory = []
-        errorCountPerArchitecture =  defaultdict(int)
+        errorCountPerArchitecture = defaultdict(int)
         platforms = set()
         compilersPerArchitecture = defaultdict(set)
         errorMessageCounts = defaultdict(int)

--- a/backend/kernelCI_app/views/bootsView.py
+++ b/backend/kernelCI_app/views/bootsView.py
@@ -1,0 +1,127 @@
+from typing_extensions import Union
+from django.http import JsonResponse
+from django.views import View
+from kernelCI_app.models import Checkouts
+import json
+
+
+class Boots(View):
+    # TODO misc_environment is not stable and should be used as a POC only
+    # use the standardized field when that gets available
+    def extract_platform(self, misc_environment: Union[str, dict]):
+        parsedEnvMisc = None
+        if isinstance(misc_environment, dict):
+            parsedEnvMisc = misc_environment
+        else:
+            parsedEnvMisc = json.loads(misc_environment)
+        platform = parsedEnvMisc.get("platform")
+        if platform:
+            return platform
+        print("unknown platform in misc_environment", misc_environment)
+        return "unknown"
+
+    # TODO misc is not stable and should be used as a POC only
+    def extract_error_message(self, misc: Union[str, dict]):
+        parsedEnv = None
+        if isinstance(misc, dict):
+            parsedEnv = misc
+        else:
+            parsedEnv = json.loads(misc)
+        error_message = parsedEnv.get("error_msg")
+        if error_message:
+            return error_message
+        print("unknown error_msg in misc", misc)
+        return "unknown"
+
+    def get(self, request, commit_hash: str | None):
+        print("commit_hash", commit_hash)
+
+        names_map = {
+            "c.id": "id",
+            "c.git_repository_url": "git_repository_url",
+            "c.git_commit_hash": "git_commit_hash",
+            "t.build_id": "build_id",
+            "t.start_time": "start_time",
+            "t.status": "status",
+            "t.path": "path",
+            "b.architecture": "architecture",
+            "b.config_name": "config_name",
+            "b.compiler": "compiler",
+            "t.environment_misc": "environment_misc",
+            "t.environment_comment": "environment_comment",
+            "t.misc": "misc",
+        }
+
+        query = Checkouts.objects.raw(
+            """
+                SELECT DISTINCT ON (t.build_id) c.id, c.git_repository_url,
+                c.git_commit_hash, t.build_id, t.start_time,
+                t.status as status, t.path, b.architecture, b.config_name,
+                b.compiler, t.environment_misc, t.environment_comment, t.misc FROM checkouts AS c
+                INNER JOIN builds AS b ON c.id = b.checkout_id
+                INNER JOIN tests AS t ON t.build_id = b.id
+                WHERE c.git_commit_hash = %s AND t.path LIKE 'boot%%'
+                ORDER BY
+                build_id,
+                CASE t.status
+                    WHEN 'FAIL' THEN 1
+                    WHEN 'ERROR' THEN 2
+                    WHEN 'MISS' THEN 3
+                    WHEN 'PASS' THEN 4
+                ELSE 4
+                END,
+                t.id;
+            """,
+            [commit_hash],
+            translations=names_map,
+        )
+
+        errorCounts = {}
+        configCounts = {}
+        bootHistory = []
+        errorCountPerArchitecture = {}
+        platforms = set()
+        compilersPerArchitecture = {}
+        errorMessageCounts = {}
+        for record in query:
+            errorCounts[record.status] = errorCounts.get(record.status, 0) + 1
+            configCounts[record.config_name] = (
+                configCounts.get(record.config_name, 0) + 1
+            )
+            bootHistory.append(
+                {"start_time": record.start_time, "status": record.status}
+            )
+            if (
+                record.status == "MISS"
+                or record.status == "ERROR"
+                or record.status == "FAIL"
+            ):
+                errorCountPerArchitecture[record.architecture] = (
+                    errorCountPerArchitecture.get(record.architecture, 0) + 1
+                )
+                compilersPerArchitecture[record.architecture] = (
+                    compilersPerArchitecture.get(record.architecture, set())
+                )
+                compilersPerArchitecture[record.architecture].add(record.compiler)
+                platforms.add(self.extract_platform(record.environment_misc))
+                currentErrorMessage = self.extract_error_message(record.misc)
+                errorMessageCounts[currentErrorMessage] = (
+                    errorMessageCounts.get(currentErrorMessage, 0) + 1
+                )
+
+        for architecture in compilersPerArchitecture:
+            compilersPerArchitecture[architecture] = list(
+                compilersPerArchitecture[architecture]
+            )
+
+        return JsonResponse(
+            {
+                "errorCounts": errorCounts,
+                "configCounts": configCounts,
+                "bootHistory": bootHistory,
+                "errorCountPerArchitecture": errorCountPerArchitecture,
+                "compilersPerArchitecture": compilersPerArchitecture,
+                "platforms": list(platforms),
+                "errorMessageCounts": errorMessageCounts,
+            }
+        )

--- a/backend/requests/boots-get.sh
+++ b/backend/requests/boots-get.sh
@@ -1,0 +1,55 @@
+http 'http://localhost:8000/api/tree/1dd28064d4164a4dc9096fd1a7990d2de15f2bb6/boot/'
+
+
+# {
+#   "errorCounts": {
+#     "MISS": 2,
+#     "PASS": 1,
+#     "ERROR": 1
+#   },
+#   "configCounts": {
+#     "defconfig": 3,
+#     "multi_v7_defconfig": 1
+#   },
+#   "bootHistory": [
+#     {
+#       "start_time": "2024-07-06T00:58:14.830Z",
+#       "status": "MISS"
+#     },
+#     {
+#       "start_time": "2024-07-06T00:48:55.924Z",
+#       "status": "MISS"
+#     },
+#     {
+#       "start_time": "2024-07-06T01:11:10.816Z",
+#       "status": "PASS"
+#     },
+#     {
+#       "start_time": "2024-07-06T00:56:49.278Z",
+#       "status": "ERROR"
+#     }
+#   ],
+#   "errorCountPerArchitecture": {
+#     "arm64": 2,
+#     "arm": 1
+#   },
+#   "compilersPerArchitecture": {
+#     "arm64": [
+#       "gcc-12"
+#     ],
+#     "arm": [
+#       "gcc-12"
+#     ]
+#   },
+#   "platforms": [
+#     "bcm2836-rpi-2-b",
+#     "meson-g12b-a311d-khadas-vim3",
+#     "sc7180-trogdor-lazor-limozeen"
+#   ],
+#   "errorMessageCounts": {
+#     "400 Client Error: Bad Request for url: https://lava.infra.foundries.io/api/v0.2/jobs/?format=json&limit=256": 1,
+#     "No time left for remaining 1 retries. 2 retries out of 3 failed for auto-login-action": 1,
+#     "Invalid TESTCASE signal": 1
+#   }
+# }
+

--- a/backend/requests/boots-get.sh
+++ b/backend/requests/boots-get.sh
@@ -1,5 +1,8 @@
+# Database tested - `playground_kcidb`
+# This should be empty
+http 'http://localhost:8000/api/tree/a-git-commit-hash-that-clearly-does-not-exist/boot/'
+# This should find something
 http 'http://localhost:8000/api/tree/1dd28064d4164a4dc9096fd1a7990d2de15f2bb6/boot/'
-
 
 # {
 #   "errorCounts": {


### PR DESCRIPTION
This PR introduces a new view, Boots, in the backend application.
The Boots view is responsible for handling requests related to boot
information. It extracts platform and error message from the
environment and provides a detailed response including error counts,
config counts, boot history, error count per architecture, compilers
per architecture, platforms, and error message counts.

The urls.py file is also updated to include a new path for the Boots
view. This allows the application to route requests to the new view.

A new shell script file, boots-get.sh, is added to test the new
endpoint.

## How to test

Just run the new `boots-get.sh` added to the requests folder

Closes #24 