### PR TITLE
Feat/boots UI start

### DIFF
--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -5,7 +5,7 @@ from kernelCI_app import views
 urlpatterns = [
     path('tree/', views.TreeView.as_view(), name='tree'),
     path('tree/<str:commit_hash>', views.TreeDetails.as_view(), name='treeDetails'),
-    path('tree/<str:commit_hash>/boot/', views.Boots.as_view(), name='boots'),
     path('build/<str:build_id>', views.BuildDetails.as_view(), name='buildDetails'),
     path('build/<str:build_id>/tests', views.BuildTests.as_view(), name='buildTests'),
+    path('tree/<str:commit_hash>/boot/', views.Boots.as_view(), name='boots'),
 ]

--- a/backend/kernelCI_app/views/bootsView.py
+++ b/backend/kernelCI_app/views/bootsView.py
@@ -79,15 +79,16 @@ class Boots(View):
             translations=names_map,
         )
 
+        statusCounts = defaultdict(int)
         errorCounts = defaultdict(int)
         configCounts = defaultdict(int)
         bootHistory = []
         errorCountPerArchitecture = defaultdict(int)
-        platforms = set()
+        platformsWithError = set()
         compilersPerArchitecture = defaultdict(set)
         errorMessageCounts = defaultdict(int)
         for record in query:
-            errorCounts[record.status] += 1
+            statusCounts[record.status] += 1
             configCounts[record.config_name] += 1
             bootHistory.append(
                 {"start_time": record.start_time, "status": record.status}
@@ -97,9 +98,10 @@ class Boots(View):
                 or record.status == "ERROR"
                 or record.status == "FAIL"
             ):
+                errorCounts[record.status] += 1
                 errorCountPerArchitecture[record.architecture] += 1
                 compilersPerArchitecture[record.architecture].add(record.compiler)
-                platforms.add(self.extract_platform(record.environment_misc))
+                platformsWithError.add(self.extract_platform(record.environment_misc))
                 currentErrorMessage = self.extract_error_message(record.misc)
                 errorMessageCounts[currentErrorMessage] += 1
                 errorMessageCounts[currentErrorMessage] += 1
@@ -111,12 +113,13 @@ class Boots(View):
         # TODO Validate output
         return JsonResponse(
             {
+                "statusCounts": statusCounts,
                 "errorCounts": errorCounts,
                 "configCounts": configCounts,
                 "bootHistory": bootHistory,
                 "errorCountPerArchitecture": errorCountPerArchitecture,
                 "compilersPerArchitecture": compilersPerArchitecture,
-                "platforms": list(platforms),
+                "platformsWithError": list(platformsWithError),
                 "errorMessageCounts": errorMessageCounts,
             }
         )

--- a/backend/requests/boots-get.sh
+++ b/backend/requests/boots-get.sh
@@ -1,6 +1,6 @@
 # Database tested - `playground_kcidb`
 # This should be empty
-http 'http://localhost:8000/api/tree/a-git-commit-hash-that-clearly-does-not-exist/boot/'
+# http 'http://localhost:8000/api/tree/a-git-commit-hash-that-clearly-does-not-exist/boot/'
 # This should find something
 http 'http://localhost:8000/api/tree/1dd28064d4164a4dc9096fd1a7990d2de15f2bb6/boot/'
 

--- a/dashboard/.prettierrc
+++ b/dashboard/.prettierrc
@@ -5,5 +5,5 @@
   "semi": true,
   "bracketSpacing": true,
   "singleQuote": true,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -80,6 +80,7 @@
     "husky": "^9.0.11",
     "postcss": "^8.4.38",
     "prettier": "3.3.2",
+    "prettier-plugin-tailwindcss": "^0.6.5",
     "storybook": "^8.1.10",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.2.2"

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       prettier:
         specifier: 3.3.2
         version: 3.3.2
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.5
+        version: 0.6.5(prettier@3.3.2)
       storybook:
         specifier: ^8.1.10
         version: 8.2.1(@babel/preset-env@7.24.7(@babel/core@7.24.7))
@@ -4202,6 +4205,58 @@ packages:
   prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
+
+  prettier-plugin-tailwindcss@0.6.5:
+    resolution: {integrity: sha512-axfeOArc/RiGHjOIy9HytehlC0ZLeMaqY09mm8YCkMzznKiDkwFzOpBvtuhuv3xG5qB73+Mj7OCe2j/L1ryfuQ==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig-melody': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig-melody':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
 
   prettier@3.3.2:
     resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
@@ -9612,6 +9667,10 @@ snapshots:
   prettier-linter-helpers@1.0.0:
     dependencies:
       fast-diff: 1.3.0
+
+  prettier-plugin-tailwindcss@0.6.5(prettier@3.3.2):
+    dependencies:
+      prettier: 3.3.2
 
   prettier@3.3.2: {}
 

--- a/dashboard/src/api/TreeDetails.tsx
+++ b/dashboard/src/api/TreeDetails.tsx
@@ -1,6 +1,10 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
-import { TreeDetails, TTreeDetailsFilter } from '@/types/tree/TreeDetails';
+import {
+  TBootsTabData,
+  TreeDetails,
+  TTreeDetailsFilter,
+} from '@/types/tree/TreeDetails';
 
 import http from './api';
 
@@ -28,5 +32,17 @@ export const useTreeDetails = (
   return useQuery({
     queryKey: ['treeData', treeId, filter],
     queryFn: () => fetchTreeDetailData(treeId, filter),
+  });
+};
+
+const fetchBootsTabData = async (treeId: string): Promise<TBootsTabData> => {
+  const res = await http.get<TBootsTabData>(`/api/tree/${treeId}/boot`, {});
+  return res.data;
+};
+
+export const useBootsTab = (treeId: string): UseQueryResult<TBootsTabData> => {
+  return useQuery({
+    queryKey: ['treeData', treeId],
+    queryFn: () => fetchBootsTabData(treeId),
   });
 };

--- a/dashboard/src/components/Cards/BaseCard.tsx
+++ b/dashboard/src/components/Cards/BaseCard.tsx
@@ -1,8 +1,8 @@
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 
 interface IBaseCard {
-  title: ReactElement;
+  title: ReactNode;
   content: ReactElement;
   className?: string;
 }

--- a/dashboard/src/components/CardsGroup/CardsGroup.tsx
+++ b/dashboard/src/components/CardsGroup/CardsGroup.tsx
@@ -34,7 +34,7 @@ const CardContent = ({ card }: ICardContent): JSX.Element => {
   } else if (card.type === 'summary' && card.summaryBody) {
     return (
       <Summary
-        key=""
+        key={card.title.key}
         summaryHeaders={card?.summaryHeaders}
         summaryBody={card?.summaryBody}
       />

--- a/dashboard/src/components/ColoredCircle/ColoredCircle.tsx
+++ b/dashboard/src/components/ColoredCircle/ColoredCircle.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import { cn } from '../../lib/utils';
 
 interface IColoredCircle {
   tooltipText?: string;
@@ -16,8 +16,8 @@ const ColoredCircle = ({
   return (
     <div
       title={tooltipText}
-      className={classNames(
-        'rounded-full text-black h-6 min-w-6 flex justify-center px-1',
+      className={cn(
+        'inline-flex h-6 w-6 justify-center rounded-full px-1 text-black',
         className,
         backgroundClassName,
       )}

--- a/dashboard/src/components/ListingContent/ListingContent.tsx
+++ b/dashboard/src/components/ListingContent/ListingContent.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useMemo } from 'react';
+import { ReactElement, ReactNode, useMemo } from 'react';
 
 import ListingItem, {
   IListingItem,
@@ -14,6 +14,15 @@ interface IListingCardContent {
   items: IListingItem[];
 }
 
+interface DumbListingContent {
+  children: ReactNode;
+}
+export const DumbListingContent = ({
+  children,
+}: DumbListingContent): JSX.Element => {
+  return <div className="flex flex-col gap-2 p-4">{children}</div>;
+};
+
 const ListingContent = ({ items }: IListingCardContent): JSX.Element => {
   const content = useMemo(() => {
     return items.map(item => (
@@ -26,7 +35,7 @@ const ListingContent = ({ items }: IListingCardContent): JSX.Element => {
       />
     ));
   }, [items]);
-  return <div className="flex flex-col gap-2 p-4">{content}</div>;
+  return <DumbListingContent>{content}</DumbListingContent>;
 };
 
 export default ListingContent;

--- a/dashboard/src/components/ListingItem/ListingItem.tsx
+++ b/dashboard/src/components/ListingItem/ListingItem.tsx
@@ -24,40 +24,39 @@ const ListingItem = ({
   success,
   hasBottomBorder,
 }: IListingItem): JSX.Element => {
-  const hasBorder = hasBottomBorder ? 'border-b' : '';
-  const itemError =
-    errors && errors > 0 ? (
-      <ColoredCircle quantity={errors} backgroundClassName={ItemType.Error} />
-    ) : (
-      <></>
-    );
+  const hasBorder = hasBottomBorder
+    ? '[&:not(:last-child)]:border-b [&:not(:last-child)]:pb-2 [&:not(:last-child)]:mb-2'
+    : '';
+  const hasErrors = errors && errors > 0;
+  const hasWarnings = warnings && warnings > 0;
+  const hasSuccess = success && success > 0;
+  const hasNone = !hasErrors && !hasWarnings && !hasSuccess;
 
-  const itemWarning =
-    warnings && warnings > 0 ? (
-      <ColoredCircle
-        quantity={warnings}
-        backgroundClassName={ItemType.Warning}
-      />
-    ) : (
-      <></>
-    );
+  const itemError = hasErrors ? (
+    <ColoredCircle quantity={errors} backgroundClassName={ItemType.Error} />
+  ) : (
+    <></>
+  );
 
-  const itemNeutral =
-    !errors || errors === 0 || !success || success === 0 ? (
+  const itemWarning = hasWarnings ? (
+    <ColoredCircle quantity={warnings} backgroundClassName={ItemType.Warning} />
+  ) : (
+    <></>
+  );
+
+  const itemNeutral = hasNone ? (
+    <div>
       <ColoredCircle quantity={0} backgroundClassName={ItemType.None} />
-    ) : (
-      <></>
-    );
+    </div>
+  ) : (
+    <></>
+  );
 
-  const itemSuccess =
-    success && success > 0 ? (
-      <ColoredCircle
-        quantity={success}
-        backgroundClassName={ItemType.Success}
-      />
-    ) : (
-      <></>
-    );
+  const itemSuccess = hasSuccess ? (
+    <ColoredCircle quantity={success} backgroundClassName={ItemType.Success} />
+  ) : (
+    <></>
+  );
 
   return (
     <div className={classNames('flex flex-row gap-2 pb-1', hasBorder)}>
@@ -65,7 +64,7 @@ const ListingItem = ({
       {itemWarning}
       {itemSuccess}
       {itemNeutral}
-      <span className="text-black text-sm">{text}</span>
+      <span className="text-sm text-black">{text}</span>
     </div>
   );
 };

--- a/dashboard/src/components/StatusChart/StatusCharts.tsx
+++ b/dashboard/src/components/StatusChart/StatusCharts.tsx
@@ -8,7 +8,7 @@ import { styled } from '@mui/material';
 
 import ColoredCircle from '../ColoredCircle/ColoredCircle';
 
-type StatusChartValues = {
+export type StatusChartValues = {
   value: number;
   label: ReactElement;
   color: Colors;
@@ -125,7 +125,7 @@ const ChartLegend = ({ chartValues }: IChartLegend): JSX.Element => {
     return chartValues.map(chartValue => (
       <div key={chartValue?.color} className="flex flex-row">
         {chartValue && (
-          <div className="pt-1 pr-2">
+          <div className="pr-2 pt-1">
             <ColoredCircle
               backgroundClassName={getColorClassName(chartValue.color)}
             />

--- a/dashboard/src/components/Summary/Summary.tsx
+++ b/dashboard/src/components/Summary/Summary.tsx
@@ -19,6 +19,24 @@ export interface ISummaryItem {
   compilers: string[];
 }
 
+interface IDumbSummary {
+  children: ReactElement | ReactElement[];
+  summaryHeaders: ReactElement[];
+}
+
+export const DumbSummary = ({
+  children,
+  summaryHeaders,
+}: IDumbSummary): JSX.Element => {
+  return (
+    <BaseTable
+      className="!rounded-[0rem] bg-mediumGray"
+      headers={summaryHeaders}
+      body={<TableBody>{children}</TableBody>}
+    />
+  );
+};
+
 const Summary = ({
   summaryHeaders,
   summaryBody,
@@ -36,15 +54,13 @@ const Summary = ({
   );
 
   return (
-    <BaseTable
-      className="!rounded-[0rem] bg-mediumGray"
-      headers={summaryHeaders}
-      body={<TableBody>{summaryBodyRows}</TableBody>}
-    />
+    <DumbSummary summaryHeaders={summaryHeaders}>
+      <TableBody>{summaryBodyRows}</TableBody>
+    </DumbSummary>
   );
 };
 
-const SummaryItem = ({ arch, compilers }: ISummaryItem): JSX.Element => {
+export const SummaryItem = ({ arch, compilers }: ISummaryItem): JSX.Element => {
   const compilersElement = useMemo(
     () =>
       compilers?.map(compiler => (

--- a/dashboard/src/components/Table/BaseTable.tsx
+++ b/dashboard/src/components/Table/BaseTable.tsx
@@ -32,13 +32,13 @@ const BaseTable = ({
       <Table
         className={classNames(
           className,
-          'rounded-lg text-black bg-white w-full',
+          'w-full rounded-lg bg-white text-black',
         )}
       >
         <TableHeader className="bg-mediumGray">
           <TableRow>
             {headers.map(column => (
-              <TableHead className="text-black border-b" key={column.key}>
+              <TableHead className="border-b text-black" key={column.key}>
                 {column}
               </TableHead>
             ))}

--- a/dashboard/src/components/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/components/Tabs/Boots/BootsTab.tsx
@@ -1,0 +1,352 @@
+import { FormattedMessage } from 'react-intl';
+
+import { memo } from 'react';
+
+import { useParams } from 'react-router-dom';
+
+import { LineChart } from '@mui/x-charts/LineChart';
+
+import { DumbListingContent } from '@/components/ListingContent/ListingContent';
+import { useBootsTab } from '@/api/TreeDetails';
+import BaseCard from '@/components/Cards/BaseCard';
+import ListingItem from '@/components/ListingItem/ListingItem';
+import { TBootsTabData } from '@/types/tree/TreeDetails';
+import { DumbSummary, SummaryItem } from '@/components/Summary/Summary';
+import StatusChartMemoized, {
+  Colors,
+  StatusChartValues,
+} from '@/components/StatusChart/StatusCharts';
+import { errorStatusSet } from '@/utils/constants/database';
+import { ErrorStatus, Status } from '@/types/database';
+import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
+
+const ConfigsList = ({
+  configCounts,
+}: Pick<TBootsTabData, 'configCounts'>): JSX.Element => {
+  return (
+    <BaseCard
+      title="Configs"
+      content={
+        <DumbListingContent>
+          {Object.keys(configCounts).map(configName => {
+            const currentConfigCount = configCounts[configName];
+            return (
+              <ListingItem
+                hasBottomBorder
+                key={configName}
+                text={configName}
+                success={currentConfigCount}
+              />
+            );
+          })}
+        </DumbListingContent>
+      }
+    />
+  );
+};
+const MemoizedConfigList = memo(ConfigsList);
+
+const PlatformsWithError = ({
+  platformsWithError,
+}: Pick<TBootsTabData, 'platformsWithError'>): JSX.Element => {
+  return (
+    <BaseCard
+      title="Platforms failing at boot"
+      content={
+        <DumbListingContent>
+          {platformsWithError.map(platformWithErrorItem => {
+            return (
+              <ListingItem
+                hasBottomBorder
+                key={platformWithErrorItem}
+                text={platformWithErrorItem}
+              />
+            );
+          })}
+        </DumbListingContent>
+      }
+    />
+  );
+};
+const MemoizedPlatformsWithError = memo(PlatformsWithError);
+
+const ErrorCountList = ({
+  errorMessageCounts,
+}: Pick<TBootsTabData, 'errorMessageCounts'>): JSX.Element => {
+  return (
+    <BaseCard
+      title={<>Fail</>}
+      content={
+        <DumbListingContent>
+          {Object.keys(errorMessageCounts).map(errorMessage => {
+            const currentErrorMessageCount = errorMessageCounts[errorMessage];
+            return (
+              <ListingItem
+                key={errorMessage}
+                text={errorMessage}
+                errors={currentErrorMessageCount}
+              />
+            );
+          })}
+        </DumbListingContent>
+      }
+    />
+  );
+};
+const MemoizedErrorCountList = memo(ErrorCountList);
+
+const ErrorsSummary = ({
+  errorCountPerArchitecture,
+  compilersPerArchitecture,
+}: Pick<
+  TBootsTabData,
+  'errorCountPerArchitecture' | 'compilersPerArchitecture'
+>): JSX.Element => {
+  const summaryHeaders = [
+    <FormattedMessage key="treeDetails.arch" id="treeDetails.arch" />,
+    <FormattedMessage key="treeDetails.compiler" id="treeDetails.compiler" />,
+  ];
+
+  return (
+    <BaseCard
+      title="Errors Summary"
+      content={
+        <DumbSummary summaryHeaders={summaryHeaders}>
+          {Object.keys(errorCountPerArchitecture).map(architecture => {
+            const currentErrorCount = errorCountPerArchitecture[architecture];
+            const currentCompilers = compilersPerArchitecture[architecture];
+            return (
+              <SummaryItem
+                key={architecture}
+                arch={{
+                  text: architecture,
+                  errors: currentErrorCount,
+                }}
+                compilers={currentCompilers}
+              />
+            );
+          })}
+        </DumbSummary>
+      }
+    />
+  );
+};
+
+const MemoizedErrorsSummary = memo(ErrorsSummary);
+
+const StatusChart = ({
+  statusCounts,
+}: Pick<TBootsTabData, 'statusCounts'>): JSX.Element => {
+  const groupedStatus = {
+    success: 0,
+    fail: 0,
+    skip: 0,
+  };
+
+  const statusKeys = Object.keys(statusCounts) as Status[];
+  statusKeys.forEach(status => {
+    if (errorStatusSet.has(status as ErrorStatus)) {
+      groupedStatus.fail += statusCounts[status] ?? 0;
+    } else if (status === 'SKIP') {
+      groupedStatus.skip += 1;
+    } else {
+      groupedStatus.success += statusCounts[status] ?? 0;
+    }
+  });
+
+  const chartElements = [
+    {
+      label: <div>Success</div>,
+      value: groupedStatus.success,
+      color: Colors.Green,
+    },
+    {
+      label: <div>Fail</div>,
+      value: groupedStatus.fail,
+      color: Colors.Red,
+    },
+    {
+      label: <div>Skip</div>,
+      value: groupedStatus.skip,
+      color: Colors.Yellow,
+    },
+  ] satisfies StatusChartValues[];
+
+  const filteredChartElements = chartElements.filter(chartElement => {
+    return chartElement.value > 0;
+  });
+
+  return (
+    <BaseCard
+      title="Boot Status"
+      content={
+        <StatusChartMemoized type="chart" elements={filteredChartElements} />
+      }
+    />
+  );
+};
+
+const StatusChartMemo = memo(StatusChart);
+
+interface ILineChartLabel {
+  text: string;
+  backgroundColor: string;
+}
+
+//TODO Extract Line Chart to its own component
+
+const LineChartLabel = ({
+  text,
+  backgroundColor,
+}: ILineChartLabel): JSX.Element => {
+  return (
+    <div className="flex items-center gap-2 pr-6 font-medium text-gray-700">
+      <ColoredCircle
+        className="h-3 w-3"
+        backgroundClassName={backgroundColor}
+      />
+      <span>{text}</span>
+    </div>
+  );
+};
+
+const LineChartCard = ({
+  bootHistory,
+}: Pick<TBootsTabData, 'bootHistory'>): JSX.Element => {
+  const allStartTimeStamps: number[] = [];
+  const errorData: Array<number | null> = [];
+  const skipData: Array<number | null> = [];
+  const successData: Array<number | null> = [];
+  let lastSkipData: null | number = null;
+  let lastErrorData: null | number = null;
+  let lastSuccessData: null | number = null;
+
+  bootHistory.forEach(boot => {
+    allStartTimeStamps.push(new Date(boot.start_time).getTime());
+
+    if (boot.status === 'SKIP') {
+      lastSkipData = (lastSkipData ?? 0) + 1;
+      skipData.push(lastSkipData);
+      successData.push(null);
+      errorData.push(null);
+    } else if (errorStatusSet.has(boot.status as ErrorStatus)) {
+      lastErrorData = (lastErrorData ?? 0) + 1;
+      errorData.push(lastErrorData);
+      successData.push(null);
+      skipData.push(null);
+    } else {
+      lastSuccessData = (lastSuccessData ?? 0) + 1;
+      successData.push(lastSuccessData);
+      skipData.push(null);
+      errorData.push(null);
+    }
+  });
+
+  allStartTimeStamps.sort((a, b) => a - b);
+
+  const lineChartSeries = [
+    {
+      color: Colors.Red,
+      data: errorData,
+      connectNulls: true,
+      lastData: lastErrorData,
+    },
+    {
+      color: Colors.Green,
+      data: successData,
+      connectNulls: true,
+      lastData: lastSuccessData,
+    },
+    {
+      color: Colors.Yellow,
+      data: skipData,
+      connectNulls: true,
+      lastData: lastSkipData,
+    },
+  ];
+
+  const filteredLineChartSeries = lineChartSeries.filter(series => {
+    return series.data.some(data => data !== null);
+  });
+  return (
+    <BaseCard
+      title="Boot history"
+      content={
+        <div className="px-4">
+          <div className="mb-0 mt-3 flex justify-end gap-2">
+            {lastErrorData && (
+              <LineChartLabel text="Error" backgroundColor="bg-red" />
+            )}
+            {lastSuccessData && (
+              <LineChartLabel text="Success" backgroundColor="bg-green" />
+            )}
+            {lastSkipData && (
+              <LineChartLabel text="Skip" backgroundColor="bg-yellow" />
+            )}
+          </div>
+          <LineChart
+            className="w-full bg-red"
+            xAxis={[
+              {
+                scaleType: 'time',
+                data: allStartTimeStamps,
+              },
+            ]}
+            series={filteredLineChartSeries}
+            height={300}
+          />
+        </div>
+      }
+    />
+  );
+};
+
+const MemoizedLineChartCard = memo(LineChartCard);
+
+const BootsTab = (): JSX.Element => {
+  const { treeId } = useParams();
+  const { isLoading, data, error } = useBootsTab(treeId ?? '');
+
+  if (error || !treeId) {
+    return <div>Error</div>;
+  }
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!data) return <div />;
+
+  if (data.bootHistory.length < 1) {
+    return (
+      <BaseCard
+        title="Info"
+        content={
+          <p className="p-4 text-[1.3rem] text-darkGray">
+            ℹ️ There is no boot test data available for this tree
+          </p>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-8 pt-4">
+      <div className="md:columns-2">
+        <StatusChartMemo statusCounts={data.statusCounts} />
+        <MemoizedConfigList configCounts={data.configCounts} />
+        <MemoizedErrorsSummary
+          errorCountPerArchitecture={data.errorCountPerArchitecture}
+          compilersPerArchitecture={data.compilersPerArchitecture}
+        />
+        <MemoizedLineChartCard bootHistory={data.bootHistory} />
+        <MemoizedPlatformsWithError
+          platformsWithError={data.platformsWithError}
+        />
+        <MemoizedErrorCountList errorMessageCounts={data.errorMessageCounts} />
+      </div>
+    </div>
+  );
+};
+
+export default BootsTab;

--- a/dashboard/src/components/Tabs/Boots/index.tsx
+++ b/dashboard/src/components/Tabs/Boots/index.tsx
@@ -1,0 +1,3 @@
+import BootsTab from './BootsTab';
+
+export default BootsTab;

--- a/dashboard/src/components/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/components/Tabs/TreeDetailsTab.tsx
@@ -2,6 +2,7 @@ import Tabs, { ITabItem } from '@/components/Tabs/Tabs';
 import { ITreeDetails } from '@/routes/TreeDetails/TreeDetails';
 
 import TreeDetailsBuildTab from './TreeDetails/TreeDetailsBuildTab';
+import BootsTab from './Boots';
 
 export interface ITreeDetailsBuildTab {
   treeDetailsData?: ITreeDetails;
@@ -20,8 +21,8 @@ const TreeDetailsTab = ({
 
   const bootsTab: ITabItem = {
     name: 'treeDetails.boots',
-    content: <></>,
-    disabled: true,
+    content: <BootsTab />,
+    disabled: false,
   };
 
   const testsTab: ITabItem = {

--- a/dashboard/src/types/database.ts
+++ b/dashboard/src/types/database.ts
@@ -1,0 +1,5 @@
+import { status } from '../utils/constants/database';
+
+export type Status = (typeof status)[number];
+
+export type ErrorStatus = Exclude<Status, 'PASS' | 'SKIP' | 'DONE'>;

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -1,3 +1,5 @@
+import type { ErrorStatus, Status } from '../database';
+
 type TreeDetailsBuild = {
   id: string;
   architecture: string;
@@ -75,3 +77,43 @@ export interface TTreeDetailsFilter
   }> {
   valid?: string[];
 }
+
+type BootHistory = {
+  start_time: string;
+  status: string;
+};
+
+type ErrorCounts = {
+  [key in ErrorStatus]: number | undefined;
+};
+
+type ConfigCounts = {
+  [key: string]: number;
+};
+
+type ErrorCountPerArchitecture = {
+  [key: string]: number;
+};
+
+type CompilersPerArchitecture = {
+  [key: string]: string[];
+};
+
+type ErrorMessageCounts = {
+  [key: string]: number;
+};
+
+type StatusCounts = {
+  [key in Status]: number | undefined;
+};
+
+export type TBootsTabData = {
+  statusCounts: StatusCounts;
+  errorCounts: ErrorCounts;
+  configCounts: ConfigCounts;
+  bootHistory: BootHistory[];
+  errorCountPerArchitecture: ErrorCountPerArchitecture;
+  compilersPerArchitecture: CompilersPerArchitecture;
+  platformsWithError: string[];
+  errorMessageCounts: ErrorMessageCounts;
+};

--- a/dashboard/src/utils/constants/database.ts
+++ b/dashboard/src/utils/constants/database.ts
@@ -1,0 +1,14 @@
+import type { ErrorStatus } from '@/types/database';
+
+export const status = [
+  'MISS',
+  'ERROR',
+  'FAIL',
+  'PASS',
+  'SKIP',
+  'DONE',
+] as const;
+
+const errorStatus = ['MISS', 'ERROR', 'FAIL'] as const satisfies ErrorStatus[];
+
+export const errorStatusSet = new Set(errorStatus);


### PR DESCRIPTION
This commit introduces a new tab in the TreeDetails page, the BootsTab.
This tab provides a detailed view of the boot tests for a specific tree.
It includes various components such as StatusChart, ConfigsList,
ErrorsSummary, LineChartCard, PlatformsWithError, and ErrorCountList.
Each component represents a specific aspect of the boot tests data.

The BootsTab data is fetched using the useBootsTab hook from the
/api/tree/{treeId}/boot endpoint. The data includes statusCounts,
errorCounts, configCounts, bootHistory, errorCountPerArchitecture,
compilersPerArchitecture, platformsWithError, and errorMessageCounts.

This commit also includes the necessary types and constants related to
the boot tests data.

Additionally, some existing components were updated to accommodate the
new features and some were extracted to their own component for better
reusability and separation of concerns.

## How to test
Use the `playground_kcidb` database, run the backend and front, use this link:

http://localhost:5173/tree/1dd28064d4164a4dc9096fd1a7990d2de15f2bb6

## Observations
Due to the deadline there are still things to do to polish this PR

- Use strings with internationalization
- Enables the tailwind prettier rule that has been downloaded in this package (the reason I didn't enable is because it would pollute the entire PR)


Closes #25 #23