### PR TITLE
feat(api): add endpoint for test details retrieval

### DIFF
--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -3,10 +3,13 @@ from kernelCI_app import views
 
 
 urlpatterns = [
-    path('tree/', views.TreeView.as_view(), name='tree'),
-    path('tree/<str:commit_hash>', views.TreeDetails.as_view(), name='treeDetails'),
-    path('build/<str:build_id>', views.BuildDetails.as_view(), name='buildDetails'),
-    path('build/<str:build_id>/tests', views.BuildTests.as_view(), name='buildTests'),
-    path('tree/<str:commit_hash>/tests/', views.TreeTestsView.as_view(), name='treeTests'),
-    path('revision/tests/', views.revisionTests.as_view(), name='revisionTests'),
+    path("tree/", views.TreeView.as_view(), name="tree"),
+    path("revision/tests/", views.revisionTests.as_view(), name="revisionTests"),
+    path("tree/<str:commit_hash>", views.TreeDetails.as_view(), name="treeDetails"),
+    path(
+        "tree/<str:commit_hash>/tests/", views.TreeTestsView.as_view(), name="treeTests"
+    ),
+    path("build/<str:build_id>", views.BuildDetails.as_view(), name="buildDetails"),
+    path("build/<str:build_id>/tests", views.BuildTests.as_view(), name="buildTests"),
+    path("tests/<str:test_id>", views.TestDetails.as_view(), name="testDetails"),
 ]

--- a/backend/kernelCI_app/views/testDetailsView.py
+++ b/backend/kernelCI_app/views/testDetailsView.py
@@ -1,0 +1,96 @@
+from django.http import JsonResponse
+from django.db import connection
+from django.views import View
+
+
+class TestDetails(View):
+    def get(self, _request, test_id: str | None):
+        names_map = {
+            "id": "combined_tests.id",
+            "build_id": "combined_tests.build_id",
+            "status": "combined_tests.status",
+            "path": "combined_tests.path",
+            "log_excerpt": "combined_tests.log_excerpt",
+            "log_url": "combined_tests.log_url",
+            "misc": "combined_tests.misc",
+            "environment_misc": "combined_tests.environment_misc",
+            "start_time": "combined_tests.start_time",
+            "compiler": "builds.compiler",
+            "architecture": "builds.architecture",
+            "config_name": "builds.config_name",
+            "git_commit_hash": "checkouts.git_commit_hash",
+            "git_repository_branch": "checkouts.git_repository_branch",
+            "git_repository_url": "checkouts.git_repository_url",
+        }
+
+        query = """
+            WITH current_test AS (
+                SELECT *
+                FROM tests
+                WHERE id = %s
+                LIMIT 1
+            )
+            SELECT
+                combined_tests.id,
+                combined_tests.build_id,
+                combined_tests.status,
+                combined_tests.path,
+                combined_tests.log_excerpt,
+                combined_tests.log_url,
+                combined_tests.misc,
+                combined_tests.environment_misc,
+                combined_tests.start_time,
+                builds.compiler,
+                builds.architecture,
+                builds.config_name,
+                checkouts.git_commit_hash,
+                checkouts.git_repository_branch,
+                checkouts.git_repository_url
+            FROM (
+                SELECT
+                    id,
+                    build_id,
+                    status,
+                    path,
+                    log_excerpt,
+                    log_url,
+                    misc,
+                    environment_misc,
+                    start_time
+                FROM tests
+                WHERE build_id = (SELECT build_id FROM current_test)
+                -- A dot to get only descendants of this test
+                  AND path LIKE (SELECT path FROM current_test) || '.%%'
+                UNION
+                SELECT
+                    id,
+                    build_id,
+                    status,
+                    path,
+                    log_excerpt,
+                    log_url,
+                    misc,
+                    environment_misc,
+                    start_time
+                FROM current_test
+            ) AS combined_tests
+            INNER JOIN builds
+                ON combined_tests.build_id = builds.id
+            INNER JOIN checkouts
+                ON builds.checkout_id = checkouts.id
+            ORDER BY
+                (combined_tests.id = %s) DESC,
+                combined_tests.id;
+            """
+
+        response_data = []
+        with connection.cursor() as cursor:
+            cursor.execute(query, [test_id, test_id])
+            rows = cursor.fetchall()
+
+            for row in rows:
+                item = {}
+                for idx, key in enumerate(names_map.keys()):
+                    item[key] = row[idx]
+                response_data.append(item)
+        return JsonResponse({"tests": response_data}, safe=False)

--- a/backend/requests/test-details-get.sh
+++ b/backend/requests/test-details-get.sh
@@ -1,0 +1,27 @@
+# Database tested - `playground_kcidb`
+http 'http://localhost:8000/api/tests/kernelci:staging.kernelci.org:662be1c98baa75de59ce77b0'
+#TODO, find a better test ID which showcase a test with descendants
+
+
+# {
+#   "tests": [
+#     {
+#       "id": "kernelci:staging.kernelci.org:662be1c98baa75de59ce77b0",
+#       "build_id": "kernelci:staging.kernelci.org:662bdd1aa697ce1c37ce7692",
+#       "status": "PASS",
+#       "path": "kselftest-alsa.login",
+#       "log_excerpt": null,
+#       "log_url": null,
+#       "misc": "{\"plan\": \"kselftest-alsa\", \"plan_variant\": \"kselftest-alsa\", \"kernelci_status\": \"PASS\"}",
+#       "environment_misc": "{\"lab\": \"lab-broonie\", \"mach\": \"broadcom\", \"device\": \"bcm2711-rpi-4-b\", \"instance\": \"rpi4-02\", \"rootfs_url\": \"http://storage.kernelci.org/images/rootfs/debian/bookworm-kselftest/20240313.0/arm64/initrd.cpio.gz\"}",
+#       "start_time": "2024-04-26T17:18:01.037Z",
+#       "compiler": "aarch64-linux-gnu-gcc (Debian 10.2.1-6) 10.2.1 20210110",
+#       "architecture": "arm64",
+#       "config_name": "defconfig+arm64-chromebook",
+#       "git_commit_hash": "4ffa3ead5ba2c4ed2ade804492f855f7f06e49d8",
+#       "git_repository_branch": "staging-stable",
+#       "git_repository_url": "https://github.com/kernelci/linux.git"
+#     }
+#   ]
+# }
+#


### PR DESCRIPTION
- Added a new endpoint `/api/tests/<str:test_id>` to retrieve test details.
- Implemented `TestDetails` view to handle GET requests for test details.
- Created a new SQL query to fetch test details and their descendants.
- Added a test script `test-details-get.sh` to verify the new endpoint.
- Updated `urls.py` to include the new endpoint.

This change allows users to fetch detailed information about specific tests, including their build information and related metadata.

Closes #92 

## Test

Use the test-details-get script to get the request