### PR TITLE
fix title of the dashboard to KernelCI

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/kernelci.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Kernel CI Dashboard</title>
+    <title>KernelCI Dashboard</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
There is no space between 'Kernel' and 'CI'.