### PR TITLE
fix: make config cards show tests statuses on Boot and Test tabs

### DIFF
--- a/backend/kernelCI_app/views/treeTestsView.py
+++ b/backend/kernelCI_app/views/treeTestsView.py
@@ -125,14 +125,15 @@ class TreeTestsView(View):
         statusCounts = defaultdict(int)
         errorCounts = defaultdict(int)
         configStatusCounts = defaultdict(lambda: defaultdict(int))
+        architectureStatusCounts = defaultdict(lambda: defaultdict(int))
         testHistory = []
-        errorCountPerArchitecture = defaultdict(int)
         platformsWithError = set()
         compilersPerArchitecture = defaultdict(set)
         errorMessageCounts = defaultdict(int)
         for record in query:
             statusCounts[record.status] += 1
             configStatusCounts[record.config_name][record.status] += 1
+            architectureStatusCounts[record.architecture][record.status] += 1
             testHistory.append(
                 {"start_time": record.start_time, "status": record.status}
             )
@@ -142,7 +143,6 @@ class TreeTestsView(View):
                 or record.status == "FAIL"
             ):
                 errorCounts[record.status] += 1
-                errorCountPerArchitecture[record.architecture] += 1
                 compilersPerArchitecture[record.architecture].add(
                     record.compiler)
                 platformsWithError.add(
@@ -162,7 +162,7 @@ class TreeTestsView(View):
                 "errorCounts": errorCounts,
                 "configStatusCounts": configStatusCounts,
                 "testHistory": testHistory,
-                "errorCountPerArchitecture": errorCountPerArchitecture,
+                "architectureStatusCounts": architectureStatusCounts,
                 "compilersPerArchitecture": compilersPerArchitecture,
                 "platformsWithError": list(platformsWithError),
                 "errorMessageCounts": errorMessageCounts,

--- a/backend/kernelCI_app/views/treeTestsView.py
+++ b/backend/kernelCI_app/views/treeTestsView.py
@@ -101,7 +101,8 @@ class TreeTestsView(View):
                 SELECT c.id, c.git_repository_url,
                 c.git_commit_hash, t.build_id, t.start_time,
                 t.status as status, t.path, b.architecture, b.config_name,
-                b.compiler, t.environment_misc, t.environment_comment, t.misc FROM checkouts AS c
+                b.compiler, t.environment_misc, t.environment_comment, t.misc
+                FROM checkouts AS c
                 INNER JOIN builds AS b ON c.id = b.checkout_id
                 INNER JOIN tests AS t ON t.build_id = b.id
                 WHERE c.git_commit_hash = %s AND c.origin = %s AND c.git_repository_url = %s AND
@@ -123,7 +124,7 @@ class TreeTestsView(View):
 
         statusCounts = defaultdict(int)
         errorCounts = defaultdict(int)
-        configCounts = defaultdict(int)
+        configStatusCounts = defaultdict(lambda: defaultdict(int))
         testHistory = []
         errorCountPerArchitecture = defaultdict(int)
         platformsWithError = set()
@@ -131,7 +132,7 @@ class TreeTestsView(View):
         errorMessageCounts = defaultdict(int)
         for record in query:
             statusCounts[record.status] += 1
-            configCounts[record.config_name] += 1
+            configStatusCounts[record.config_name][record.status] += 1
             testHistory.append(
                 {"start_time": record.start_time, "status": record.status}
             )
@@ -159,7 +160,7 @@ class TreeTestsView(View):
             {
                 "statusCounts": statusCounts,
                 "errorCounts": errorCounts,
-                "configCounts": configCounts,
+                "configStatusCounts": configStatusCounts,
                 "testHistory": testHistory,
                 "errorCountPerArchitecture": errorCountPerArchitecture,
                 "compilersPerArchitecture": compilersPerArchitecture,

--- a/backend/requests/boots-get.sh
+++ b/backend/requests/boots-get.sh
@@ -5,19 +5,33 @@
 http 'http://localhost:8000/api/tree/1dd28064d4164a4dc9096fd1a7990d2de15f2bb6/tests/'
 
 # {
-#   "errorCounts": {
-#     "MISS": 2,
+#   "statusCounts": {
+#     "FAIL": 2,
+#     "MISS": 1,
 #     "PASS": 1,
 #     "ERROR": 1
 #   },
-#   "configCounts": {
-#     "defconfig": 3,
-#     "multi_v7_defconfig": 1
+#   "errorCounts": {
+#     "FAIL": 2,
+#     "MISS": 1,
+#     "ERROR": 1
 #   },
-#   "bootHistory": [
+#   "configStatusCounts": {
+#     "defconfig": {
+#       "FAIL": 2,
+#       "PASS": 1
+#     },
+#     "multi_v7_defconfig": {
+#       "MISS": 1
+#     },
+#     "null": {
+#       "ERROR": 1
+#     }
+#   },
+#   "testHistory": [
 #     {
-#       "start_time": "2024-07-06T00:58:14.830Z",
-#       "status": "MISS"
+#       "start_time": "2024-07-06T00:58:20.149Z",
+#       "status": "FAIL"
 #     },
 #     {
 #       "start_time": "2024-07-06T00:48:55.924Z",
@@ -28,13 +42,18 @@ http 'http://localhost:8000/api/tree/1dd28064d4164a4dc9096fd1a7990d2de15f2bb6/te
 #       "status": "PASS"
 #     },
 #     {
-#       "start_time": "2024-07-06T00:56:49.278Z",
+#       "start_time": "2024-07-06T00:56:56.659Z",
+#       "status": "FAIL"
+#     },
+#     {
+#       "start_time": "2024-07-06T00:26:44.970Z",
 #       "status": "ERROR"
 #     }
 #   ],
 #   "errorCountPerArchitecture": {
 #     "arm64": 2,
-#     "arm": 1
+#     "arm": 1,
+#     "null": 1
 #   },
 #   "compilersPerArchitecture": {
 #     "arm64": [
@@ -42,17 +61,20 @@ http 'http://localhost:8000/api/tree/1dd28064d4164a4dc9096fd1a7990d2de15f2bb6/te
 #     ],
 #     "arm": [
 #       "gcc-12"
+#     ],
+#     "null": [
+#       null
 #     ]
 #   },
-#   "platforms": [
-#     "bcm2836-rpi-2-b",
-#     "meson-g12b-a311d-khadas-vim3",
-#     "sc7180-trogdor-lazor-limozeen"
+#   "platformsWithError": [
+#     "mt8183-kukui-jacuzzi-juniper-sku16",
+#     "kubernetes",
+#     "bcm2711-rpi-4-b",
+#     "bcm2836-rpi-2-b"
 #   ],
 #   "errorMessageCounts": {
-#     "400 Client Error: Bad Request for url: https://lava.infra.foundries.io/api/v0.2/jobs/?format=json&limit=256": 1,
-#     "No time left for remaining 1 retries. 2 retries out of 3 failed for auto-login-action": 1,
-#     "Invalid TESTCASE signal": 1
+#     "unknown error": 4,
+#     "No time left for remaining 1 retries. 2 retries out of 3 failed for auto-login-action": 2,
+#     "Node timed-out": 2
 #   }
 # }
-

--- a/dashboard/src/components/ListingItem/ListingItem.tsx
+++ b/dashboard/src/components/ListingItem/ListingItem.tsx
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import ColoredCircle from '../ColoredCircle/ColoredCircle';
 
 export interface IListingItem {
+  leftIcon?: React.ReactNode;
   warnings?: number;
   errors?: number;
   success?: number;
@@ -25,6 +26,7 @@ export enum ItemType {
 
 // TODO Add Tooltip text
 const ListingItem = ({
+  leftIcon,
   warnings,
   errors,
   text,
@@ -42,7 +44,12 @@ const ListingItem = ({
   const hasSuccess = success && success > 0 && showNumber;
   const hasUnknown = unknown && unknown > 0 && showNumber;
   const hasNone =
-    !hasErrors && !hasWarnings && !hasSuccess && !hasUnknown && showNumber;
+    !leftIcon &&
+    !hasErrors &&
+    !hasWarnings &&
+    !hasSuccess &&
+    !hasUnknown &&
+    showNumber;
 
   const handleOnClick = useCallback(() => {
     if (onClick) {
@@ -94,6 +101,7 @@ const ListingItem = ({
       {itemSuccess}
       {itemUnknown}
       {itemNeutral}
+      {leftIcon}
       <span className="text-sm text-black">{text}</span>
     </WrapperComponent>
   );

--- a/dashboard/src/components/Status/Status.tsx
+++ b/dashboard/src/components/Status/Status.tsx
@@ -7,6 +7,7 @@ interface ITestStatus {
   fail?: number;
   done?: number;
   skip?: number;
+  forceNumber?: boolean;
 }
 
 interface IBuildStatus {
@@ -22,39 +23,52 @@ export const TestStatus = ({
   fail,
   done,
   skip,
+  forceNumber = true,
 }: ITestStatus): JSX.Element => {
   return (
     <div className="flex flex-row gap-1">
-      <ColoredCircle
-        quantity={pass ?? 0}
-        tooltipText="global.pass"
-        backgroundClassName="bg-lightGreen"
-      />
-      <ColoredCircle
-        quantity={error ?? 0}
-        tooltipText="global.error"
-        backgroundClassName="bg-lightRed"
-      />
-      <ColoredCircle
-        quantity={miss ?? 0}
-        tooltipText="global.missed"
-        backgroundClassName="bg-lightGray"
-      />
-      <ColoredCircle
-        quantity={fail ?? 0}
-        tooltipText="global.failed"
-        backgroundClassName="bg-yellow"
-      />
-      <ColoredCircle
-        quantity={done ?? 0}
-        backgroundClassName="bg-lightBlue"
-        tooltipText="global.done"
-      />
-      <ColoredCircle
-        quantity={skip ?? 0}
-        tooltipText="global.skipped"
-        backgroundClassName="bg-mediumGray"
-      />
+      {(forceNumber || pass) && (
+        <ColoredCircle
+          quantity={pass ?? 0}
+          tooltipText="global.pass"
+          backgroundClassName="bg-lightGreen"
+        />
+      )}
+      {(forceNumber || error) && (
+        <ColoredCircle
+          quantity={error ?? 0}
+          tooltipText="global.error"
+          backgroundClassName="bg-lightRed"
+        />
+      )}
+      {(forceNumber || miss) && (
+        <ColoredCircle
+          quantity={miss ?? 0}
+          tooltipText="global.missed"
+          backgroundClassName="bg-lightGray"
+        />
+      )}
+      {(forceNumber || fail) && (
+        <ColoredCircle
+          quantity={fail ?? 0}
+          tooltipText="global.failed"
+          backgroundClassName="bg-yellow"
+        />
+      )}
+      {(forceNumber || done) && (
+        <ColoredCircle
+          quantity={done ?? 0}
+          tooltipText="global.done"
+          backgroundClassName="bg-lightBlue"
+        />
+      )}
+      {(forceNumber || done) && (
+        <ColoredCircle
+          quantity={skip ?? 0}
+          tooltipText="global.skipped"
+          backgroundClassName="bg-mediumGray"
+        />
+      )}
     </div>
   );
 };

--- a/dashboard/src/components/Summary/Summary.tsx
+++ b/dashboard/src/components/Summary/Summary.tsx
@@ -17,7 +17,8 @@ export interface ISummaryTable {
 }
 
 export interface ISummaryItem {
-  arch: IListingItem;
+  arch: Omit<IListingItem, 'leftIcon'>;
+  leftIcon?: IListingItem['leftIcon'];
   onClickKey?: (key: string) => void;
   onClickCompiler?: (compiler: string) => void;
   compilers: string[];
@@ -53,7 +54,7 @@ const Summary = ({
         <SummaryItem
           onClickKey={onClickKey}
           key={row.arch.text}
-          arch={row.arch}
+          arch={{ text: row.arch.text }}
           compilers={row.compilers}
           onClickCompiler={onClickCompiler}
         />
@@ -71,6 +72,7 @@ export const SummaryItem = ({
   compilers,
   onClickKey,
   onClickCompiler,
+  leftIcon,
 }: ISummaryItem): JSX.Element => {
   const compilersElement = useMemo(() => {
     return compilers?.map(compiler => (
@@ -88,12 +90,10 @@ export const SummaryItem = ({
     <TableRow>
       <TableCell>
         <ListingItem
-          errors={arch.errors}
           onClick={onClickKey}
           warnings={arch.warnings}
           text={arch.text}
-          success={arch.success}
-          unknown={arch.unknown}
+          leftIcon={leftIcon}
         />
       </TableCell>
       <TableCell>

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -7,7 +7,6 @@ export const messages = {
     'bootsTab.bootStatus': 'Boot Status',
     'bootsTab.configs': 'Configs',
     'bootsTab.error': 'Error',
-    'bootsTab.errorsSummary': 'Errors Summary',
     'bootsTab.fail': 'Fail',
     'bootsTab.info': 'Info',
     'bootsTab.info.description':
@@ -100,6 +99,7 @@ export const messages = {
     'global.somethingWrong': 'Sorry... something went wrong',
     'global.status': 'Status',
     'global.successful': 'Successful',
+    'global.summary': 'Summary',
     'global.timing': 'Timing',
     'global.total': 'Total',
     'global.tree': 'Tree',

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -74,7 +74,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
         />
         <MemoizedConfigList
           title={<FormattedMessage id="bootsTab.configs" />}
-          configCounts={data.configCounts}
+          configStatusCounts={data.configStatusCounts}
         />
         <MemoizedErrorsSummary
           title={<FormattedMessage id="bootsTab.errorsSummary" />}

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -77,8 +77,8 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
           configStatusCounts={data.configStatusCounts}
         />
         <MemoizedErrorsSummary
-          title={<FormattedMessage id="bootsTab.errorsSummary" />}
-          errorCountPerArchitecture={data.errorCountPerArchitecture}
+          title={<FormattedMessage id="global.summary" />}
+          architectureStatusCounts={data.architectureStatusCounts}
           compilersPerArchitecture={data.compilersPerArchitecture}
         />
         <MemoizedLineChartCard

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -123,13 +123,13 @@ export const MemoizedErrorCountList = memo(ErrorCountList);
 interface IErrorsSummary
   extends Pick<
     TTreeTestsData,
-    'errorCountPerArchitecture' | 'compilersPerArchitecture'
+    'architectureStatusCounts' | 'compilersPerArchitecture'
   > {
   title: IBaseCard['title'];
 }
 
 const ErrorsSummary = ({
-  errorCountPerArchitecture,
+  architectureStatusCounts,
   compilersPerArchitecture,
   title,
 }: IErrorsSummary): JSX.Element => {
@@ -143,16 +143,26 @@ const ErrorsSummary = ({
       title={title}
       content={
         <DumbSummary summaryHeaders={summaryHeaders}>
-          {Object.keys(errorCountPerArchitecture).map(architecture => {
-            const currentErrorCount = errorCountPerArchitecture[architecture];
+          {Object.keys(architectureStatusCounts).map(architecture => {
+            const statusCounts = architectureStatusCounts[architecture];
             const currentCompilers = compilersPerArchitecture[architecture];
             return (
               <SummaryItem
                 key={architecture}
                 arch={{
                   text: architecture,
-                  errors: currentErrorCount,
                 }}
+                leftIcon={
+                  <TestStatus
+                    forceNumber={false}
+                    done={statusCounts.DONE}
+                    fail={statusCounts.FAIL}
+                    error={statusCounts.ERROR}
+                    miss={statusCounts.MISS}
+                    pass={statusCounts.PASS}
+                    skip={statusCounts.SKIP}
+                  />
+                }
                 compilers={currentCompilers}
               />
             );

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -6,6 +6,8 @@ import { DumbListingContent } from '@/components/ListingContent/ListingContent';
 import BaseCard, { IBaseCard } from '@/components/Cards/BaseCard';
 import ListingItem from '@/components/ListingItem/ListingItem';
 import { TTreeTestsData } from '@/types/tree/TreeDetails';
+import { TestStatus } from '@/components/Status/Status';
+
 import { DumbSummary, SummaryItem } from '@/components/Summary/Summary';
 import StatusChartMemoized, {
   Colors,
@@ -15,24 +17,38 @@ import { errorStatusSet } from '@/utils/constants/database';
 import { ErrorStatus } from '@/types/database';
 import { LineChart, LineChartLabel } from '@/components/LineChart';
 
-interface IConfigList extends Pick<TTreeTestsData, 'configCounts'> {
+interface IConfigList extends Pick<TTreeTestsData, 'configStatusCounts'> {
   title: IBaseCard['title'];
 }
 
-const ConfigsList = ({ configCounts, title }: IConfigList): JSX.Element => {
+const ConfigsList = ({
+  configStatusCounts,
+  title,
+}: IConfigList): JSX.Element => {
   return (
     <BaseCard
       title={title}
       content={
         <DumbListingContent>
-          {Object.keys(configCounts).map(configName => {
-            const currentConfigCount = configCounts[configName];
+          {Object.keys(configStatusCounts).map(configName => {
+            const { DONE, FAIL, ERROR, MISS, PASS, SKIP } =
+              configStatusCounts[configName];
             return (
               <ListingItem
                 hasBottomBorder
                 key={configName}
                 text={configName}
-                success={currentConfigCount}
+                leftIcon={
+                  <TestStatus
+                    done={DONE}
+                    fail={FAIL}
+                    error={ERROR}
+                    miss={MISS}
+                    pass={PASS}
+                    skip={SKIP}
+                    forceNumber={false}
+                  />
+                }
               />
             );
           })}

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -74,7 +74,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
         />
         <MemoizedConfigList
           title={<FormattedMessage id="global.configs" />}
-          configCounts={data.configCounts}
+          configStatusCounts={data.configStatusCounts}
         />
         <MemoizedErrorsSummary
           title={<FormattedMessage id="testsTab.errorsSummary" />}

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -77,8 +77,8 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
           configStatusCounts={data.configStatusCounts}
         />
         <MemoizedErrorsSummary
-          title={<FormattedMessage id="testsTab.errorsSummary" />}
-          errorCountPerArchitecture={data.errorCountPerArchitecture}
+          title={<FormattedMessage id="global.summary" />}
+          architectureStatusCounts={data.architectureStatusCounts}
           compilersPerArchitecture={data.compilersPerArchitecture}
         />
         <MemoizedLineChartCard

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -103,10 +103,6 @@ type ErrorCounts = {
   [key in ErrorStatus]: number | undefined;
 };
 
-type ErrorCountPerArchitecture = {
-  [key: string]: number;
-};
-
 type CompilersPerArchitecture = {
   [key: string]: string[];
 };
@@ -119,14 +115,14 @@ type StatusCounts = {
   [key in Status]: number | undefined;
 };
 
-type ConfigStatusCounts = Record<string, StatusCounts>;
+type PropertyStatusCounts = Record<string, StatusCounts>;
 
 export type TTreeTestsData = {
   statusCounts: StatusCounts;
   errorCounts: ErrorCounts;
-  configStatusCounts: ConfigStatusCounts;
+  configStatusCounts: PropertyStatusCounts;
   testHistory: TestHistory[];
-  errorCountPerArchitecture: ErrorCountPerArchitecture;
+  architectureStatusCounts: PropertyStatusCounts;
   compilersPerArchitecture: CompilersPerArchitecture;
   platformsWithError: string[];
   errorMessageCounts: ErrorMessageCounts;

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -103,10 +103,6 @@ type ErrorCounts = {
   [key in ErrorStatus]: number | undefined;
 };
 
-type ConfigCounts = {
-  [key: string]: number;
-};
-
 type ErrorCountPerArchitecture = {
   [key: string]: number;
 };
@@ -123,10 +119,12 @@ type StatusCounts = {
   [key in Status]: number | undefined;
 };
 
+type ConfigStatusCounts = Record<string, StatusCounts>;
+
 export type TTreeTestsData = {
   statusCounts: StatusCounts;
   errorCounts: ErrorCounts;
-  configCounts: ConfigCounts;
+  configStatusCounts: ConfigStatusCounts;
   testHistory: TestHistory[];
   errorCountPerArchitecture: ErrorCountPerArchitecture;
   compilersPerArchitecture: CompilersPerArchitecture;


### PR DESCRIPTION
- make config cards show tests statuses on Boot and Test tabs
- rename Erros `Summary` to `Summary`
- make summary show tests statuses
<img width="560" alt="image" src="https://github.com/user-attachments/assets/c2a55d6b-042c-4e3d-bef2-12f18802d199">


Close: #199 