### PR TITLE
fix(BootsTab): remove duplicated emoji

### DIFF
--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -58,7 +58,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
         title={<FormattedMessage id="bootsTab.info" />}
         content={
           <p className="p-4 text-[1.3rem] text-darkGray">
-            ℹ️ <FormattedMessage id="bootsTab.info.description" />
+            <FormattedMessage id="bootsTab.info.description" />
           </p>
         }
       />


### PR DESCRIPTION
## Description

Remove a duplicate emoji in the BootsTab that was defined in both the localization and the page file.

## Visual Reference

| Previous | Now |
|--------|--------|
| <img width="1411"  src="https://github.com/user-attachments/assets/501fb58a-0a4d-4c35-8e7d-a564cffab49b"> | <img width="1411" src="https://github.com/user-attachments/assets/1aa8f638-d5cf-4f50-9958-aaa0f3eb016b"> |

