### PR TITLE
fix(dashboard): reduce staleTime to 5 minutes

### DIFF
--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -38,9 +38,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       // eslint-disable-next-line no-magic-numbers
-      gcTime: 1000 * 60 * 30, // 30 minutes,
-      // eslint-disable-next-line no-magic-numbers
-      staleTime: 1000 * 60 * 30, // 30 minutes,
+      staleTime: 1000 * 60 * 5, // 5 minutes,
     },
   },
 });


### PR DESCRIPTION
The staleTime for queries has been reduced from 30 minutes to 5 minutes.
This change ensures that the data is refreshed more frequently, improving
the responsiveness and accuracy of the dashboard.
