### PR TITLE
fix: use grouped status in status chart for all tree details tab

### DIFF
--- a/dashboard/src/components/StatusChart/StatusCharts.tsx
+++ b/dashboard/src/components/StatusChart/StatusCharts.tsx
@@ -154,7 +154,7 @@ const ChartLegend = ({ chartValues, onClick }: IChartLegend): JSX.Element => {
           <WrapperElement
             onClick={(): void => onClick?.(status)}
             key={chartValue?.color}
-            className="flex flex-row"
+            className="flex flex-row text-left"
           >
             {chartValue && (
               <div className="pr-2 pt-1">

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -72,7 +72,7 @@ const StatusCard = ({
             },
             {
               value: treeDetailsData?.buildsSummary.null ?? 0,
-              label: 'treeDetails.unknown',
+              label: 'global.inconclusive',
               color: Colors.Gray,
             },
           ]}

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -13,6 +13,7 @@ import StatusChartMemoized, {
   Colors,
   StatusChartValues,
 } from '@/components/StatusChart/StatusCharts';
+import { groupStatus } from '@/utils/status';
 
 interface IConfigList extends Pick<TTreeTestsData, 'configStatusCounts'> {
   title: IBaseCard['title'];
@@ -177,36 +178,30 @@ interface IStatusChart extends Pick<TTreeTestsData, 'statusCounts'> {
 }
 
 const StatusChart = ({ statusCounts, title }: IStatusChart): JSX.Element => {
+  const groupedStatusCounts = groupStatus({
+    doneCount: statusCounts.DONE ?? 0,
+    errorCount: statusCounts.ERROR ?? 0,
+    failCount: statusCounts.FAIL ?? 0,
+    missCount: statusCounts.MISS ?? 0,
+    passCount: statusCounts.PASS ?? 0,
+    skipCount: statusCounts.SKIP ?? 0,
+  });
+
   const chartElements = [
     {
       label: 'bootsTab.success',
-      value: statusCounts['PASS'] ?? 0,
+      value: groupedStatusCounts.successCount,
       color: Colors.Green,
     },
     {
       label: 'global.failed',
-      value: statusCounts['FAIL'] ?? 0,
-      color: Colors.Yellow,
-    },
-    {
-      label: 'bootsTab.skip',
-      value: statusCounts['SKIP'] ?? 0,
-      color: Colors.DimGray,
-    },
-    {
-      label: 'global.missed',
-      value: statusCounts['MISS'] ?? 0,
-      color: Colors.Gray,
-    },
-    {
-      label: 'global.done',
-      value: statusCounts['DONE'] ?? 0,
-      color: Colors.Blue,
-    },
-    {
-      label: 'bootsTab.error',
-      value: statusCounts['ERROR'] ?? 0,
+      value: groupedStatusCounts.failedCount,
       color: Colors.Red,
+    },
+    {
+      label: 'global.inconclusive',
+      value: groupedStatusCounts.inconclusiveCount ?? 0,
+      color: Colors.Gray,
     },
   ] satisfies StatusChartValues[];
 


### PR DESCRIPTION
| Previous | Now |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cf429da5-a727-4831-992b-27f1b914bd8e)| ![image](https://github.com/user-attachments/assets/d48c2ffe-e64c-4efc-9996-d5a5d68bd96f) |


Close #259 



