### PR TITLE
fix: wrong usage of misc platform field

### DIFF
--- a/dashboard/src/pages/TestDetails/TestDetails.tsx
+++ b/dashboard/src/pages/TestDetails/TestDetails.tsx
@@ -53,6 +53,11 @@ const LogExcerpt = ({ test }: TTestDetailsDefaultProps): JSX.Element => {
 
 const TestDetailsSection = ({ test }: { test: TTestDetails }): JSX.Element => {
   const intl = useIntl();
+  const misc = test.environment_misc ?? test.misc;
+  const platform: string = misc
+    ? JSON.parse(misc).platform
+    : intl.formatMessage({ id: 'global.unknown' });
+
   const infos: ISubsection['infos'] = useMemo(() => {
     const baseInfo = [
       {
@@ -92,10 +97,7 @@ const TestDetailsSection = ({ test }: { test: TTestDetails }): JSX.Element => {
       },
       {
         title: intl.formatMessage({ id: 'testDetails.platform' }),
-        linkText:
-          test.misc?.platform ??
-          test.environment_misc?.platform ??
-          intl.formatMessage({ id: 'global.unknown' }),
+        linkText: platform,
         icon: <GiFlatPlatform className="text-blue" />,
       },
     ];
@@ -104,14 +106,13 @@ const TestDetailsSection = ({ test }: { test: TTestDetails }): JSX.Element => {
     intl,
     test.architecture,
     test.compiler,
-    test.environment_misc?.platform,
     test.git_commit_hash,
     test.git_repository_branch,
     test.git_repository_url,
     test.log_url,
-    test.misc?.platform,
     test.path,
     test.status,
+    platform,
   ]);
   return <Subsection infos={infos} />;
 };

--- a/dashboard/src/types/tree/TestDetails.tsx
+++ b/dashboard/src/types/tree/TestDetails.tsx
@@ -3,14 +3,14 @@ export type TTestDetails = {
   build_id: string;
   compiler: string;
   config_name: string;
-  environment_misc: Record<string, string> | undefined;
+  environment_misc: string | undefined;
   git_commit_hash: string;
   git_repository_branch: string;
   git_repository_url: string;
   id: string;
   log_excerpt: string | undefined;
   log_url: string | undefined;
-  misc: Record<string, string> | undefined;
+  misc: string | undefined;
   path: string;
   start_time: string;
   status: string;


### PR DESCRIPTION
- misc fields are json strings and must be parsed before being used as an object

| Before | After |
|--------|--------|
| <img width="146" alt="image" src="https://github.com/user-attachments/assets/7c2c7da0-6fb5-4e77-91aa-7cf971f32c57"> | <img width="242" alt="image" src="https://github.com/user-attachments/assets/a13b0108-e45f-4e60-a41c-d7e48eaf9639"> |

Close #261 
