### PR TITLE
feat/performance boots

### DIFF
--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path(
         "tree/<str:commit_hash>/tests/", views.TreeTestsView.as_view(), name="treeTests"
     ),
+    path("build/<str:build_id>/status-count", views.BuildStatusCountView.as_view(), name="buildStatusCount"),
     path("build/<str:build_id>", views.BuildDetails.as_view(), name="buildDetails"),
     path("build/<str:build_id>/tests", views.BuildTests.as_view(), name="buildTests"),
     path("tests/test/<str:test_id>", views.TestDetails.as_view(), name="testDetails"),

--- a/backend/kernelCI_app/views/buildStatusCountView.py
+++ b/backend/kernelCI_app/views/buildStatusCountView.py
@@ -1,0 +1,48 @@
+from django.http import JsonResponse
+from rest_framework.views import APIView
+from kernelCI_app.models import Builds
+
+
+class BuildStatusCountView(APIView):
+    def get(self, _request, build_id):
+        builds = Builds.objects.raw(
+            """
+            SELECT
+                builds.id,
+                COUNT(CASE WHEN tests.status = 'FAIL' THEN 1 END) AS fail_tests,
+                COUNT(CASE WHEN tests.status = 'ERROR' THEN 1 END) AS error_tests,
+                COUNT(CASE WHEN tests.status = 'MISS' THEN 1 END) AS miss_tests,
+                COUNT(CASE WHEN tests.status = 'PASS' THEN 1 END) AS pass_tests,
+                COUNT(CASE WHEN tests.status = 'DONE' THEN 1 END) AS done_tests,
+                COUNT(CASE WHEN tests.status = 'SKIP' THEN 1 END) AS skip_tests,
+                SUM(CASE WHEN tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END)
+                    AS null_tests,
+                COUNT(tests.id) AS total_tests
+            FROM
+                builds
+            LEFT JOIN
+                tests ON tests.build_id = builds.id
+            WHERE builds.id = %s
+            GROUP BY builds.id;
+            """,
+            [build_id],
+        )
+
+        build_status_counts = list(builds)
+        if not build_status_counts:
+            return JsonResponse({"error": "Build not found"}, status=404)
+
+        build_status = build_status_counts[0]
+        build_counts = {
+            "build_id": build_status.id,
+            "fail_tests": build_status.fail_tests,
+            "error_tests": build_status.error_tests,
+            "miss_tests": build_status.miss_tests,
+            "pass_tests": build_status.pass_tests,
+            "done_tests": build_status.done_tests,
+            "skip_tests": build_status.skip_tests,
+            "null_tests": build_status.null_tests,
+            "total_tests": build_status.total_tests,
+        }
+
+        return JsonResponse({"build_counts": build_counts})

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -11,72 +11,65 @@ class TreeDetails(View):
         return {"valid": 0, "invalid": 0, "null": 0}
 
     def create_summary(self, builds_dict):
-        status_map = {True: 'valid', False: 'invalid', None: 'null'}
+        status_map = {True: "valid", False: "invalid", None: "null"}
 
         build_summ = self.create_default_status()
         config_summ = {}
         arch_summ = {}
 
         for build in builds_dict:
-            status_key = status_map[build['valid']]
+            status_key = status_map[build["valid"]]
             build_summ[status_key] += 1
 
-            if config := build['config_name']:
+            if config := build["config_name"]:
                 status = config_summ.get(config)
                 if not status:
                     status = self.create_default_status()
                     config_summ[config] = status
                 status[status_key] += 1
 
-            if arch := build['architecture']:
-                status = arch_summ.setdefault(
-                    arch, self.create_default_status())
+            if arch := build["architecture"]:
+                status = arch_summ.setdefault(arch, self.create_default_status())
                 status[status_key] += 1
-                compiler = build['compiler']
-                if compiler and compiler not in status.setdefault('compilers', []):
-                    status['compilers'].append(compiler)
+                compiler = build["compiler"]
+                if compiler and compiler not in status.setdefault("compilers", []):
+                    status["compilers"].append(compiler)
 
-        return {"builds": build_summ, "configs": config_summ, "architectures": arch_summ}
-
-    def get_test_status(self, build_id):
-        status_keys = ["fail_tests", "error_tests", "miss_tests", "pass_tests",
-                       "done_tests", "skip_tests", "null_tests", "total_tests"]
-        builds = Builds.objects.raw(
-            """
-            SELECT
-                builds.id,
-                COUNT(CASE WHEN tests.status = 'FAIL' THEN 1 END) AS fail_tests,
-                COUNT(CASE WHEN tests.status = 'ERROR' THEN 1 END) AS error_tests,
-                COUNT(CASE WHEN tests.status = 'MISS' THEN 1 END) AS miss_tests,
-                COUNT(CASE WHEN tests.status = 'PASS' THEN 1 END) AS pass_tests,
-                COUNT(CASE WHEN tests.status = 'DONE' THEN 1 END) AS done_tests,
-                COUNT(CASE WHEN tests.status = 'SKIP' THEN 1 END) AS skip_tests,
-                SUM(CASE WHEN tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END)
-                    AS null_tests,
-                COUNT(tests.id) AS total_tests
-            FROM
-                builds
-            LEFT JOIN
-                tests ON tests.build_id = builds.id
-            WHERE builds.id = %s
-            GROUP BY builds.id;
-            """,
-            [build_id]
-        )
-        return {k: getattr(builds[0], k) for k in status_keys}
+        return {
+            "builds": build_summ,
+            "configs": config_summ,
+            "architectures": arch_summ,
+        }
 
     def get(self, request, commit_hash):
         build_fields = [
-            'id', 'architecture', 'config_name', 'misc', 'config_url',
-            'compiler', 'valid', 'duration', 'log_url', 'start_time']
+            "id",
+            "architecture",
+            "config_name",
+            "misc",
+            "config_url",
+            "compiler",
+            "valid",
+            "duration",
+            "log_url",
+            "start_time",
+        ]
         checkout_fields = [
-            'git_repository_branch', 'git_repository_url', 'git_repository_branch']
+            "git_repository_branch",
+            "git_repository_url",
+            "git_repository_branch",
+        ]
 
-        query = Query().from_table(Builds, build_fields).join(
-            'checkouts',
-            condition='checkouts.id = builds.checkout_id',
-            fields=checkout_fields
-        ).where(git_commit_hash__eq=commit_hash)
+        query = (
+            Query()
+            .from_table(Builds, build_fields)
+            .join(
+                "checkouts",
+                condition="checkouts.id = builds.checkout_id",
+                fields=checkout_fields,
+            )
+            .where(git_commit_hash__eq=commit_hash)
+        )
 
         try:
             filter_params = FilterParams(request)
@@ -84,22 +77,20 @@ class TreeDetails(View):
             return HttpResponseBadRequest(getErrorResponseBody(str(e)))
 
         for f in filter_params.filters:
-            field = f['field']
+            field = f["field"]
             table = None
             if field in build_fields:
-                table = 'builds'
+                table = "builds"
             elif field in checkout_fields:
-                table = 'checkouts'
+                table = "checkouts"
             if table:
-                op = filter_params.get_comparison_op(f, 'orm')
-                query.where(
-                    **{f'{table}.{field}__{op}': f['value']})
+                op = filter_params.get_comparison_op(f, "orm")
+                query.where(**{f"{table}.{field}__{op}": f["value"]})
 
         records = query.select()
-        for r in records:
-            status = self.get_test_status(r.get('id'))
-            r['status'] = status
 
         summary = self.create_summary(records)
+
+        print("Summary: ", summary)
 
         return JsonResponse({"builds": records, "summary": summary}, safe=False)

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -91,6 +91,4 @@ class TreeDetails(View):
 
         summary = self.create_summary(records)
 
-        print("Summary: ", summary)
-
         return JsonResponse({"builds": records, "summary": summary}, safe=False)

--- a/backend/requests/build-status-count-get.sh
+++ b/backend/requests/build-status-count-get.sh
@@ -1,0 +1,33 @@
+http GET 'http://localhost:8000/api/build/kernelci:kernelci.org:666ce37cab1bab49d17e7074/status-count'
+# HTTP/1.1 200 OK
+# Content-Length: 625
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Thu, 25 Jul 2024 17:27:16 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.0
+# Vary: origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "_timestamp": "2024-06-30T22:46:03.064Z",
+#     "architecture": "openrisc",
+#     "checkout_id": "0dayci:6681dfff2e96c85bf5ad3a7f",
+#     "command": null,
+#     "comment": null,
+#     "compiler": "gcc-13.2.0",
+#     "config_name": "allnoconfig",
+#     "config_url": null,
+#     "duration": null,
+#     "git_commit_hash": "22a40d14b572deb80c0648557f4bd502d7e83826",
+#     "git_commit_name": "v6.10-rc6",
+#     "git_repository_branch": "master",
+#     "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+#     "id": "0dayci:build:6681e0032e96c85bf5ad3a80",
+#     "log_url": null,
+#     "misc": null,
+#     "origin": "0dayci",
+#     "start_time": "2024-06-30T22:45:23.477Z",
+#     "valid": true
+# }

--- a/dashboard/src/api/TreeDetails.tsx
+++ b/dashboard/src/api/TreeDetails.tsx
@@ -2,7 +2,7 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
 import {
   TTreeTestsData,
-  BootsTab,
+  BuildsTab,
   TTreeDetailsFilter,
   TTestByCommitHashResponse,
   TTreeCommitHistoryResponse,
@@ -18,7 +18,7 @@ import http from './api';
 const fetchTreeDetailData = async (
   treeId: string,
   filter: TTreeDetailsFilter | Record<string, never>,
-): Promise<BootsTab> => {
+): Promise<BuildsTab> => {
   const filterParam = mapFiltersToUrlSearchParams(filter);
 
   const res = await http.get(`/api/tree/${treeId}`, { params: filterParam });
@@ -43,7 +43,7 @@ const mapFiltersToUrlSearchParams = (
 export const useBuildsTab = (
   treeId: string,
   filter: TTreeDetailsFilter | Record<string, never> = {},
-): UseQueryResult<BootsTab> => {
+): UseQueryResult<BuildsTab> => {
   const detailsFilter = getTargetFilter(filter, 'treeDetails');
 
   return useQuery({

--- a/dashboard/src/api/TreeDetails.tsx
+++ b/dashboard/src/api/TreeDetails.tsx
@@ -2,10 +2,11 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
 import {
   TTreeTestsData,
-  TreeDetails,
+  BootsTab,
   TTreeDetailsFilter,
   TTestByCommitHashResponse,
   TTreeCommitHistoryResponse,
+  BuildCountsResponse,
 } from '@/types/tree/TreeDetails';
 
 import { TPathTests } from '@/types/general';
@@ -17,7 +18,7 @@ import http from './api';
 const fetchTreeDetailData = async (
   treeId: string,
   filter: TTreeDetailsFilter | Record<string, never>,
-): Promise<TreeDetails> => {
+): Promise<BootsTab> => {
   const filterParam = mapFiltersToUrlSearchParams(filter);
 
   const res = await http.get(`/api/tree/${treeId}`, { params: filterParam });
@@ -39,10 +40,10 @@ const mapFiltersToUrlSearchParams = (
   return filterParam;
 };
 
-export const useTreeDetails = (
+export const useBuildsTab = (
   treeId: string,
   filter: TTreeDetailsFilter | Record<string, never> = {},
-): UseQueryResult<TreeDetails> => {
+): UseQueryResult<BootsTab> => {
   const detailsFilter = getTargetFilter(filter, 'treeDetails');
 
   return useQuery({
@@ -233,5 +234,29 @@ export const useTreeCommitHistory = (
     enabled,
     queryFn: () =>
       fetchTreeCommitHistory(commitHash, origin, gitUrl, gitBranch),
+  });
+};
+
+const fetchBuildStatusCount = async (
+  buildId: string,
+): Promise<BuildCountsResponse> => {
+  const res = await http.get<BuildCountsResponse>(
+    `/api/build/${buildId}/status-count`,
+  );
+  return res.data;
+};
+
+export const useBuildStatusCount = (
+  {
+    buildId,
+  }: {
+    buildId: string;
+  },
+  { enabled = true },
+): UseQueryResult<BuildCountsResponse> => {
+  return useQuery({
+    queryKey: [buildId],
+    enabled,
+    queryFn: () => fetchBuildStatusCount(buildId),
   });
 };

--- a/dashboard/src/components/Accordion/Accordion.tsx
+++ b/dashboard/src/components/Accordion/Accordion.tsx
@@ -110,36 +110,42 @@ const AccordionTableBody = ({
         </div>
       );
     }
-    return items.map((item, index) => (
-      <Collapsible key={index} asChild>
-        <>
-          <CollapsibleTrigger asChild>
-            <TableRow className="group cursor-pointer hover:bg-lightBlue">
-              {type === 'build' ? (
-                <AccordionBuildsTrigger accordionData={item} />
-              ) : (
-                <AccordionTestsTrigger accordionData={item} />
-              )}
+    return items.map(item => {
+      const itemKey =
+        type === 'build'
+          ? (item as AccordionItemBuilds).id
+          : (item as TPathTests).path_group;
+      return (
+        <Collapsible key={itemKey} asChild>
+          <>
+            <CollapsibleTrigger asChild>
+              <TableRow className="group cursor-pointer hover:bg-lightBlue">
+                {type === 'build' ? (
+                  <AccordionBuildsTrigger accordionData={item} />
+                ) : (
+                  <AccordionTestsTrigger accordionData={item} />
+                )}
+              </TableRow>
+            </CollapsibleTrigger>
+            <TableRow>
+              <TableCell colSpan={6} className="p-0">
+                <CollapsibleContent>
+                  <div className="group max-h-[400px] w-full overflow-scroll border-b border-darkGray bg-lightGray p-8">
+                    {type === 'build' ? (
+                      <AccordionBuildContent accordionData={item} />
+                    ) : (
+                      <AccordionTestsContent
+                        data={(item as TPathTests).individual_tests}
+                      />
+                    )}
+                  </div>
+                </CollapsibleContent>
+              </TableCell>
             </TableRow>
-          </CollapsibleTrigger>
-          <TableRow>
-            <TableCell colSpan={6} className="p-0">
-              <CollapsibleContent>
-                <div className="group max-h-[400px] w-full overflow-scroll border-b border-darkGray bg-lightGray p-8">
-                  {type === 'build' ? (
-                    <AccordionBuildContent accordionData={item} />
-                  ) : (
-                    <AccordionTestsContent
-                      data={(item as TPathTests).individual_tests}
-                    />
-                  )}
-                </div>
-              </CollapsibleContent>
-            </TableCell>
-          </TableRow>
-        </>
-      </Collapsible>
-    ));
+          </>
+        </Collapsible>
+      );
+    });
   }, [items, type]);
 
   return <TableBody>{accordionItems}</TableBody>;

--- a/dashboard/src/components/Accordion/BuildAccordionContent.tsx
+++ b/dashboard/src/components/Accordion/BuildAccordionContent.tsx
@@ -121,8 +121,6 @@ const AccordionBuildContent = ({
 }: IAccordionItems): JSX.Element => {
   const { treeId } = useParams({ from: '/tree/$treeId/' });
 
-  console.log('oii', accordionData);
-
   //TODO: Fix the typing for not using as
   const contentData = accordionData as AccordionItemBuilds;
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -142,14 +142,6 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
         '-'
       ),
       date: row.date?.split('T')[0],
-      testStatus: {
-        failTests: row.testStatus?.failTests ?? 0,
-        errorTests: row.testStatus?.errorTests ?? 0,
-        passTests: row.testStatus?.passTests ?? 0,
-        skipTests: row.testStatus?.skipTests ?? 0,
-        doneTests: row.testStatus?.doneTests ?? 0,
-        missTests: row.testStatus?.missTests ?? 0,
-      },
     }));
   }, [treeDetailsData?.builds]);
 

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -9,7 +9,7 @@ import { ISummaryItem } from '@/components/Summary/Summary';
 import {
   AccordionItemBuilds,
   BuildStatus,
-  BuildsTab,
+  BuildsTabBuild,
 } from '@/types/tree/TreeDetails';
 import { Skeleton } from '@/components/Skeleton';
 import {
@@ -102,7 +102,7 @@ const TreeHeader = ({
   );
 };
 
-const isBuildError = (build: BuildsTab): number => {
+const isBuildError = (build: BuildsTabBuild): number => {
   return build.valid || build.valid === null ? 0 : 1;
 };
 

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -3,13 +3,13 @@ import { useMemo } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-import { useTreeDetails } from '@/api/TreeDetails';
+import { useBuildsTab } from '@/api/TreeDetails';
 import { IListingItem } from '@/components/ListingItem/ListingItem';
 import { ISummaryItem } from '@/components/Summary/Summary';
 import {
   AccordionItemBuilds,
   BuildStatus,
-  TreeDetailsBuild,
+  BuildsTab,
 } from '@/types/tree/TreeDetails';
 import { Skeleton } from '@/components/Skeleton';
 import {
@@ -102,7 +102,7 @@ const TreeHeader = ({
   );
 };
 
-const isBuildError = (build: TreeDetailsBuild): number => {
+const isBuildError = (build: BuildsTab): number => {
   return build.valid || build.valid === null ? 0 : 1;
 };
 
@@ -113,7 +113,7 @@ function TreeDetails(): JSX.Element {
 
   const reqFilter = mapFilterToReq(diffFilter);
 
-  const { isLoading, data } = useTreeDetails(treeId ?? '', reqFilter);
+  const { isLoading, data } = useBuildsTab(treeId ?? '', reqFilter);
 
   const filterListElement = useMemo(
     () => <TreeDetailsFilterList filter={diffFilter} />,
@@ -172,14 +172,6 @@ function TreeDetails(): JSX.Element {
           buildErrors: isBuildError(value),
           status:
             value.valid === null ? 'null' : value.valid ? 'valid' : 'invalid',
-          testStatus: {
-            failTests: value.status?.fail_tests,
-            passTests: value.status?.pass_tests,
-            errorTests: value.status?.error_tests,
-            skipTests: value.status?.skip_tests,
-            missTests: value.status?.miss_tests,
-            doneTests: value.status?.done_tests,
-          },
           buildLogs: value.log_url,
           kernelConfig: value.config_url,
           kernelImage: value.misc ? value.misc['kernel_type'] : undefined,

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -24,9 +24,9 @@ import {
   TFilterObjectsKeys,
   TFilterNumberKeys,
   isTFilterObjectKeys,
-  TreeDetails as TreeDetailsType,
+  BuildsTab as TreeDetailsType,
 } from '@/types/tree/TreeDetails';
-import { useTreeDetails } from '@/api/TreeDetails';
+import { useBuildsTab } from '@/api/TreeDetails';
 import { Skeleton } from '@/components/Skeleton';
 import { TRequestFiltersValues } from '@/utils/filters';
 
@@ -326,7 +326,7 @@ const TreeDetailsFilter = ({
 }: ITreeDetailsFilter): JSX.Element => {
   const { treeId } = useParams({ from: '/tree/$treeId/' });
 
-  const { data, isLoading } = useTreeDetails(treeId);
+  const { data, isLoading } = useBuildsTab(treeId);
 
   const navigate = useNavigate({
     from: '/tree/$treeId',

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -6,7 +6,7 @@ import { MessagesKey } from '@/locales/messages';
 
 import type { ErrorStatus, Status } from '../database';
 
-export type TreeDetailsBuild = {
+export type BuildsTab = {
   id: string;
   architecture: string;
   config_name: string;
@@ -18,16 +18,6 @@ export type TreeDetailsBuild = {
   log_url: string;
   git_repository_branch: string;
   git_repository_url: string;
-  status: {
-    fail_tests: number;
-    error_tests: number;
-    miss_tests: number;
-    pass_tests: number;
-    done_tests: number;
-    skip_tests: number;
-    null_tests: number;
-    total_tests: number;
-  };
   misc: ITreeDetailsMisc | null;
 };
 
@@ -46,14 +36,6 @@ export type AccordionItemBuilds = {
   buildErrors?: number;
   buildTime?: string | ReactNode;
   status?: 'valid' | 'invalid' | 'null';
-  testStatus?: {
-    failTests: number;
-    errorTests: number;
-    passTests: number;
-    skipTests: number;
-    missTests: number;
-    doneTests: number;
-  };
   kernelImage?: string;
   buildLogs?: string;
   kernelConfig?: string;
@@ -62,8 +44,8 @@ export type AccordionItemBuilds = {
   modules?: string;
 };
 
-export type TreeDetails = {
-  builds: TreeDetailsBuild[];
+export type BootsTab = {
+  builds: BuildsTab[];
   summary: {
     builds: BuildStatus;
     configs: Record<string, BuildStatus>;
@@ -87,9 +69,9 @@ type TArch = Record<
 export interface TTreeDetailsFilter
   extends Partial<{
     [K in keyof Omit<
-      TreeDetailsBuild,
+      BuildsTab,
       'test_status' | 'misc' | 'valid'
-    >]: TreeDetailsBuild[K][];
+    >]: BuildsTab[K][];
   }> {
   valid?: string[];
 }
@@ -277,6 +259,20 @@ export type PaginatedCommitHistoryByTree = {
     pass_count: number;
     done_count: number;
     skip_count: number;
+  };
+};
+
+export type BuildCountsResponse = {
+  build_counts: {
+    build_id: string;
+    fail_tests: number;
+    error_tests: number;
+    miss_tests: number;
+    pass_tests: number;
+    done_tests: number;
+    skip_tests: number;
+    null_tests: number;
+    total_tests: number;
   };
 };
 

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -6,7 +6,7 @@ import { MessagesKey } from '@/locales/messages';
 
 import type { ErrorStatus, Status } from '../database';
 
-export type BuildsTab = {
+export type BuildsTabBuild = {
   id: string;
   architecture: string;
   config_name: string;
@@ -44,8 +44,8 @@ export type AccordionItemBuilds = {
   modules?: string;
 };
 
-export type BootsTab = {
-  builds: BuildsTab[];
+export type BuildsTab = {
+  builds: BuildsTabBuild[];
   summary: {
     builds: BuildStatus;
     configs: Record<string, BuildStatus>;
@@ -69,9 +69,9 @@ type TArch = Record<
 export interface TTreeDetailsFilter
   extends Partial<{
     [K in keyof Omit<
-      BuildsTab,
+      BuildsTabBuild,
       'test_status' | 'misc' | 'valid'
-    >]: BuildsTab[K][];
+    >]: BuildsTabBuild[K][];
   }> {
   valid?: string[];
 }


### PR DESCRIPTION
# Description

This PR remove the precounts of the status for each builds and put it under demand when the user opens an accordion


You can test the graphs in this link:
http://localhost:5173/tree/034835342aab1cc7dc1733a98cd2a6d159ee242a?tableFilter=%7B%22bootsTable%22%3A%22all%22%2C%22buildsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.builds&diffFilter=%7B%7D&treeInfo=%7B%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Famlogic%2Flinux.git%22%2C%22gitBranch%22%3A%22for-next%22%2C%22treeName%22%3A%22amlogic%22%2C%22commitName%22%3A%22v6.11-rc1-22-g034835342aab%22%2C%22headCommitHash%22%3A%22034835342aab1cc7dc1733a98cd2a6d159ee242a%22%7D


And the slow repo in this link:

http://localhost:5173/tree/fe3b83691989077c55cd1e91e0a0bd831b6255aa?tableFilter=%7B%22bootsTable%22%3A%22all%22%2C%22buildsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.builds&diffFilter=%7B%7D&treeInfo=%7B%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fnext%2Flinux-next.git%22%2C%22gitBranch%22%3A%22pending-fixes%22%2C%22treeName%22%3A%22next%22%2C%22commitName%22%3A%22v6.11-rc7-98-gfe3b83691989%22%2C%22headCommitHash%22%3A%22fe3b83691989077c55cd1e91e0a0bd831b6255aa%22%7D