### PR TITLE
fix: Summary card status not showing in Build tab

### DIFF
--- a/dashboard/src/components/Status/Status.tsx
+++ b/dashboard/src/components/Status/Status.tsx
@@ -28,42 +28,42 @@ export const TestStatus = ({
 }: ITestStatus): JSX.Element => {
   return (
     <div className="flex flex-row gap-1">
-      {(forceNumber || pass) && (
+      {(forceNumber || Boolean(pass)) && (
         <ColoredCircle
           quantity={pass ?? 0}
           tooltipText="global.pass"
           backgroundClassName="bg-lightGreen"
         />
       )}
-      {(forceNumber || error) && (
+      {(forceNumber || Boolean(error)) && (
         <ColoredCircle
           quantity={error ?? 0}
           tooltipText="global.error"
           backgroundClassName="bg-lightRed"
         />
       )}
-      {(forceNumber || miss) && (
+      {(forceNumber || Boolean(miss)) && (
         <ColoredCircle
           quantity={miss ?? 0}
           tooltipText="global.missed"
           backgroundClassName="bg-lightGray"
         />
       )}
-      {(forceNumber || fail) && (
+      {(forceNumber || Boolean(fail)) && (
         <ColoredCircle
           quantity={fail ?? 0}
           tooltipText="global.failed"
           backgroundClassName="bg-yellow"
         />
       )}
-      {(forceNumber || done) && (
+      {(forceNumber || Boolean(done)) && (
         <ColoredCircle
           quantity={done ?? 0}
           tooltipText="global.done"
           backgroundClassName="bg-lightBlue"
         />
       )}
-      {(forceNumber || done) && (
+      {(forceNumber || Boolean(skip)) && (
         <ColoredCircle
           quantity={skip ?? 0}
           tooltipText="global.skipped"

--- a/dashboard/src/components/Summary/Summary.tsx
+++ b/dashboard/src/components/Summary/Summary.tsx
@@ -54,7 +54,7 @@ const Summary = ({
         <SummaryItem
           onClickKey={onClickKey}
           key={row.arch.text}
-          arch={{ text: row.arch.text }}
+          arch={row.arch}
           compilers={row.compilers}
           onClickCompiler={onClickCompiler}
         />
@@ -94,6 +94,9 @@ export const SummaryItem = ({
           warnings={arch.warnings}
           text={arch.text}
           leftIcon={leftIcon}
+          success={arch.success}
+          unknown={arch.unknown}
+          errors={arch.errors}
         />
       </TableCell>
       <TableCell>


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="138" alt="image" src="https://github.com/user-attachments/assets/11932c54-3150-44a7-9a16-0a99600470c4"> | <img width="155" alt="image" src="https://github.com/user-attachments/assets/ff680986-aea7-49cc-8cf6-ff4f246cf527">|

Close #283 