### PR TITLE
fix: build details table

### DIFF
--- a/dashboard/src/api/buildTests.ts
+++ b/dashboard/src/api/buildTests.ts
@@ -1,13 +1,13 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
-import { TPathTests } from '@/types/general';
+import { TBuildTests } from '@/types/general';
 
 import http from './api';
 
 const fetchBuildTestsData = async (
   buildId: string,
   path: string,
-): Promise<TPathTests[]> => {
+): Promise<TBuildTests[]> => {
   const params = path ? { path } : {};
   const res = await http.get(`/api/build/${buildId}/tests`, { params });
 
@@ -17,7 +17,7 @@ const fetchBuildTestsData = async (
 export const useBuildTests = (
   buildId: string,
   path = '',
-): UseQueryResult<TPathTests[]> => {
+): UseQueryResult<TBuildTests[]> => {
   return useQuery({
     queryKey: ['buildTests', buildId, path],
     queryFn: () => fetchBuildTestsData(buildId, path),

--- a/dashboard/src/pages/BuildDetails/BuildDetailsTestSection.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetailsTestSection.tsx
@@ -12,6 +12,7 @@ import { useBuildTests } from '@/api/buildTests';
 import { usePagination } from '@/hooks/usePagination';
 import { MessagesKey } from '@/locales/messages';
 import { GroupedTestStatus } from '@/components/Status/Status';
+import { formatDate } from '@/utils/utils';
 
 interface IBuildDetailsTestSection {
   buildId: string;
@@ -62,10 +63,11 @@ const BuildDetailsTestSection = ({
 
   const rows = useMemo(() => {
     if (!data || error) return <></>;
-
     return data.slice(startIndex, endIndex).map(test => (
-      <TableRow key={test.path_group}>
-        <TableCell onClick={onClickName}>{test.path_group}</TableCell>
+      <TableRow key={test.current_path}>
+        <TableCell>{test.origins.join(', ')}</TableCell>
+        <TableCell onClick={onClickName}>{test.current_path}</TableCell>
+
         <TableCell className="flex flex-row gap-1">
           <GroupedTestStatus
             pass={test.pass_tests}
@@ -76,6 +78,7 @@ const BuildDetailsTestSection = ({
             error={test.error_tests}
           />
         </TableCell>
+        <TableCell>{formatDate(test.start_time)}</TableCell>
       </TableRow>
     ));
   }, [data, error, onClickName, startIndex, endIndex]);

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -19,3 +19,17 @@ export type TIndividualTest = {
   start_time: string;
   duration: string;
 };
+
+export type TBuildTests = {
+  current_path: string;
+  start_time: string;
+  origins: string[];
+  fail_tests: number;
+  error_tests: number;
+  miss_tests: number;
+  pass_tests: number;
+  done_tests: number;
+  skip_tests: number;
+  null_tests: number;
+  total_tests: number;
+};


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1156" alt="image" src="https://github.com/user-attachments/assets/31c0cde0-0fa2-4076-bc2d-105f7f264d08"> | <img width="1142" alt="image" src="https://github.com/user-attachments/assets/e067f76c-f69c-4677-84d5-6d14ca64baa1"> |


Close #288 

Tested using: http://localhost:5173/tree/5f5673607153e36fc1b83583b41973a75529ab99/build/redhat:1450845118-aarch64-kernel?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.builds&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.11-rc7-105-g5f5673607153e%22%2C%22headCommitHash%22%3A%225f5673607153e36fc1b83583b41973a75529ab99%22%7D