### PR TITLE
feat(dashboard): date and time on tooltip

### DIFF
--- a/dashboard/src/components/Table/TreeTable.tsx
+++ b/dashboard/src/components/Table/TreeTable.tsx
@@ -101,6 +101,9 @@ const TreeTableRow = (row: TreeTableBody): JSX.Element => {
     ],
   );
 
+  const date = row.date.split('T')[0] ?? '';
+  const time = row.date.split('T')[1].split('.')[0] ?? '';
+
   return (
     <TableRow>
       <TableCell
@@ -134,7 +137,18 @@ const TreeTableRow = (row: TreeTableBody): JSX.Element => {
         onClick={navigateToTreeDetailPage}
         data-target="treeDetails.builds"
       >
-        {sanitizeTableValue(row.date.split('T')[0] ?? '')}
+        <Tooltip>
+          <TooltipTrigger>
+            <div>{date}</div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <div className="text-center">
+              {date}
+              <br />
+              {time}
+            </div>
+          </TooltipContent>
+        </Tooltip>
       </TableCell>
       <TableCell
         onClick={navigateToTreeDetailPage}


### PR DESCRIPTION
Date and time now are shown when hovering over date.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/9aa674f8-553d-44bc-8994-23b96992d1a9) | ![image](https://github.com/user-attachments/assets/ac47f55c-260b-40ae-be11-1d42faf9f2e7) |


Closes #228