### PR TITLE
fix(tests-table): failed tests are failed and error is inconclusive

### DIFF
--- a/backend/kernelCI_app/views/groupedTestsView.py
+++ b/backend/kernelCI_app/views/groupedTestsView.py
@@ -20,8 +20,10 @@ class groupedTests(View):
         get_required_params = [
             "git_commit_hash",
             "git_repository_branch",
-            "git_repository_url" "origin",
+            "git_repository_url",
+            "origin"
         ]
+
         errorResponse = validate_required_params(request, get_required_params)
 
         if errorResponse:

--- a/dashboard/src/components/Table/TestsTable.tsx
+++ b/dashboard/src/components/Table/TestsTable.tsx
@@ -118,7 +118,7 @@ const TestsTable = ({ treeId }: ITestsTable): JSX.Element => {
           }));
       case 'failed':
         return data
-          ?.filter(tests => tests.error_tests > 0)
+          ?.filter(tests => tests.fail_tests > 0)
           .map(test => ({
             ...test,
             individual_tests: test.individual_tests.filter(
@@ -130,7 +130,7 @@ const TestsTable = ({ treeId }: ITestsTable): JSX.Element => {
           ?.filter(
             tests =>
               tests.done_tests > 0 ||
-              tests.fail_tests > 0 ||
+              tests.error_tests > 0 ||
               tests.miss_tests > 0 ||
               tests.skip_tests > 0 ||
               tests.null_tests > 0,

--- a/dashboard/src/utils/status.ts
+++ b/dashboard/src/utils/status.ts
@@ -31,6 +31,6 @@ export function groupStatus(counts: StatusCount): GroupedStatus {
 
 export const getStatusGroup = (status: Status): StatusGroups => {
   if (status === 'PASS') return 'success';
-  if (status === 'ERROR') return 'failed';
+  if (status === 'FAIL') return 'failed';
   return 'inconclusive';
 };


### PR DESCRIPTION
failed tests should show fail and inconclusive should show inconclusive

![image](https://github.com/user-attachments/assets/4efd9779-0cca-4816-bff1-db98d207c8a6)


http://localhost:5173/tree/5f5673607153e36fc1b83583b41973a75529ab99?tableFilter=%7B%22bootsTable%22%3A%22success%22%2C%22buildsTable%22%3A%22all%22%2C%22testsTable%22%3A%22success%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.11-rc7-105-g5f5673607153e%22%2C%22headCommitHash%22%3A%225f5673607153e36fc1b83583b41973a75529ab99%22%7D

