### PR TITLE
feat(dashboard): adding tz offset to dates

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -16,6 +16,7 @@
     "pypush": "cd .. && cd backend && sh pre-push"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.0.1",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^5.16.7",
@@ -42,6 +43,7 @@
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.5.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.0.0",
     "eslint-import-resolver-typescript": "^3.6.3",
     "lucide-react": "^0.396.0",
     "react": "^18.3.1",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@date-fns/tz':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@emotion/react':
         specifier: ^11.13.3
         version: 11.13.3(@types/react@18.3.6)(react@18.3.1)
@@ -86,6 +89,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.0.0
+        version: 4.0.0
       eslint-import-resolver-typescript:
         specifier: ^3.6.3
         version: 3.6.3(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0)
@@ -419,6 +425,9 @@ packages:
   '@chromatic-com/storybook@1.9.0':
     resolution: {integrity: sha512-vYQ+TcfktEE3GHnLZXHCzXF/sN9dw+KivH8a5cmPyd9YtQs7fZtHrEgsIjWpYycXiweKMo1Lm1RZsjxk8DH3rA==}
     engines: {node: '>=16.0.0', yarn: '>=1.22.18'}
+
+  '@date-fns/tz@1.0.1':
+    resolution: {integrity: sha512-xaoJsguTUTPgafdT+u6TQNb4xcXQqaroeQSJL/7VCEWxQLTd//+ywV90u0VfkeKXfq1E9GRm5waS3bgIfUNu0g==}
 
   '@emotion/babel-plugin@11.12.0':
     resolution: {integrity: sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==}
@@ -2528,6 +2537,9 @@ packages:
   data-view-byte-offset@1.0.0:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.0.0:
+    resolution: {integrity: sha512-6K33+I8fQ5otvHgLIvKK1xmMbLAh0pduyrx7dwMXKiGYeoWhmk6M3Zoak9n7bXHMJQlHq1yqmdGy1QxKddJjUA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -4903,6 +4915,8 @@ snapshots:
       - '@chromatic-com/playwright'
       - react
 
+  '@date-fns/tz@1.0.1': {}
+
   '@emotion/babel-plugin@11.12.0':
     dependencies:
       '@babel/helper-module-imports': 7.24.7
@@ -7195,6 +7209,8 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
+
+  date-fns@4.0.0: {}
 
   debug@2.6.9:
     dependencies:

--- a/dashboard/src/components/Accordion/Accordion.tsx
+++ b/dashboard/src/components/Accordion/Accordion.tsx
@@ -28,6 +28,8 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 
+import { TooltipDateTime } from '@/components/TooltipDateTime';
+
 import AccordionBuildContent from './BuildAccordionContent';
 
 export interface IAccordion {
@@ -165,7 +167,18 @@ const AccordionBuildsTrigger = ({
     <>
       <TableCell>{triggerInfo.config}</TableCell>
       <TableCell>{triggerInfo.compiler}</TableCell>
-      <TableCell>{triggerInfo.date}</TableCell>
+      <TableCell>
+        {triggerInfo.date ? (
+          <TooltipDateTime
+            dateTime={triggerInfo.date}
+            lineBreak={true}
+            showLabelTime={true}
+            showLabelTZ={true}
+          />
+        ) : (
+          '-'
+        )}
+      </TableCell>
       <TableCell>
         <ColoredCircle
           className="max-w-6"
@@ -255,7 +268,14 @@ const TestTableRow = ({ test, onClick }: ITestTableRow): JSX.Element => {
     >
       <TableCell>{test.path}</TableCell>
       <TableCell>{test.status}</TableCell>
-      <TableCell>{test.start_time ?? '-'}</TableCell>
+      <TableCell>
+        <TooltipDateTime
+          dateTime={test.start_time}
+          lineBreak={true}
+          showLabelTime={true}
+          showLabelTZ={true}
+        />
+      </TableCell>
       <TableCell>{test.duration ?? '-'}</TableCell>
       <TableCell>
         <ChevronRightAnimate />

--- a/dashboard/src/components/Table/BootsTable.tsx
+++ b/dashboard/src/components/Table/BootsTable.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import { MdChevronRight } from 'react-icons/md';
 
 import BaseTable from '@/components/Table/BaseTable';
+import { TooltipDateTime } from '@/components/TooltipDateTime';
 import { TableInfo } from '@/components/Table/TableInfo';
 import { TableCell, TableRow } from '@/components/ui/table';
 import { usePagination } from '@/hooks/usePagination';
@@ -124,7 +125,14 @@ const BootsTable = ({ treeId, testHistory }: ITestsTable): JSX.Element => {
       <TableRow onClick={() => onClickName(test.id)} key={test.id}>
         <TableCell>{test.path}</TableCell>
         <TableCell>{test.status}</TableCell>
-        <TableCell>{test.startTime ?? '-'}</TableCell>
+        <TableCell>
+          <TooltipDateTime
+            dateTime={test.startTime}
+            lineBreak={true}
+            showLabelTime={true}
+            showLabelTZ={true}
+          />
+        </TableCell>
         <TableCell>{test.duration ?? '-'}</TableCell>
         <TableCell>
           <MdChevronRight />

--- a/dashboard/src/components/Table/TreeTable.tsx
+++ b/dashboard/src/components/Table/TreeTable.tsx
@@ -18,6 +18,8 @@ import { TreeTableBody, zOrigin } from '@/types/tree/Tree';
 
 import { TableRow, TableCell, TableBody } from '@/components/ui/table';
 
+import { TooltipDateTime } from '@/components/TooltipDateTime';
+
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 
 import HeaderWithInfo from '@/pages/TreeDetails/Tabs/HeaderWithInfo';
@@ -101,10 +103,6 @@ const TreeTableRow = (row: TreeTableBody): JSX.Element => {
     ],
   );
 
-  const dateObj = new Date(row.date);
-  const date = dateObj.toLocaleDateString();
-  const time = dateObj.toLocaleTimeString();
-
   return (
     <TableRow>
       <TableCell
@@ -138,18 +136,7 @@ const TreeTableRow = (row: TreeTableBody): JSX.Element => {
         onClick={navigateToTreeDetailPage}
         data-target="treeDetails.builds"
       >
-        <Tooltip>
-          <TooltipTrigger>
-            <div>{date}</div>
-          </TooltipTrigger>
-          <TooltipContent>
-            <div className="text-center">
-              {date}
-              <br />
-              {time}
-            </div>
-          </TooltipContent>
-        </Tooltip>
+        <TooltipDateTime dateTime={row.date} lineBreak={true} />
       </TableCell>
       <TableCell
         onClick={navigateToTreeDetailPage}

--- a/dashboard/src/components/TooltipDateTime/TooltipDateTime.tsx
+++ b/dashboard/src/components/TooltipDateTime/TooltipDateTime.tsx
@@ -1,0 +1,56 @@
+import { format, isValid } from 'date-fns';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
+import { getDateOffset } from '@/utils/utils';
+
+type TooltipDateTimeProps = {
+  dateTime: string;
+  dateFormat?: string;
+  timeFormat?: string;
+  lineBreak?: boolean;
+  showLabelTime?: boolean;
+  showLabelTZ?: boolean;
+  showTooltip?: boolean;
+};
+
+const TooltipDateTime = ({
+  dateTime,
+  dateFormat,
+  timeFormat,
+  lineBreak = true,
+  showLabelTime,
+  showLabelTZ = false,
+  showTooltip = true,
+}: TooltipDateTimeProps): JSX.Element => {
+  const dateObj = new Date(dateTime);
+  if (!isValid(dateObj)) return <div>-</div>;
+
+  const date = dateFormat
+    ? format(dateObj, dateFormat)
+    : dateObj.toLocaleDateString();
+  const time = timeFormat
+    ? format(dateObj, timeFormat)
+    : dateObj.toLocaleTimeString();
+  const tz = getDateOffset(dateObj);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <div>
+          {date} {showLabelTime ? time : ''} {showLabelTZ ? tz : ''}
+        </div>
+      </TooltipTrigger>
+      {showTooltip && (
+        <TooltipContent>
+          <div className="text-center">
+            {date}
+            {lineBreak ? <br /> : ' '}
+            {time} {tz}
+          </div>
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
+};
+
+export default TooltipDateTime;

--- a/dashboard/src/components/TooltipDateTime/index.tsx
+++ b/dashboard/src/components/TooltipDateTime/index.tsx
@@ -1,0 +1,3 @@
+import TooltipDateTime from './TooltipDateTime';
+
+export { TooltipDateTime };

--- a/dashboard/src/pages/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetails.tsx
@@ -14,6 +14,8 @@ import { ISection } from '@/components/Section/Section';
 import { useBuildDetails } from '@/api/BuildDetails';
 import UnexpectedError from '@/components/UnexpectedError/UnexpectedError';
 
+import { formatDate } from '@/utils/utils';
+
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -85,7 +87,7 @@ const BuildDetails = (): JSX.Element => {
               },
               {
                 title: intl.formatMessage({ id: 'global.date' }),
-                linkText: valueOrEmpty(data.timestamp),
+                linkText: formatDate(valueOrEmpty(data.start_time)),
               },
               {
                 title: intl.formatMessage({ id: 'global.defconfig' }),

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -156,7 +156,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
       ) : (
         '-'
       ),
-      date: row.date?.split('T')[0],
+      date: row.date,
     }));
   }, [treeDetailsData?.builds]);
 

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { format } from 'date-fns';
+
 export function formatDate(date: Date | string): string {
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
@@ -14,3 +16,7 @@ export function formatDate(date: Date | string): string {
 
   return new Intl.DateTimeFormat('en-US', options).format(date);
 }
+
+export const getDateOffset = (date: Date): string => {
+  return format(date, 'z');
+};


### PR DESCRIPTION
Adds timezone offset to dates at main page and other places:

| Before | After |
|--------|--------|
| ![Screenshot from 2024-09-16 11-21-15](https://github.com/user-attachments/assets/f2c1ca20-ebdd-49fa-9ea7-15369701c2ce) | ![image](https://github.com/user-attachments/assets/0c7b034e-708f-4414-b67f-092a73530c26) | 

Closes #305