### PR TITLE
fix: test path was being used as test id

### DIFF
--- a/dashboard/src/components/Accordion/Accordion.tsx
+++ b/dashboard/src/components/Accordion/Accordion.tsx
@@ -212,41 +212,24 @@ const AccordionTestsContent = ({
 }: IAccordionTestContent): JSX.Element => {
   const navigate = useNavigate({ from: '/tree/$treeId' });
 
-  const onClickName = useCallback(
-    (e: React.MouseEvent<HTMLTableRowElement>) => {
-      const newTestPath = e.currentTarget.querySelector(
-        'td:first-child',
-      ) as HTMLTableCellElement;
-      if (newTestPath) {
-        navigate({
-          to: '/tree/$treeId/test/$testId',
-          params: {
-            testId: newTestPath.innerText,
-          },
-          search: s => s,
-        });
-      }
+  const onClickRow = useCallback(
+    (testId: string) => {
+      navigate({
+        to: '/tree/$treeId/test/$testId',
+        params: {
+          testId: testId,
+        },
+        search: s => s,
+      });
     },
     [navigate],
   );
 
   const rows = useMemo(() => {
     return data.map(test => (
-      <TableRow
-        className="cursor-pointer hover:bg-lightBlue"
-        onClick={onClickName}
-        key={test.id}
-      >
-        <TableCell>{test.path}</TableCell>
-        <TableCell>{test.status}</TableCell>
-        <TableCell>{test.start_time ?? '-'}</TableCell>
-        <TableCell>{test.duration ?? '-'}</TableCell>
-        <TableCell>
-          <ChevronRightAnimate />
-        </TableCell>
-      </TableRow>
+      <TestTableRow key={test.id} test={test} onClick={onClickRow} />
     ));
-  }, [data, onClickName]);
+  }, [data, onClickRow]);
 
   return (
     <div className="h-max-12 overflow-scroll">
@@ -254,6 +237,30 @@ const AccordionTestsContent = ({
         <TableBody>{rows}</TableBody>
       </BaseTable>
     </div>
+  );
+};
+
+interface ITestTableRow {
+  test: TIndividualTest;
+  onClick: (testId: string) => void;
+}
+
+const TestTableRow = ({ test, onClick }: ITestTableRow): JSX.Element => {
+  const onClickHandle = useCallback(() => onClick(test.id), [onClick, test.id]);
+  return (
+    <TableRow
+      className="cursor-pointer hover:bg-lightBlue"
+      onClick={onClickHandle}
+      key={test.id}
+    >
+      <TableCell>{test.path}</TableCell>
+      <TableCell>{test.status}</TableCell>
+      <TableCell>{test.start_time ?? '-'}</TableCell>
+      <TableCell>{test.duration ?? '-'}</TableCell>
+      <TableCell>
+        <ChevronRightAnimate />
+      </TableCell>
+    </TableRow>
   );
 };
 


### PR DESCRIPTION
Fix: The test tab was using` test.path` to navigate to TestDetails when it should have been using `test.id`

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ced40915-6918-4c8b-8192-52e689b3110f) | ![image](https://github.com/user-attachments/assets/29852fe5-c3bf-4273-851c-3acb1a42546b) |
