### PR TITLE
feat(debug): add SQL query debugging option

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -53,3 +53,10 @@ We are not using sessions or anything like that right now, so changing the secre
 
 # Requests
 In the `/requests` directory we have scripts that execute requests to endpoints using [httpie](https://httpie.io/)
+
+
+# Debug
+
+For debugging we have two env variables
+
+`DEBUG` and `DEBUG_SQL_QUERY` that can be set to `True` to enable debugging. The reason `DEBUG_SQL_QUERY` is separated is that it can be very verbose.

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -48,6 +48,12 @@ ENV_DEBUG = get_json_env_var("DEBUG", False)
 if isBooleanOrStringTrue(ENV_DEBUG):
     DEBUG = True
 
+DEBUG_SQL_QUERY = False
+
+ENV_DEBUG_SQL_QUERY = get_json_env_var("DEBUG_SQL_QUERY", False)
+
+if isBooleanOrStringTrue(ENV_DEBUG_SQL_QUERY) and DEBUG:
+    DEBUG_SQL_QUERY = True
 
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
@@ -127,9 +133,9 @@ DATABASES = {
 
 
 CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'ecom',
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "ecom",
     }
 }
 
@@ -195,5 +201,34 @@ if DEBUG:
     CSRF_COOKIE_SECURE = False
     SECURE_SSL_REDIRECT = False
     SECURE_HSTS_SECONDS = 3600
+
+if DEBUG_SQL_QUERY:
+    LOGGING = {
+        "disable_existing_loggers": False,
+        "version": 1,
+        "handlers": {
+            "console": {
+                # logging handler that outputs log messages to terminal
+                "class": "logging.StreamHandler",
+                "level": "DEBUG",  # message level to be written to console
+            },
+        },
+        "loggers": {
+            "": {
+                # this sets root level logger to log debug and higher level
+                # logs to console. All other loggers inherit settings from
+                # root level logger.
+                "handlers": ["console"],
+                "level": "DEBUG",
+                "propagate": False,  # this tells logger to send logging message
+                # to its parent (will send if set to True)
+            },
+            "django.db": {
+                # django also has database level logging
+                "level": "DEBUG"
+            },
+        },
+    }
+
 
 CACHE_TIMEOUT = int(get_json_env_var("CACHE_TIMEOUT", "600"))


### PR DESCRIPTION
Added two environment variables `DEBUG` and `DEBUG_SQL_QUERY` for
debugging. The `DEBUG_SQL_QUERY` variable is separated to control
verbose SQL query logging. Updated settings to handle these variables
and configure logging accordingly.

Closes #268


![image](https://github.com/user-attachments/assets/b9e16a84-22bd-4c17-b9ae-2b6ab1e57f5b)
