### PR TITLE
Feat/add filters tests

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -193,6 +193,8 @@ MIGRATION_MODULES = DisableMigrations()
 
 CORS_ALLOW_ALL_ORIGINS = False
 
+CACHE_TIMEOUT = int(get_json_env_var("CACHE_TIMEOUT", "600"))
+
 if DEBUG:
     CORS_ALLOWED_ORIGIN_REGEXES = [
         r"^http://localhost",  # dashboard dev server
@@ -201,6 +203,7 @@ if DEBUG:
     CSRF_COOKIE_SECURE = False
     SECURE_SSL_REDIRECT = False
     SECURE_HSTS_SECONDS = 3600
+    CACHE_TIMEOUT = 0
 
 if DEBUG_SQL_QUERY:
     LOGGING = {
@@ -229,6 +232,3 @@ if DEBUG_SQL_QUERY:
             },
         },
     }
-
-
-CACHE_TIMEOUT = int(get_json_env_var("CACHE_TIMEOUT", "600"))

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useParams, useSearch } from '@tanstack/react-router';
+import { useParams } from '@tanstack/react-router';
 
 import { useTestsTab } from '@/api/TreeDetails';
 import BaseCard from '@/components/Cards/BaseCard';
@@ -31,16 +31,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
   const { treeId } = useParams({
     from: '/tree/$treeId/',
   });
-  const { origin, treeInfo } = useSearch({
-    from: '/tree/$treeId/',
-  });
-  const { isLoading, data, error } = useTestsTab(
-    treeId ?? '',
-    origin,
-    treeInfo.gitBranch ?? '',
-    treeInfo.gitUrl ?? '',
-    reqFilter,
-  );
+  const { isLoading, data, error } = useTestsTab(treeId ?? '', reqFilter);
 
   if (error || !treeId) {
     return (

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useParams, useSearch } from '@tanstack/react-router';
+import { useParams } from '@tanstack/react-router';
 
 import { Skeleton } from '@/components/Skeleton';
 
@@ -30,16 +30,7 @@ interface TestsTabProps {
 
 const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
   const { treeId } = useParams({ from: '/tree/$treeId/' });
-  const { origin, treeInfo } = useSearch({
-    from: '/tree/$treeId/',
-  });
-  const { isLoading, data, error } = useTestsTab(
-    treeId ?? '',
-    origin,
-    treeInfo.gitBranch ?? '',
-    treeInfo.gitUrl ?? '',
-    reqFilter,
-  );
+  const { isLoading, data, error } = useTestsTab(treeId ?? '', reqFilter);
 
   if (error || !treeId) {
     return (


### PR DESCRIPTION
# Add filter to tests and boots in tree details


- Changed filter lists to sets for better performance and clarity.
- Updated variable names for better readability.
- Added additional filters for configs, compiler, and architecture.
- Refactored the filtering logic in the `TreeDetailsSlow` view.
- Updated the frontend to handle new filter parameters.
- Removed unnecessary useSearch hook in BootsTab and TestsTab.


## How to test
Go to any tree that has tests eg: (broonie-sounds), and mess with the filters, see if it affects the boots/tests tab 

It is really hard to know if it is right, so, check the test details to see which filters you can use, because not all builds have tests

Coses #302, #326