### PR TITLE
bug(dashboard): small arrow breaking in graph

### DIFF
--- a/dashboard/src/pages/TreeDetails/Tabs/CommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/CommitNavigationGraph.tsx
@@ -168,7 +168,7 @@ const CommitNavigationGraph = (): JSX.Element => {
           );
         }
 
-        return `commitIndex-${value} - ${currentCommitDateTime}`;
+        return `commitIndex-${value}`;
       },
     },
   ];


### PR DESCRIPTION
In details, a small arrow was breaking in Builds History, now fixed.

Closes #342