### PR TITLE
feat: include log excerpt in build status response

### DIFF
--- a/backend/kernelCI_app/views/buildStatusCountView.py
+++ b/backend/kernelCI_app/views/buildStatusCountView.py
@@ -8,7 +8,7 @@ class BuildStatusCountView(APIView):
         builds = Builds.objects.raw(
             """
             SELECT
-                builds.id,
+                builds.id, builds.log_excerpt,
                 COUNT(CASE WHEN tests.status = 'FAIL' THEN 1 END) AS fail_tests,
                 COUNT(CASE WHEN tests.status = 'ERROR' THEN 1 END) AS error_tests,
                 COUNT(CASE WHEN tests.status = 'MISS' THEN 1 END) AS miss_tests,
@@ -23,7 +23,7 @@ class BuildStatusCountView(APIView):
             LEFT JOIN
                 tests ON tests.build_id = builds.id
             WHERE builds.id = %s
-            GROUP BY builds.id;
+            GROUP BY builds.id, builds.log_excerpt;
             """,
             [build_id],
         )
@@ -33,6 +33,7 @@ class BuildStatusCountView(APIView):
             return JsonResponse({"error": "Build not found"}, status=404)
 
         build_status = build_status_counts[0]
+        log_excerpt = build_status.log_excerpt
         build_counts = {
             "build_id": build_status.id,
             "fail_tests": build_status.fail_tests,
@@ -45,4 +46,4 @@ class BuildStatusCountView(APIView):
             "total_tests": build_status.total_tests,
         }
 
-        return JsonResponse({"build_counts": build_counts})
+        return JsonResponse({"log_excerpt": log_excerpt, "build_counts": build_counts})

--- a/backend/requests/build-status-count-get.sh
+++ b/backend/requests/build-status-count-get.sh
@@ -1,4 +1,4 @@
-http GET 'http://localhost:8000/api/build/kernelci:kernelci.org:666ce37cab1bab49d17e7074/status-count'
+http GET 'http://localhost:8000/api/build/maestro:66fd98545acad1231036a15a/status-count'
 # HTTP/1.1 200 OK
 # Content-Length: 625
 # Content-Type: application/json

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -292,6 +292,7 @@ export type PaginatedCommitHistoryByTree = {
 };
 
 export type BuildCountsResponse = {
+  log_excerpt?: string;
   build_counts: {
     build_id: string;
     fail_tests: number;


### PR DESCRIPTION
- Added `log_excerpt` field to the SQL query in `BuildStatusCountView`.
- Updated the JSON response to include `log_excerpt`.
- Modified the test request script to an example with log_excerpt data
- Updated `BuildCountsResponse` type to include `log_excerpt`.

Closes #347 