### PR TITLE
fix(#322): add no-console lint rule

### DIFF
--- a/dashboard/.eslintrc.cjs
+++ b/dashboard/.eslintrc.cjs
@@ -54,6 +54,12 @@ module.exports = {
     "@typescript-eslint",
   ],
   rules: {
+    "no-console": [
+      "error",
+      {
+        allow: ["error"]
+      }
+    ],
     "no-duplicate-imports": "warn",
     "no-magic-numbers": [
       "error",


### PR DESCRIPTION
Added no-console rule to eslint, any console.log() or console.warn() will be shown as a problem; console.error() can still be used.

Closes #322