### PR TITLE
feat/slide with log excerpt

### DIFF
--- a/dashboard/src/components/Accordion/BuildAccordionContent.tsx
+++ b/dashboard/src/components/Accordion/BuildAccordionContent.tsx
@@ -13,20 +13,20 @@ import {
 
 import { useBuildStatusCount } from '@/api/TreeDetails';
 
-import { SheetTrigger } from '@/components/Sheet';
-
-import { DevOnly } from '@/components/FeatureFlag';
+import { Sheet, SheetTrigger } from '@/components/Sheet';
 
 import StatusChartMemoized, {
   Colors,
   IStatusChart,
-} from '../StatusChart/StatusCharts';
+} from '@/components/StatusChart/StatusCharts';
 
-import LinksGroup from '../LinkGroup/LinkGroup';
+import LinksGroup, { ILinkGroup } from '@/components/LinkGroup/LinkGroup';
 
-import { Button } from '../ui/button';
+import { Button } from '@/components/ui/button';
 
-import QuerySwitcher from '../QuerySwitcher/QuerySwitcher';
+import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
+
+import { LogSheet } from '@/pages/TreeDetails/Tabs/LogSheet';
 
 import { IAccordionItems } from './Accordion';
 
@@ -143,18 +143,18 @@ const AccordionBuildContent = ({
     });
   }, [contentData.id, navigate, treeId]);
 
-  const links = useMemo(
+  const links: ILinkGroup['links'] = useMemo(
     () => [
       contentData.kernelImage
         ? {
-            title: <FormattedMessage id="buildAccordion.kernelImage" />,
+            title: 'buildAccordion.kernelImage',
             icon: <MdFolderOpen className={blueText} />,
             linkText: <span>{`kernel/${contentData.kernelImage}`}</span>,
           }
         : undefined,
       contentData.kernelConfig
         ? {
-            title: <FormattedMessage id="buildAccordion.kernelConfig" />,
+            title: 'buildAccordion.kernelConfig',
             icon: <MdFolderOpen className={blueText} />,
             link: contentData.kernelConfig,
             linkText: <FormattedMessage id="buildAccordion.kernelConfigPath" />,
@@ -162,7 +162,7 @@ const AccordionBuildContent = ({
         : undefined,
       contentData.dtb
         ? {
-            title: <FormattedMessage id="buildAccordion.dtb" />,
+            title: 'buildAccordion.dtb',
             icon: <MdFolderOpen className={blueText} />,
             link: contentData.dtb,
             linkText: <FormattedMessage id="buildAccordion.dtbs" />,
@@ -170,15 +170,15 @@ const AccordionBuildContent = ({
         : undefined,
       contentData.buildLogs
         ? {
-            title: <FormattedMessage id="buildAccordion.buildLogs" />,
+            title: 'buildAccordion.buildLogs',
             icon: <MdFolderOpen className={blueText} />,
-            link: contentData.buildLogs,
             linkText: <FormattedMessage id="buildAccordion.logs" />,
+            wrapperComponent: SheetTrigger,
           }
         : undefined,
       contentData.systemMap
         ? {
-            title: <FormattedMessage id="buildAccordion.systemMap" />,
+            title: 'buildAccordion.systemMap',
             icon: <MdFolderOpen className={blueText} />,
             link: contentData.systemMap,
             linkText: <FormattedMessage id="buildAccordion.systemMapPath" />,
@@ -186,7 +186,7 @@ const AccordionBuildContent = ({
         : undefined,
       contentData.modules
         ? {
-            title: <FormattedMessage id="buildAccordion.modules" />,
+            title: 'buildAccordion.modules',
             icon: <MdFolderOpen className={blueText} />,
             link: contentData.modules,
             linkText: <FormattedMessage id="buildAccordion.modulesZip" />,
@@ -205,27 +205,33 @@ const AccordionBuildContent = ({
 
   return (
     <>
-      <div className="flex flex-row justify-between">
-        <QuerySwitcher data={data} status={status} skeletonClassname="h-[60px]">
-          {data && <AccordBuildStatusChart buildCountsData={data} />}
-        </QuerySwitcher>
-        <div className="flex flex-col gap-8">
-          <LinksGroup links={links} />
-          <div className="flex flex-row gap-4">
-            <Button
-              variant="outline"
-              className="w-min rounded-full border-2 border-black text-sm text-dimGray hover:bg-mediumGray"
-              onClick={navigateToBuildDetails}
-            >
-              <FormattedMessage id="buildAccordion.showMore" />
-            </Button>
-            <DevOnly>
-              {/* TODO: Transform the trigger in the real show logs button when the Log Excerpt preview arrives */}
-              <SheetTrigger>Show Logs</SheetTrigger>
-            </DevOnly>
+      <Sheet>
+        <div className="flex flex-row justify-between">
+          <QuerySwitcher
+            data={data}
+            status={status}
+            skeletonClassname="h-[60px]"
+          >
+            {data && <AccordBuildStatusChart buildCountsData={data} />}
+          </QuerySwitcher>
+          <div className="flex flex-col gap-8">
+            <LinksGroup links={links} />
+            <div className="flex flex-row gap-4">
+              <Button
+                variant="outline"
+                className="w-min rounded-full border-2 border-black text-sm text-dimGray hover:bg-mediumGray"
+                onClick={navigateToBuildDetails}
+              >
+                <FormattedMessage id="buildAccordion.showMore" />
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
+        <LogSheet
+          logExcerpt={data?.log_excerpt}
+          logUrl={contentData.buildLogs}
+        />
+      </Sheet>
     </>
   );
 };

--- a/dashboard/src/components/FeatureFlag/DevOnly.tsx
+++ b/dashboard/src/components/FeatureFlag/DevOnly.tsx
@@ -1,12 +1,8 @@
-import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 
-export const DevOnly = ({
-  children,
-}: {
-  children: ReactElement;
-}): JSX.Element => {
+export const DevOnly = ({ children }: { children: ReactNode }): JSX.Element => {
   const { showDev } = useFeatureFlag();
 
   return <>{showDev ? children : null}</>;

--- a/dashboard/src/components/LinkGroup/LinkGroup.tsx
+++ b/dashboard/src/components/LinkGroup/LinkGroup.tsx
@@ -1,35 +1,58 @@
-import { ReactElement, useMemo } from 'react';
+import { ElementType, Fragment, memo, ReactElement, ReactNode } from 'react';
 
-import LinkWithIcon from '../LinkWithIcon/LinkWithIcon';
+import LinkWithIcon from '@/components/LinkWithIcon/LinkWithIcon';
+import { MessagesKey } from '@/locales/messages';
 
-interface ILinkGroup {
+export interface ILinkGroup {
   links: (ILink | undefined)[];
 }
 
 interface ILink {
   linkText: JSX.Element;
-  title?: ReactElement;
+  title: MessagesKey;
   link?: string;
   icon?: ReactElement;
+  wrapperComponent?: ElementType<{ children: ReactNode }>;
 }
 
-const LinksGroup = ({ links }: ILinkGroup): JSX.Element => {
-  const linkGroup = useMemo(() => {
-    return links?.map(
-      link =>
-        link && (
-          <LinkWithIcon
-            title={link.title}
-            icon={link.icon}
-            linkText={link.linkText}
-            key={link.link}
-            link={link.link}
-          />
-        ),
-    );
-  }, [links]);
+type LinkGroupContainerProps = {
+  children: ReactNode;
+};
+
+export const LinkGroupFilling = ({ links }: ILinkGroup): JSX.Element => {
   return (
-    <div className="grid min-w-[350px] grid-cols-3 gap-4">{linkGroup}</div>
+    <>
+      {links?.map(link => {
+        if (link) {
+          const WrapperComponent = link.wrapperComponent ?? Fragment;
+          return (
+            <WrapperComponent key={link.title}>
+              <LinkWithIcon
+                title={link.title}
+                icon={link.icon}
+                linkText={link.linkText}
+                link={link.link}
+              />
+            </WrapperComponent>
+          );
+        }
+      })}
+    </>
+  );
+};
+
+const MemoizedLinkGroupFilling = memo(LinkGroupFilling);
+
+export const LinkGroupContainer = ({
+  children,
+}: LinkGroupContainerProps): JSX.Element => {
+  return <div className="grid min-w-[350px] grid-cols-3 gap-4">{children}</div>;
+};
+const LinksGroup = ({ links }: ILinkGroup): JSX.Element => {
+  return (
+    <LinkGroupContainer>
+      <MemoizedLinkGroupFilling links={links} />
+    </LinkGroupContainer>
   );
 };
 

--- a/dashboard/src/components/LinkWithIcon/LinkWithIcon.tsx
+++ b/dashboard/src/components/LinkWithIcon/LinkWithIcon.tsx
@@ -1,7 +1,11 @@
 import { ReactElement } from 'react';
 
+import { FormattedMessage } from 'react-intl';
+
+import { MessagesKey } from '@/locales/messages';
+
 export interface ILinkWithIcon {
-  title?: string | ReactElement;
+  title?: MessagesKey;
   linkText?: string | ReactElement;
   link?: string;
   icon?: ReactElement;
@@ -13,10 +17,13 @@ const LinkWithIcon = ({
   icon,
   link,
 }: ILinkWithIcon): JSX.Element => {
+  const WrapperLink = link ? 'a' : 'div';
   return (
     <div className="flex flex-col gap-2 text-sm">
-      <span className="font-bold">{title}</span>
-      <a
+      <span className="font-bold">
+        <FormattedMessage id={title} />
+      </span>
+      <WrapperLink
         className="flex flex-row items-center gap-1"
         href={link}
         target="_blank"
@@ -24,7 +31,7 @@ const LinkWithIcon = ({
       >
         {linkText}
         {icon}
-      </a>
+      </WrapperLink>
     </div>
   );
 };

--- a/dashboard/src/components/Section/Section.tsx
+++ b/dashboard/src/components/Section/Section.tsx
@@ -2,7 +2,9 @@ import { FiLink } from 'react-icons/fi';
 
 import { ReactElement, useMemo } from 'react';
 
-import LinkWithIcon, { ILinkWithIcon } from '../LinkWithIcon/LinkWithIcon';
+import LinkWithIcon, {
+  ILinkWithIcon,
+} from '@/components/LinkWithIcon/LinkWithIcon';
 
 export interface ISection {
   title: string;

--- a/dashboard/src/lib/string.ts
+++ b/dashboard/src/lib/string.ts
@@ -1,0 +1,10 @@
+const valueOrEmpty = (value: string | undefined, emptyValue = '-'): string =>
+  value || emptyValue;
+
+export const truncateBigText = (
+  text: string | undefined,
+  maxTextLength = 50,
+): string | undefined =>
+  text && text.length > maxTextLength
+    ? text.slice(0, maxTextLength) + '...'
+    : valueOrEmpty(text);

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -143,6 +143,7 @@ export const messages = {
     'logSheet.errorsFound': 'Errors found on Kernel.log',
     'logSheet.fileName': 'File Name',
     'logSheet.fileSize': 'File Size',
+    'logSheet.indexOf': 'Index of {link}',
     'routes.deviceMonitor': 'Devices',
     'routes.labsMonitor': 'Labs',
     'routes.sendFeedback': 'Send us Feedback',

--- a/dashboard/src/pages/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetails.tsx
@@ -27,17 +27,13 @@ import {
 
 import IssueSection from '@/components/Issue/IssueSection';
 
+import { truncateBigText } from '@/lib/string';
+
 import BuildDetailsTestSection from './BuildDetailsTestSection';
 
 const emptyValue = '-';
-const maxTextLength = 50;
 
 const valueOrEmpty = (value: string | undefined): string => value || emptyValue;
-
-const truncateBigText = (text: string | undefined): string | undefined =>
-  text && text.length > maxTextLength
-    ? text.slice(0, maxTextLength) + '...'
-    : valueOrEmpty(text);
 
 const BlueFolderIcon = (): JSX.Element => (
   <MdFolderOpen className="text-blue" />
@@ -67,38 +63,38 @@ const BuildDetails = (): JSX.Element => {
           {
             infos: [
               {
-                title: intl.formatMessage({ id: 'global.tree' }),
+                title: 'global.tree',
                 linkText: valueOrEmpty(data.tree_name),
                 icon: <ImTree className="text-blue" />,
               },
               {
-                title: intl.formatMessage({ id: 'buildDetails.gitUrl' }),
+                title: 'buildDetails.gitUrl',
                 linkText: truncateBigText(data.git_repository_url),
                 link: data.git_repository_url,
               },
               {
-                title: intl.formatMessage({ id: 'buildDetails.gitBranch' }),
+                title: 'buildDetails.gitBranch',
                 linkText: valueOrEmpty(data.git_repository_branch),
                 icon: <ImTree className="text-bslue" />,
               },
               {
-                title: intl.formatMessage({ id: 'buildDetails.gitCommit' }),
+                title: 'buildDetails.gitCommit',
                 linkText: valueOrEmpty(data.git_commit_hash),
               },
               {
-                title: intl.formatMessage({ id: 'buildDetails.gitDescribe' }),
+                title: 'buildDetails.gitDescribe',
                 linkText: valueOrEmpty(data.git_commit_name),
               },
               {
-                title: intl.formatMessage({ id: 'global.date' }),
+                title: 'global.date',
                 linkText: formatDate(valueOrEmpty(data.start_time)),
               },
               {
-                title: intl.formatMessage({ id: 'global.defconfig' }),
+                title: 'global.defconfig',
                 linkText: valueOrEmpty(data.config_name),
               },
               {
-                title: intl.formatMessage({ id: 'global.status' }),
+                title: 'global.status',
                 icon: data.valid ? (
                   <MdCheck className="text-green" />
                 ) : (
@@ -106,11 +102,11 @@ const BuildDetails = (): JSX.Element => {
                 ),
               },
               {
-                title: intl.formatMessage({ id: 'global.architecture' }),
+                title: 'global.architecture',
                 linkText: valueOrEmpty(data.architecture),
               },
               {
-                title: intl.formatMessage({ id: 'buildDetails.buildTime' }),
+                title: 'buildDetails.buildTime',
                 linkText: data.duration ? `${data.duration} sec` : emptyValue,
               },
             ],
@@ -118,11 +114,11 @@ const BuildDetails = (): JSX.Element => {
           {
             infos: [
               {
-                title: intl.formatMessage({ id: 'buildDetails.compiler' }),
+                title: 'buildDetails.compiler',
                 linkText: valueOrEmpty(data.compiler),
               },
               {
-                title: intl.formatMessage({ id: 'global.command' }),
+                title: 'global.command',
                 linkText: valueOrEmpty(valueOrEmpty(data.command)),
               },
             ],
@@ -130,7 +126,7 @@ const BuildDetails = (): JSX.Element => {
           {
             infos: [
               {
-                title: intl.formatMessage({ id: 'buildDetails.buildLogs' }),
+                title: 'buildDetails.buildLogs',
                 linkText: truncateBigText(data.log_url),
                 link: data.log_url,
                 icon: data.log_url ? (
@@ -138,28 +134,28 @@ const BuildDetails = (): JSX.Element => {
                 ) : undefined,
               },
               {
-                title: intl.formatMessage({ id: 'global.dtb' }),
+                title: 'global.dtb',
                 linkText: valueOrEmpty(data.misc?.dtb),
                 icon: data.misc?.dtb ? <BlueFolderIcon /> : undefined,
               },
               {
-                title: intl.formatMessage({ id: 'buildDetails.kernelConfig' }),
+                title: 'buildDetails.kernelConfig',
                 linkText: truncateBigText(data.config_url),
                 link: data.config_url,
                 icon: data.config_url ? <BlueFolderIcon /> : undefined,
               },
               {
-                title: intl.formatMessage({ id: 'global.modules' }),
+                title: 'global.modules',
                 linkText: valueOrEmpty(data.misc?.modules),
                 icon: data.misc?.modules ? <BlueFolderIcon /> : undefined,
               },
               {
-                title: intl.formatMessage({ id: 'buildDetails.kernelImage' }),
+                title: 'buildDetails.kernelImage',
                 linkText: valueOrEmpty(data.misc?.kernel_type),
                 icon: data.misc?.kernel_type ? <BlueFolderIcon /> : undefined,
               },
               {
-                title: intl.formatMessage({ id: 'buildDetails.systemMap' }),
+                title: 'buildDetails.systemMap',
                 linkText: valueOrEmpty(data.misc?.system_map),
                 icon: data.misc?.system_map ? <BlueFolderIcon /> : undefined,
               },

--- a/dashboard/src/pages/TestDetails/TestDetails.tsx
+++ b/dashboard/src/pages/TestDetails/TestDetails.tsx
@@ -27,6 +27,8 @@ import {
   BreadcrumbSeparator,
 } from '@/components/Breadcrumb/Breadcrumb';
 import IssueSection from '@/components/Issue/IssueSection';
+import { truncateBigText } from '@/lib/string';
+import { ILinkWithIcon } from '@/components/LinkWithIcon/LinkWithIcon';
 
 type TTestDetailsDefaultProps = {
   test: TTestDetails;
@@ -34,13 +36,6 @@ type TTestDetailsDefaultProps = {
 
 const emptyValue = '-';
 const valueOrEmpty = (value: string | undefined): string => value || emptyValue;
-
-const maxTextLength = 50;
-
-const truncateBigText = (text: string | undefined): string | undefined =>
-  text && text.length > maxTextLength
-    ? text.slice(0, maxTextLength) + '...'
-    : valueOrEmpty(text);
 
 const LogExcerpt = ({ test }: TTestDetailsDefaultProps): JSX.Element => {
   return (
@@ -65,56 +60,56 @@ const TestDetailsSection = ({ test }: { test: TTestDetails }): JSX.Element => {
     `${window.location.search}`;
 
   const infos: ISubsection['infos'] = useMemo(() => {
-    const baseInfo = [
+    const baseInfo: ILinkWithIcon[] = [
       {
-        title: intl.formatMessage({ id: 'testDetails.status' }),
+        title: 'testDetails.status',
         linkText: truncateBigText(test.status),
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.path' }),
+        title: 'testDetails.path',
         linkText: valueOrEmpty(test.path),
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.arch' }),
+        title: 'testDetails.arch',
         linkText: valueOrEmpty(test.architecture),
         icon: <PiComputerTowerThin className="text-blue" />,
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.compiler' }),
+        title: 'testDetails.compiler',
         linkText: valueOrEmpty(test.compiler),
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.logUrl' }),
+        title: 'testDetails.logUrl',
         linkText: truncateBigText(valueOrEmpty(test.log_url)),
         link: test.log_url,
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.gitCommitHash' }),
+        title: 'testDetails.gitCommitHash',
         linkText: valueOrEmpty(test.git_commit_hash),
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.gitRepositoryUrl' }),
+        title: 'testDetails.gitRepositoryUrl',
         linkText: truncateBigText(valueOrEmpty(test.git_repository_url)),
         link: test.git_repository_url,
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.gitRepositoryBranch' }),
+        title: 'testDetails.gitRepositoryBranch',
         linkText: valueOrEmpty(test.git_repository_branch),
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.buildInfo' }),
+        title: 'testDetails.buildInfo',
         linkText: truncateBigText(test.build_id),
         link: buildDetailsLink,
       },
       {
-        title: intl.formatMessage({ id: 'testDetails.platform' }),
+        title: 'testDetails.platform',
         linkText: platform,
         icon: <GiFlatPlatform className="text-blue" />,
       },
     ];
+
     return baseInfo;
   }, [
-    intl,
     test.architecture,
     test.build_id,
     test.compiler,

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -11,7 +11,6 @@ import { TableInfo } from '@/components/Table/TableInfo';
 import { usePagination } from '@/hooks/usePagination';
 import Accordion from '@/components/Accordion/Accordion';
 import { DumbListingContent } from '@/components/ListingContent/ListingContent';
-import { DevOnly } from '@/components/FeatureFlag/DevOnly';
 
 import {
   BuildsTableFilter,
@@ -32,9 +31,6 @@ import ListingItem from '@/components/ListingItem/ListingItem';
 import { ItemsPerPageValues } from '@/utils/constants/general';
 
 import { MemoizedIssuesList } from '@/pages/TreeDetails/Tabs/TestCards';
-import { LogSheet } from '@/pages/TreeDetails/Tabs/LogSheet';
-
-import { Sheet } from '@/components/Sheet';
 
 import { DesktopGrid, InnerMobileGrid, MobileGrid } from '../TabGrid';
 
@@ -245,100 +241,95 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
   );
 
   return (
-    <Sheet>
-      <div className="flex flex-col gap-8 pt-4">
-        <DesktopGrid>
-          <div>
-            <MemoizedStatusCard
-              toggleFilterBySection={toggleFilterBySection}
-              treeDetailsData={treeDetailsData}
-            />
-            <MemoizedErrorsSummaryBuild
-              summaryBody={treeDetailsData?.archs ?? []}
-              toggleFilterBySection={toggleFilterBySection}
-            />
-            <MemoizedIssuesList
-              title={<FormattedMessage id="global.issues" />}
-              issues={treeDetailsData?.issues || []}
-            />
-          </div>
-          <div>
-            <CommitNavigationGraph />
-            <MemoizedConfigsCard
-              treeDetailsData={treeDetailsData}
-              toggleFilterBySection={toggleFilterBySection}
-            />
-          </div>
-        </DesktopGrid>
-        <MobileGrid>
-          <CommitNavigationGraph />
+    <div className="flex flex-col gap-8 pt-4">
+      <DesktopGrid>
+        <div>
           <MemoizedStatusCard
             toggleFilterBySection={toggleFilterBySection}
             treeDetailsData={treeDetailsData}
           />
-          <InnerMobileGrid>
-            <MemoizedErrorsSummaryBuild
-              summaryBody={treeDetailsData?.archs ?? []}
-              toggleFilterBySection={toggleFilterBySection}
-            />
-            <MemoizedConfigsCard
-              treeDetailsData={treeDetailsData}
-              toggleFilterBySection={toggleFilterBySection}
-            />
-          </InnerMobileGrid>
+          <MemoizedErrorsSummaryBuild
+            summaryBody={treeDetailsData?.archs ?? []}
+            toggleFilterBySection={toggleFilterBySection}
+          />
           <MemoizedIssuesList
             title={<FormattedMessage id="global.issues" />}
             issues={treeDetailsData?.issues || []}
           />
-        </MobileGrid>
+        </div>
+        <div>
+          <CommitNavigationGraph />
+          <MemoizedConfigsCard
+            treeDetailsData={treeDetailsData}
+            toggleFilterBySection={toggleFilterBySection}
+          />
+        </div>
+      </DesktopGrid>
+      <MobileGrid>
+        <CommitNavigationGraph />
+        <MemoizedStatusCard
+          toggleFilterBySection={toggleFilterBySection}
+          treeDetailsData={treeDetailsData}
+        />
+        <InnerMobileGrid>
+          <MemoizedErrorsSummaryBuild
+            summaryBody={treeDetailsData?.archs ?? []}
+            toggleFilterBySection={toggleFilterBySection}
+          />
+          <MemoizedConfigsCard
+            treeDetailsData={treeDetailsData}
+            toggleFilterBySection={toggleFilterBySection}
+          />
+        </InnerMobileGrid>
+        <MemoizedIssuesList
+          title={<FormattedMessage id="global.issues" />}
+          issues={treeDetailsData?.issues || []}
+        />
+      </MobileGrid>
 
-        {filteredContent && (
-          <div className="flex flex-col gap-4">
-            <div className="text-lg">
-              <FormattedMessage id="treeDetails.builds" />
-            </div>
-            <div className="flex flex-row justify-between">
-              <TableStatusFilter
-                onClickBuild={(filter: BuildsTableFilter) =>
-                  onClickFilter(filter)
-                }
-                filters={[
-                  {
-                    label: intl.formatMessage({ id: 'global.all' }),
-                    value: possibleBuildsTableFilter[2],
-                    isSelected: selectedFilter === possibleBuildsTableFilter[2],
-                  },
-                  {
-                    label: intl.formatMessage({ id: 'global.successful' }),
-                    value: possibleBuildsTableFilter[1],
-                    isSelected: selectedFilter === possibleBuildsTableFilter[1],
-                  },
-                  {
-                    label: intl.formatMessage({ id: 'global.failed' }),
-                    value: possibleBuildsTableFilter[0],
-                    isSelected: selectedFilter === possibleBuildsTableFilter[0],
-                  },
-                  {
-                    label: intl.formatMessage({ id: 'global.inconclusive' }),
-                    value: possibleBuildsTableFilter[3],
-                    isSelected: selectedFilter === possibleBuildsTableFilter[3],
-                  },
-                ]}
-              />
-              {tableInfoElement}
-            </div>
-            <Accordion
-              type="build"
-              items={filteredContent.slice(startIndex, endIndex)}
-            />
-            <div className="flex justify-end">{tableInfoElement}</div>
+      {filteredContent && (
+        <div className="flex flex-col gap-4">
+          <div className="text-lg">
+            <FormattedMessage id="treeDetails.builds" />
           </div>
-        )}
-        <DevOnly>
-          <LogSheet />
-        </DevOnly>
-      </div>
-    </Sheet>
+          <div className="flex flex-row justify-between">
+            <TableStatusFilter
+              onClickBuild={(filter: BuildsTableFilter) =>
+                onClickFilter(filter)
+              }
+              filters={[
+                {
+                  label: intl.formatMessage({ id: 'global.all' }),
+                  value: possibleBuildsTableFilter[2],
+                  isSelected: selectedFilter === possibleBuildsTableFilter[2],
+                },
+                {
+                  label: intl.formatMessage({ id: 'global.successful' }),
+                  value: possibleBuildsTableFilter[1],
+                  isSelected: selectedFilter === possibleBuildsTableFilter[1],
+                },
+                {
+                  label: intl.formatMessage({ id: 'global.failed' }),
+                  value: possibleBuildsTableFilter[0],
+                  isSelected: selectedFilter === possibleBuildsTableFilter[0],
+                },
+                {
+                  label: intl.formatMessage({ id: 'global.inconclusive' }),
+                  value: possibleBuildsTableFilter[3],
+                  isSelected: selectedFilter === possibleBuildsTableFilter[3],
+                },
+              ]}
+            />
+            {tableInfoElement}
+          </div>
+          <Accordion
+            type="build"
+            items={filteredContent.slice(startIndex, endIndex)}
+          />
+          <div className="flex justify-end">{tableInfoElement}</div>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/dashboard/src/pages/TreeDetails/Tabs/LogSheet.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/LogSheet.tsx
@@ -1,5 +1,7 @@
 import { FormattedMessage } from 'react-intl';
 
+import { GrDocumentDownload } from 'react-icons/gr';
+
 import BaseCard from '@/components/Cards/BaseCard';
 import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
 import CodeBlock from '@/components/Filter/CodeBlock';
@@ -12,60 +14,82 @@ import {
 import { DumbTableHeader, TableHead } from '@/components/Table/BaseTable';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
+import { DevOnly } from '@/components/FeatureFlag';
+import { truncateBigText } from '@/lib/string';
 
-const PlaceholderLog = `
-_______________
-< This is a log >
- ---------------
-       \\ ^__^
-          (oo)_______
-          (__)       )/
-             ||----w |
-             ||     ||`;
+const FallbackLog = `
+ ________________________________
+/ Sorry, there is no Log Excerpt \\
+\\ available for this build.      /
+ --------------------------------
+        \\   ^__^
+         \\  (oo)\\_______
+            (__)\\       )\\/\\
+                ||----w |
+                ||     ||`;
 
-export const LogSheet = (): JSX.Element => {
+type LogSheetProps = {
+  logExcerpt?: string;
+  logUrl?: string;
+};
+
+export const LogSheet = ({
+  logExcerpt,
+  logUrl,
+}: LogSheetProps): JSX.Element => {
   return (
-    <SheetContent className="w-[25rem] sm:w-full sm:max-w-[44rem]">
+    <SheetContent className="flex w-[25rem] flex-col sm:w-full sm:max-w-[44rem]">
       <SheetHeader className="mb-3">
         <SheetTitle className="text-[1.75rem]">Build Logs</SheetTitle>
       </SheetHeader>
       <BaseCard className="gap-0" title={<>Logs</>}>
         <div className="px-2 py-3 font-mono text-sm text-[#454545]">
-          {/* TODO Replace with actual data */}
-          Index of
-          /stable-rc/linux-5.10.y/v5.10.215-32-gd3c603576d90b/mips/32r2el_defconfig/gcc-10/logs/
+          <FormattedMessage
+            id="logSheet.indexOf"
+            values={{
+              link: (
+                <a href={logUrl} className="flex gap-2">
+                  <span>{truncateBigText(logUrl)}</span>
+                  <GrDocumentDownload className="text-blue" />
+                </a>
+              ),
+            }}
+          />
         </div>
-        <Table containerClassName="rounded-none border-none">
-          <DumbTableHeader>
-            <TableHead>
-              <FormattedMessage id="logSheet.fileName" />
-            </TableHead>
-            <TableHead>
-              <FormattedMessage id="logSheet.fileSize" />
-            </TableHead>
-            <TableHead>
-              <FormattedMessage id="global.date" />
-            </TableHead>
-          </DumbTableHeader>
-          <TableBody>
-            {/* TODO: Replace with actual data */}
-            <TableRow>
-              <TableCell>Placeholder 1</TableCell>
-              <TableCell>Placeholder 2</TableCell>
-              <TableCell>Placeholder 3</TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell>test.log</TableCell>
-              <TableCell>23mb</TableCell>
-              <TableCell>2024-03-1</TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell>task.log</TableCell>
-              <TableCell>27mb</TableCell>
-              <TableCell>2024-05-1</TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
+        {/* TODO Replace with actual data */}
+        <DevOnly>
+          <Table containerClassName="rounded-none border-none">
+            <DumbTableHeader>
+              <TableHead>
+                <FormattedMessage id="logSheet.fileName" />
+              </TableHead>
+              <TableHead>
+                <FormattedMessage id="logSheet.fileSize" />
+              </TableHead>
+              <TableHead>
+                <FormattedMessage id="global.date" />
+              </TableHead>
+            </DumbTableHeader>
+            <TableBody>
+              {/* TODO: Replace with actual data */}
+              <TableRow>
+                <TableCell>Placeholder 1</TableCell>
+                <TableCell>Placeholder 2</TableCell>
+                <TableCell>Placeholder 3</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>test.log</TableCell>
+                <TableCell>23mb</TableCell>
+                <TableCell>2024-03-1</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>task.log</TableCell>
+                <TableCell>27mb</TableCell>
+                <TableCell>2024-05-1</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </DevOnly>
       </BaseCard>
       <div className="my-8 flex flex-row gap-2">
         <ColoredCircle quantity={3} backgroundClassName="bg-lightRed" />
@@ -77,9 +101,8 @@ export const LogSheet = (): JSX.Element => {
         </h2>
       </div>
       {/*TODO: Replace with actual log data */}
-      <CodeBlock code={PlaceholderLog} />
-
-      <div className="mt-5 flex justify-end">
+      <CodeBlock code={logExcerpt ?? FallbackLog} />
+      <div className="mt-auto flex justify-end">
         <SheetTrigger>
           <Button className="rounded-3xl bg-[#11B3E6] px-14 font-bold text-white">
             <FormattedMessage id="global.close" defaultMessage="Close" />


### PR DESCRIPTION
This PR adds the log excerpt data from the backend to the log sheet modal

It also refactors part of the code to make it easier to use the grouped links.

Closes https://github.com/kernelci/dashboard/issues/349

## How to test

Go to:

http://localhost:5173/tree/80cb3fb6113554f316c79901354b2a3c81479bf5?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.builds&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.12-rc1-44-g80cb3fb61135%22%2C%22headCommitHash%22%3A%2280cb3fb6113554f316c79901354b2a3c81479bf5%22%7D


Keep opening the builds accordions and clicking `Logs` until you get one with log excerpt

One of the `defconfig` will have an usable `Log Excerpt`


