### PR TITLE
feat(#350): Highlight errors and show error count in log excerpt

### DIFF
--- a/dashboard/src/components/Filter/CodeBlock.tsx
+++ b/dashboard/src/components/Filter/CodeBlock.tsx
@@ -1,20 +1,147 @@
+import { LiaInfoCircleSolid } from 'react-icons/lia';
+
+import { FormattedMessage } from 'react-intl';
+
+import { useMemo } from 'react';
+
 import { cn } from '@/lib/utils';
+
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/Tooltip';
+
+import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
+import { formattedBreakLineValue } from '@/locales/messages';
 
 type TCodeBlockProps = {
   code: string;
   className?: string;
+  highlightsClassname?: string;
 };
 
-const CodeBlock = ({ code, className }: TCodeBlockProps): JSX.Element => {
+interface IHighlightedCode {
+  highlightedCode: string;
+  highlightCount: number;
+  failCount: number;
+  errorCount: number;
+}
+
+const CodeBlock = ({
+  code,
+  className,
+  highlightsClassname,
+}: TCodeBlockProps): JSX.Element => {
+  const highlightedCode: IHighlightedCode = useMemo(() => {
+    let highlights = 0;
+    let fails = 0;
+    let errors = 0;
+
+    // matches any < or > and replaces with equivalent &lt or &gt
+    let newCode = code.replace(/[<>]/gm, match => {
+      match = match.replace(/</, '&lt');
+      match = match.replace(/>/, '&gt');
+      return match;
+    });
+
+    newCode = newCode.replace(
+      // matches any line with the occurrence of error or fail
+      /^.*(error|fail).*$/gim,
+      match => {
+        highlights++;
+        if (
+          // matches failed to/with, more than 0 fails/faileds and no flags
+          match.search(
+            /.*((\bfailed(\s*to|\s*with|([\b\s:]\s*\(*-*[1-9])))|fail(\b|:|\s*[1-9])(?![|/]))/i,
+          ) !== -1
+        ) {
+          fails++;
+          return '<span class="text-red">' + match + '</span>';
+        }
+        // matches error codes greater than 0 or more than 0 errors
+        if (
+          match.search(
+            /(error(:|,|[\b\s:]\s*\(*-*[1-9a-z]))|([1-9]\s*error)/i,
+          ) !== -1
+        ) {
+          errors++;
+          return '<span class="text-orange-500">' + match + '</span>';
+        }
+        return '<span class="text-sky-600">' + match + '</span>';
+      },
+    );
+    return {
+      highlightedCode: newCode,
+      highlightCount: highlights,
+      failCount: fails,
+      errorCount: errors,
+    };
+  }, [code]);
+
   return (
-    <pre
-      className={cn(
-        'max-h-[275px] w-full max-w-[calc(100vw_-_398px)] overflow-x-auto bg-[#DDDDDD] p-4 font-mono text-[#767676]',
-        className,
+    <div>
+      <pre
+        className={cn(
+          'max-h-[275px] w-full max-w-[calc(100vw_-_398px)] overflow-x-auto bg-[#DDDDDD] p-4 font-mono text-[#767676]',
+          className,
+        )}
+      >
+        <div
+          dangerouslySetInnerHTML={{ __html: highlightedCode.highlightedCode }}
+        ></div>
+      </pre>
+      {highlightedCode.highlightCount > 0 && (
+        <ul className={cn('flex gap-2 py-4 pl-3', highlightsClassname)}>
+          <li>
+            <span className="flex items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger>
+                  <LiaInfoCircleSolid />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <FormattedMessage
+                    id="codeBlock.highlightsTooltip"
+                    defaultMessage={
+                      'Highlighted items accounts for any lines citing fails or errors.{br}' +
+                      'That includes real failures, real errors and other information messages containing those words.'
+                    }
+                    values={formattedBreakLineValue}
+                  />
+                </TooltipContent>
+              </Tooltip>
+              <span className="font-bold">
+                <FormattedMessage
+                  id="codeBlock.highlights"
+                  defaultMessage={'Highlights:'}
+                />
+              </span>
+            </span>
+          </li>
+          <li className="flex gap-1">
+            <ColoredCircle
+              quantity={highlightedCode.failCount}
+              backgroundClassName="bg-lightRed"
+            />
+            <FormattedMessage id="global.fails" defaultMessage={'Fails'} />
+          </li>
+          <li className="flex gap-1">
+            <ColoredCircle
+              quantity={highlightedCode.errorCount}
+              backgroundClassName="bg-orange-200"
+            />
+            <FormattedMessage id="global.errors" defaultMessage={'Errors'} />
+          </li>
+          <li className="flex gap-1">
+            <ColoredCircle
+              quantity={
+                highlightedCode.highlightCount -
+                highlightedCode.failCount -
+                highlightedCode.errorCount
+              }
+              backgroundClassName="bg-mediumGray"
+            />
+            <FormattedMessage id="global.others" defaultMessage={'Others'} />
+          </li>
+        </ul>
       )}
-    >
-      {code}
-    </pre>
+    </div>
   );
 };
 

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -63,6 +63,10 @@ export const messages = {
       'Success - builds completed successfully{br}' +
       'Failed - builds failed{br}' +
       "Inconclusive - builds with unknown status, including ongoing builds that didn't finish yet.",
+    'codeBlock.highlights': 'Highlights:',
+    'codeBlock.highlightsTooltip':
+      'Highlighted items accounts for any lines citing fails or errors.{br}' +
+      'That includes real failures, real errors and other information messages containing those words',
     'filter.architectureSubtitle': 'Please select one or more Architectures:',
     'filter.bootDuration': 'Boot duration',
     'filter.bootStatus': 'Boot Status',
@@ -102,6 +106,7 @@ export const messages = {
     'global.errors': 'Errors',
     'global.estimate': 'Estimate',
     'global.failed': 'Failed',
+    'global.fails': 'Fails',
     'global.filters': 'Filters',
     'global.github': 'GitHub',
     'global.inconclusive': 'Inconclusive',
@@ -118,6 +123,7 @@ export const messages = {
     'global.none': 'None',
     'global.origin': 'Origin',
     'global.origins': 'Origins',
+    'global.others': 'Others',
     'global.pass': 'Pass',
     'global.placeholderSearch': 'Search by tree, branch or tag',
     'global.projectUnderDevelopment':


### PR DESCRIPTION
At any codeblock, used to show log excerpts, any _line_ containing fails or errors will be highlighted. Fail and error lines are counted separately, as well as other lines that contain fail or error information messages.

Closes #350 

## How to test:

Enter at a tree page, go to Tests tab, open a test details page. If it contains a log excerpt, any lines containing fails or errors will be highlighted with a different text color, the highlight count will only be shown if the log excerpt contains anything to be highlighted.

localhost example: http://localhost:5173/tree/58e2d28ed28e5bc8836f8c14df1f94c27c1f9e2f/test/maestro:6706466d7ef7358befbc7014?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-next%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Famlogic%2Flinux.git%22%2C%22treeName%22%3A%22amlogic%22%2C%22commitName%22%3A%22v6.12-rc1-18-g58e2d28ed28e5%22%2C%22headCommitHash%22%3A%2258e2d28ed28e5bc8836f8c14df1f94c27c1f9e2f%22%7D