### PR TITLE
fix: tests displaying incorrect items

### DIFF
--- a/backend/kernelCI_app/views/treeDetailsSlowView.py
+++ b/backend/kernelCI_app/views/treeDetailsSlowView.py
@@ -303,6 +303,8 @@ class TreeDetailsSlow(View):
         git_branch_param = request.GET.get("git_branch")
         self.__processFilters(request)
 
+        # Right now this query is only using for showing test data so it is doing inner joins
+        # in case it is needed for builds data they should become left join and the logic should be updated
         query = """
         SELECT
                 tests.build_id AS tests_build_id,
@@ -353,12 +355,12 @@ class TreeDetailsSlow(View):
                             checkouts.git_repository_branch = %(git_branch_param)s AND
                             checkouts.origin = %(origin_param)s
                     ) AS tree_head
-                LEFT JOIN builds
+                INNER JOIN builds
                     ON tree_head.checkout_id = builds.checkout_id
                 WHERE
                     builds.origin = %(origin_param)s
             ) AS builds_filter
-        LEFT JOIN tests
+        INNER JOIN tests
             ON builds_filter.builds_id = tests.build_id
         LEFT JOIN incidents
             ON tests.id = incidents.test_id

--- a/dashboard/src/components/Table/TestsTable.tsx
+++ b/dashboard/src/components/Table/TestsTable.tsx
@@ -13,10 +13,11 @@ import {
   possibleTestsTableFilter,
 } from '@/types/tree/TreeDetails';
 
-import { getStatusGroup } from '@/utils/status';
 import { TPathTests } from '@/types/general';
 
 import { ItemsPerPageValues } from '@/utils/constants/general';
+
+import { StatusTable } from '@/utils/constants/database';
 
 import Accordion from '../Accordion/Accordion';
 
@@ -163,7 +164,7 @@ const TestsTable = ({ testHistory }: ITestsTable): JSX.Element => {
           .map(test => ({
             ...test,
             individual_tests: test.individual_tests.filter(
-              t => getStatusGroup(t.status) === possibleTestsTableFilter[1],
+              t => t.status.toUpperCase() === StatusTable.PASS,
             ),
           }));
       case 'failed':
@@ -171,9 +172,11 @@ const TestsTable = ({ testHistory }: ITestsTable): JSX.Element => {
           ?.filter(tests => tests.fail_tests > 0)
           .map(test => ({
             ...test,
-            individual_tests: test.individual_tests.filter(
-              t => t.status.toLowerCase() === possibleTestsTableFilter[2],
-            ),
+            individual_tests: test.individual_tests.filter(t => {
+              const result = t.status.toUpperCase() === StatusTable.FAIL;
+
+              return result;
+            }),
           }));
       case 'inconclusive':
         return data
@@ -187,9 +190,13 @@ const TestsTable = ({ testHistory }: ITestsTable): JSX.Element => {
           )
           .map(test => ({
             ...test,
-            individual_tests: test.individual_tests.filter(
-              t => t.status.toLowerCase() === possibleTestsTableFilter[3],
-            ),
+            individual_tests: test.individual_tests.filter(t => {
+              const uppercaseTestStatus = t.status.toUpperCase();
+              const result =
+                uppercaseTestStatus !== StatusTable.PASS &&
+                uppercaseTestStatus !== StatusTable.FAIL;
+              return result;
+            }),
           }));
     }
   }, [tableFilter.testsTable, data]);

--- a/dashboard/src/types/database.ts
+++ b/dashboard/src/types/database.ts
@@ -1,5 +1,5 @@
-import { status } from '../utils/constants/database';
+import { status } from '@/utils/constants/database';
 
 export type Status = (typeof status)[number];
 
-export type ErrorStatus = Exclude<Status, 'PASS' | 'SKIP' | 'DONE'>;
+export type InconclusiveStatus = Exclude<Status, 'PASS' | 'FAIL'>;

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -6,7 +6,7 @@ import { MessagesKey } from '@/locales/messages';
 
 import { TIssue } from '@/types/general';
 
-import type { ErrorStatus, Status } from '../database';
+import type { Status } from '@/types/database';
 
 export type BuildsTabBuild = {
   id: string;
@@ -87,10 +87,6 @@ export type TestHistory = {
   duration?: number;
 };
 
-type ErrorCounts = {
-  [key in ErrorStatus]: number | undefined;
-};
-
 type CompilersPerArchitecture = {
   [key: string]: string[];
 };
@@ -113,7 +109,6 @@ type PropertyStatusCounts = Record<string, StatusCounts>;
 
 export type TTreeTestsData = {
   statusCounts: StatusCounts;
-  errorCounts: ErrorCounts;
   configStatusCounts: PropertyStatusCounts;
   testHistory: TestHistory[];
   architectureStatusCounts: PropertyStatusCounts;

--- a/dashboard/src/utils/constants/database.ts
+++ b/dashboard/src/utils/constants/database.ts
@@ -1,4 +1,4 @@
-import type { ErrorStatus } from '@/types/database';
+import type { InconclusiveStatus } from '@/types/database';
 
 export const status = [
   'MISS',
@@ -9,6 +9,20 @@ export const status = [
   'DONE',
 ] as const;
 
-const errorStatus = ['MISS', 'ERROR', 'FAIL'] as const satisfies ErrorStatus[];
+export const StatusTable = {
+  MISS: 'MISS',
+  ERROR: 'ERROR',
+  FAIL: 'FAIL',
+  PASS: 'PASS',
+  SKIP: 'SKIP',
+  DONE: 'DONE',
+} as const;
 
-export const errorStatusSet = new Set(errorStatus);
+const inconclusiveStatus = [
+  'ERROR',
+  'SKIP',
+  'DONE',
+  'MISS',
+] as const satisfies InconclusiveStatus[];
+
+export const errorStatusSet = new Set(inconclusiveStatus);


### PR DESCRIPTION
Make tests display the correct items in the Details View

The test status table were displaying the wrong status
and some unknown weird behavior was reported due to the failing between
joins in the table

- Changed SQL query joins from LEFT JOIN to INNER JOIN for builds and tests
- Updated status handling in TestsTable component to use StatusTable constants
- Removed unused ErrorStatus type and related code
- Adjusted imports to use absolute paths

Closes #366

## How To Test

Database: `kcidb`

Go to the broken link in the staging and try to open some tests with the inconclusive and fail filter
https://staging.dashboard.kernelci.org:9000/tree/7aa21fec187b7bc2a55be4daad4585098e2f47df?tableFilter=%7B%22bootsTable%22%3A%22all%22%2C%22buildsTable%22%3A%22all%22%2C%22testsTable%22%3A%22failed%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22linux-6.11.y%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fstable%2Flinux-stable-rc.git%22%2C%22treeName%22%3A%22stable-rc%22%2C%22commitName%22%3A%22v6.11.2%22%2C%22headCommitHash%22%3A%227aa21fec187b7bc2a55be4daad4585098e2f47df%22%7D


Now go the localhost link and do the same

http://localhost:5173/tree/7aa21fec187b7bc2a55be4daad4585098e2f47df?tableFilter=%7B%22bootsTable%22%3A%22all%22%2C%22buildsTable%22%3A%22all%22%2C%22testsTable%22%3A%22failed%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22linux-6.11.y%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fstable%2Flinux-stable-rc.git%22%2C%22treeName%22%3A%22stable-rc%22%2C%22commitName%22%3A%22v6.11.2%22%2C%22headCommitHash%22%3A%227aa21fec187b7bc2a55be4daad4585098e2f47df%22%7D
