### PR TITLE
docs: add a note in the onboarding about running the backend

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -131,6 +131,9 @@ DATABASES = {
     )
 }
 
+if DEBUG:
+    print("DEBUG: DEFAULT DATABASE:", DATABASES)
+
 
 CACHES = {
     "default": {

--- a/docs/Onboarding.md
+++ b/docs/Onboarding.md
@@ -60,6 +60,9 @@ export DB_DEFAULT="{
 poetry run python3 manage.py runserver
 ```
 
+> Note:
+> It is possible to have authentication issues when escaping special characters. In some cases, it is necessary to add more than one backslash, while in others, no addition is needed. To assist with this, when `DEBUG` is set to `True`, the default database info will be printed in the terminal, allowing you to determine if the characters got escaped as intended.
+
 Definition of Done: You have the KernelCI Dashboard backend running locally.
 
 


### PR DESCRIPTION
Add a note in the onboarding about running the backend locally
- closes #373 