### PR TITLE
fix: correct test details breadcrumb name

### DIFF
--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -155,6 +155,7 @@ export const messages = {
     'table.of': 'of',
     'table.showing': 'Showing:',
     'table.tree': 'Tree',
+    'test.details': 'Test Details',
     'testDetails.arch': 'Arch',
     'testDetails.buildInfo': 'Build Info',
     'testDetails.compiler': 'Compiler',

--- a/dashboard/src/pages/TestDetails/TestDetails.tsx
+++ b/dashboard/src/pages/TestDetails/TestDetails.tsx
@@ -169,7 +169,7 @@ const TestDetails = (): JSX.Element => {
           <BreadcrumbSeparator />
           <BreadcrumbItem>
             <BreadcrumbPage>
-              <FormattedMessage id="tree.details" />
+              <FormattedMessage id="test.details" />
             </BreadcrumbPage>
           </BreadcrumbItem>
         </BreadcrumbList>


### PR DESCRIPTION
Changing breadcrumb from

> Tree > Tree Details > Tree Details

to

>Tree > Tree Details > Test Details

- closes #364 