### PR TITLE
fix: removing filter with more than one colon

### DIFF
--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilterList.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilterList.tsx
@@ -32,7 +32,8 @@ const TreeDetailsFilterList = ({
 
   const onClickItem = useCallback(
     (flatValue: string, _: number) => {
-      const [field, value] = flatValue.split(':');
+      const [field, ...rest] = flatValue.split(':');
+      const value = rest.join(':');
 
       const newFilter = JSON.parse(JSON.stringify(filter ?? {}));
       const fieldSection = newFilter[field as TFilterKeys];


### PR DESCRIPTION
Correct the filtering by clearing the option with more than two colons by pressing the “X” next to the name.

- Closes #376 

## How to test

1. open the [dashboard](http://localhost:5173/tree/1d227fcc72223cbdd34d0ce13541cbaab5e0d72f?tableFilter={%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22}&origin=maestro&currentTreeDetailsTab=treeDetails.builds&diffFilter={%22configs%22%3A{%22cros%3A%2F%2Fchromeos-6.6%2Fx86_64%2Fchromeos-intel-pineview.flavour.config%22%3Atrue%2C%22cros%3A%2F%2Fchromeos-6.6%2Fx86_64%2Fchromeos-amd-stoneyridge.flavour.config%22%3Atrue%2C%22x86_64_defconfig%22%3Atrue}}&treeInfo={%22gitBranch%22%3A%22master%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Ftorvalds%2Flinux.git%22%2C%22treeName%22%3A%22mainline%22%2C%22commitName%22%3A%22v6.12-rc2-205-g1d227fcc7222%22%2C%22headCommitHash%22%3A%221d227fcc72223cbdd34d0ce13541cbaab5e0d72f%22})
2. Try to clear the "configs:cros://*" options