### PR TITLE
Feat(#371): add virtualization to tests table

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -41,6 +41,7 @@
     "@tanstack/react-query-persist-client": "^5.56.2",
     "@tanstack/react-router": "^1.46.8",
     "@tanstack/react-table": "^8.20.5",
+    "@tanstack/react-virtual": "^3.10.8",
     "@vitejs/plugin-react": "^4.3.1",
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.20.5
         version: 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.10.8
+        version: 3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.3.1(vite@5.4.5(@types/node@20.16.5)(terser@5.32.0))
@@ -1888,6 +1891,12 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.10.8':
+    resolution: {integrity: sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+
   '@tanstack/router-devtools@1.46.9':
     resolution: {integrity: sha512-KuUCKB3p2M1nyfQ+8Rz0m8ZerECNVjE/CdxsaR4M/HvNS+yL78K1otXm0YeSlnMEqN7SGdWVqw+8CcBi9qEYnw==}
     engines: {node: '>=12'}
@@ -1921,6 +1930,9 @@ packages:
   '@tanstack/table-core@8.20.5':
     resolution: {integrity: sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.10.8':
+    resolution: {integrity: sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -6516,6 +6528,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@tanstack/react-virtual@3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.10.8
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@tanstack/router-devtools@1.46.9(@tanstack/react-router@1.46.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/react-router': 1.46.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6559,6 +6577,8 @@ snapshots:
   '@tanstack/store@0.5.5': {}
 
   '@tanstack/table-core@8.20.5': {}
+
+  '@tanstack/virtual-core@3.10.8': {}
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/dashboard/src/components/Table/BaseTable.tsx
+++ b/dashboard/src/components/Table/BaseTable.tsx
@@ -67,9 +67,12 @@ export const DumbTableHeader = ({
 
 export const TableHead = ({
   children,
+  className,
 }: ComponentProps<typeof TableHeadComponent>): JSX.Element => {
   return (
-    <TableHeadComponent className="border-b font-bold text-black">
+    <TableHeadComponent
+      className={classNames(className, 'border-b font-bold text-black')}
+    >
       {children}
     </TableHeadComponent>
   );

--- a/dashboard/src/components/Table/TableHeader.tsx
+++ b/dashboard/src/components/Table/TableHeader.tsx
@@ -68,7 +68,7 @@ export function TableHeader({
     <span className="flex">
       <Button
         variant="ghost"
-        className="justify-start px-0"
+        className="justify-start px-2"
         onClick={headerSort}
       >
         <FormattedMessage

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTable.tsx
@@ -327,11 +327,7 @@ export function TestsTable({
           {row.getIsExpanded() && (
             <TableRow>
               <TableCell colSpan={6} className="p-0">
-                <div className="max-h-[400px] w-full overflow-scroll border-b border-darkGray bg-lightGray p-8">
-                  <IndividualTestsTable
-                    data={data[row.index].individual_tests}
-                  />
-                </div>
+                <IndividualTestsTable data={data[row.index].individual_tests} />
               </TableCell>
             </TableRow>
           )}


### PR DESCRIPTION
Adds virtualization (rendering only visible items) on the tests table. The rows of the table will be incrementally added instead of loaded all at once.

## How to test

Go to [localhost example](http://localhost:5173/tree/58e2d28ed28e5bc8836f8c14df1f94c27c1f9e2f?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-next%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Famlogic%2Flinux.git%22%2C%22treeName%22%3A%22amlogic%22%2C%22commitName%22%3A%22v6.12-rc1-18-g58e2d28ed28e5%22%2C%22headCommitHash%22%3A%2258e2d28ed28e5bc8836f8c14df1f94c27c1f9e2f%22%7D), scroll down to the tests table and open a CI with many tests (such as tast or kselftest) and compare to the [current state](https://dashboard.kernelci.org/tree/58e2d28ed28e5bc8836f8c14df1f94c27c1f9e2f?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-next%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Famlogic%2Flinux.git%22%2C%22treeName%22%3A%22amlogic%22%2C%22commitName%22%3A%22v6.12-rc1-18-g58e2d28ed28e5%22%2C%22headCommitHash%22%3A%2258e2d28ed28e5bc8836f8c14df1f94c27c1f9e2f%22%7D)

Closes #371 