### PR TITLE
fix: add filter by origin tree details builds tab

### DIFF
--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -81,6 +81,7 @@ class TreeDetails(View):
     def get(self, request, commit_hash):
         git_url_param = request.GET.get("git_url")
         git_branch_param = request.GET.get("git_branch")
+        origin = request.GET.get("origin")
 
         errorResponse = validate_required_params(
             request, ["origin", "git_url", "git_branch"]
@@ -119,6 +120,7 @@ class TreeDetails(View):
             .where(git_commit_hash__eq=commit_hash)
             .where(git_repository_url__eq=git_url_param)
             .where(git_repository_branch__eq=git_branch_param)
+            .where(**{"checkouts.origin__exact": origin})
             .join(
                 "incidents",
                 join_type="LEFT JOIN",


### PR DESCRIPTION
Builds tab was not using origin to filter, that was causing a difference between tree listing and tree details

How to test:

Goes to 

http://localhost:5173/tree/425419e5b2a8c88096b8bbc61d8865600d1a91c0?tableFilter=%7B%22buildsTable%22%3A%22invalid%22%2C%22bootsTable%22%3A%22failed%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.boots&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22android11-5.4%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fandroid.googlesource.com%2Fkernel%2Fcommon%22%2C%22treeName%22%3A%22android%22%2C%22commitName%22%3A%22ASB-2024-10-05_11-5.4-3-g425419e5b2a8c%22%2C%22headCommitHash%22%3A%22425419e5b2a8c88096b8bbc61d8865600d1a91c0%22%7D

And compare to

https://staging.dashboard.kernelci.org:9000/tree/425419e5b2a8c88096b8bbc61d8865600d1a91c0?tableFilter=%7B%22buildsTable%22%3A%22invalid%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.builds&diffFilter=%7B%22buildStatus%22%3A%7B%22Failure%22%3Atrue%7D%2C%22bootStatus%22%3A%7B%22FAIL%22%3Afalse%7D%7D&treeInfo=%7B%22gitBranch%22%3A%22android11-5.4%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fandroid.googlesource.com%2Fkernel%2Fcommon%22%2C%22treeName%22%3A%22android%22%2C%22commitName%22%3A%22ASB-2024-10-05_11-5.4-3-g425419e5b2a8c%22%2C%22headCommitHash%22%3A%22425419e5b2a8c88096b8bbc61d8865600d1a91c0%22%7D

Then go to the tree listing of each tree and compare the results and see how it is now aligned to the tree listing

Closes #377
