### PR TITLE
feat: hide card fail in boots and tests

### DIFF
--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -8,7 +8,6 @@ import { Skeleton } from '@/components/Skeleton';
 
 import {
   MemoizedConfigList,
-  MemoizedErrorCountList,
   MemoizedErrorsSummary,
   MemoizedIssuesList,
   MemoizedPlatformsWithError,
@@ -91,10 +90,6 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
             title={<FormattedMessage id="bootsTab.platformsFailingAtBoot" />}
             platformsWithError={data.bootPlatformsFailing}
           />
-          <MemoizedErrorCountList
-            title={<FormattedMessage id="bootsTab.fail" />}
-            errorMessageCounts={data.bootFailReasons}
-          />
         </div>
       </DesktopGrid>
       <MobileGrid>
@@ -122,10 +117,6 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
             <MemoizedPlatformsWithError
               title={<FormattedMessage id="bootsTab.platformsFailingAtBoot" />}
               platformsWithError={data.bootPlatformsFailing}
-            />
-            <MemoizedErrorCountList
-              title={<FormattedMessage id="bootsTab.fail" />}
-              errorMessageCounts={data.bootFailReasons}
             />
           </div>
         </InnerMobileGrid>

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -9,7 +9,6 @@ import BaseCard from '@/components/Cards/BaseCard';
 
 import {
   MemoizedStatusChart,
-  MemoizedErrorCountList,
   MemoizedConfigList,
   MemoizedErrorsSummary,
   MemoizedPlatformsWithError,
@@ -90,10 +89,6 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
             title={<FormattedMessage id="testsTab.platformsErrors" />}
             platformsWithError={data.testPlatformsWithErrors}
           />
-          <MemoizedErrorCountList
-            title={<FormattedMessage id="testsTab.fail" />}
-            errorMessageCounts={data.testFailReasons}
-          />
         </div>
       </DesktopGrid>
       <MobileGrid>
@@ -121,10 +116,6 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
             <MemoizedPlatformsWithError
               title={<FormattedMessage id="testsTab.platformsErrors" />}
               platformsWithError={data.testPlatformsWithErrors}
-            />
-            <MemoizedErrorCountList
-              title={<FormattedMessage id="testsTab.fail" />}
-              errorMessageCounts={data.testFailReasons}
             />
           </div>
         </InnerMobileGrid>


### PR DESCRIPTION
Hide card "Fail" in boots and tests tab.

Maybe this card will be used again, so MemoizedErrorCountList component has not been deleted.

- Closes #385 