### PR TITLE
fix(test-tables): fix null pointer in tests

### DIFF
--- a/dashboard/src/components/Table/TestsTable.tsx
+++ b/dashboard/src/components/Table/TestsTable.tsx
@@ -164,7 +164,7 @@ const TestsTable = ({ testHistory }: ITestsTable): JSX.Element => {
           .map(test => ({
             ...test,
             individual_tests: test.individual_tests.filter(
-              t => t.status.toUpperCase() === StatusTable.PASS,
+              t => t.status?.toUpperCase() === StatusTable.PASS,
             ),
           }));
       case 'failed':
@@ -173,7 +173,7 @@ const TestsTable = ({ testHistory }: ITestsTable): JSX.Element => {
           .map(test => ({
             ...test,
             individual_tests: test.individual_tests.filter(t => {
-              const result = t.status.toUpperCase() === StatusTable.FAIL;
+              const result = t.status?.toUpperCase() === StatusTable.FAIL;
 
               return result;
             }),
@@ -191,7 +191,7 @@ const TestsTable = ({ testHistory }: ITestsTable): JSX.Element => {
           .map(test => ({
             ...test,
             individual_tests: test.individual_tests.filter(t => {
-              const uppercaseTestStatus = t.status.toUpperCase();
+              const uppercaseTestStatus = t.status?.toUpperCase();
               const result =
                 uppercaseTestStatus !== StatusTable.PASS &&
                 uppercaseTestStatus !== StatusTable.FAIL;

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -16,7 +16,7 @@ export type TPathTests = {
 export type TIndividualTest = {
   id: string;
   path: string;
-  status: Status;
+  status?: Status;
   start_time: string;
   duration: string;
 };


### PR DESCRIPTION
some test is returning an empty status and null was not handled by it


Go to the link that was pointed as problematic an test the test table:
https://kernelci.slack.com/archives/C067UJC404A/p1729264297780649


http://localhost:5173/tree/171aa289a6fe65faffeb92a1fda283c055435a62?tableFilter=%7B%22buildsTable%22%3A%22invalid%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-next%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Famlogic%2Flinux.git%22%2C%22treeName%22%3A%22amlogic%22%2C%22commitName%22%3A%22v6.12-rc1-20-g171aa289a6fe%22%2C%22headCommitHash%22%3A%22171aa289a6fe65faffeb92a1fda283c055435a62%22%7D