### PR TITLE
feat: show hardware used in tests in tree details header

### DIFF
--- a/backend/kernelCI_app/views/treeDetailsSlowView.py
+++ b/backend/kernelCI_app/views/treeDetailsSlowView.py
@@ -57,6 +57,7 @@ class TreeDetailsSlow(View):
         self.incidentsIssueRelationship = defaultdict(
             lambda: IncidentInfo(incidentsCount=0)
         )
+        self.hardwareUsed = set()
 
     def __handle_boot_status(self, current_filter):
         self.filterBootStatus.add(current_filter["value"])
@@ -440,6 +441,9 @@ class TreeDetailsSlow(View):
                 testEnvironmentCompatible,
             ) = currentRowData
 
+            if testEnvironmentCompatible is not None:
+                self.hardwareUsed.add(testEnvironmentCompatible)
+
             if (
                 (
                     len(self.filterArchitecture) > 0
@@ -483,6 +487,7 @@ class TreeDetailsSlow(View):
                 "testEnvironmentCompatible": self.testEnvironmentCompatible,
                 "bootEnvironmentCompatible": self.bootEnvironmentCompatible,
                 "incidentsIssueRelationship": self.incidentsIssueRelationship,
+                "hardwareUsed": list(self.hardwareUsed),
             },
             safe=False,
         )

--- a/dashboard/src/api/TreeDetails.tsx
+++ b/dashboard/src/api/TreeDetails.tsx
@@ -93,10 +93,15 @@ const mapFiltersKeysToBackendCompatible = (
   return filterParam;
 };
 
-export const useBuildsTab = (
-  treeId: string,
-  filter: TTreeDetailsFilter | Record<string, never> = {},
-): UseQueryResult<BuildsTab> => {
+export const useBuildsTab = ({
+  treeId,
+  filter = {},
+  enabled = true,
+}: {
+  treeId: string;
+  filter?: TTreeDetailsFilter | Record<string, never>;
+  enabled?: boolean;
+}): UseQueryResult<BuildsTab> => {
   const detailsFilter = getTargetFilter(filter, 'treeDetails');
 
   const treeSearchParameters = useTreeSearchParameters();
@@ -105,6 +110,7 @@ export const useBuildsTab = (
     queryKey: ['treeData', treeId, detailsFilter, treeSearchParameters],
     queryFn: () =>
       fetchTreeDetailData(treeId, treeSearchParameters, detailsFilter),
+    enabled,
   });
 };
 
@@ -135,10 +141,15 @@ const fetchTreeTestsData = async (
   return res.data;
 };
 
-export const useTestsTab = (
-  treeId: string,
-  filter: TTreeDetailsFilter,
-): UseQueryResult<TTreeTestsFullData> => {
+export const useTestsTab = ({
+  treeId,
+  filter,
+  enabled = true,
+}: {
+  treeId: string;
+  filter: TTreeDetailsFilter;
+  enabled?: boolean;
+}): UseQueryResult<TTreeTestsFullData> => {
   const testFilter = getTargetFilter(filter, 'test');
   const treeDetailsFilter = getTargetFilter(filter, 'treeDetails');
   const treeSearchParameters = useTreeSearchParameters();
@@ -156,6 +167,7 @@ export const useTestsTab = (
         ...testFilter,
         ...treeDetailsFilter,
       }),
+    enabled,
   });
 };
 

--- a/dashboard/src/components/ui/badge.tsx
+++ b/dashboard/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-300",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
+        secondary:
+          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
+        destructive:
+          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80",
+        outline: "text-slate-950 dark:text-slate-50",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -214,6 +214,7 @@ export const messages = {
     'treeDetails.executed': 'Executed',
     'treeDetails.failed': 'Failed',
     'treeDetails.failedBoots': 'Failed boots',
+    'treeDetails.hardwareUsed': 'Hardware Used',
     'treeDetails.inconclusiveBoots': 'Inconclusive Boots',
     'treeDetails.inconclusiveBuilds': 'Inconclusive Builds',
     'treeDetails.inconclusiveTests': 'Inconclusive Tests',

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -31,7 +31,10 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
   const { treeId } = useParams({
     from: '/tree/$treeId/',
   });
-  const { isLoading, data, error } = useTestsTab(treeId ?? '', reqFilter);
+  const { isLoading, data, error } = useTestsTab({
+    treeId: treeId ?? '',
+    filter: reqFilter,
+  });
 
   if (error || !treeId) {
     return (

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage } from 'react-intl';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { Link } from '@tanstack/react-router';
 
@@ -19,6 +19,8 @@ import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
 import { TIssue } from '@/types/general';
 import { NoIssueFound } from '@/components/Issue/IssueSection';
 import { ScrollArea } from '@/components/ui/scroll-area';
+
+import { Badge } from '@/components/ui/badge';
 
 import FilterLink from '../TreeDetailsFilterLink';
 
@@ -289,3 +291,32 @@ const IssuesList = ({ issues, title }: IIssuesList): JSX.Element => {
 };
 
 export const MemoizedIssuesList = memo(IssuesList);
+
+interface IHardwareUsed {
+  title: IBaseCard['title'];
+  hardwareUsed?: string[];
+}
+
+const HardwareUsed = ({ hardwareUsed, title }: IHardwareUsed): JSX.Element => {
+  const hardwareSorted = useMemo(() => {
+    return hardwareUsed?.sort().map(hardware => {
+      return (
+        <Badge key={hardware} variant="outline" className="text-sm font-normal">
+          {hardware}
+        </Badge>
+      );
+    });
+  }, [hardwareUsed]);
+
+  return (
+    <BaseCard
+      title={title}
+      content={
+        <div className="flex flex-row flex-wrap gap-4 p-4">
+          {hardwareSorted}
+        </div>
+      }
+    />
+  );
+};
+export const MemoizedHardwareUsed = memo(HardwareUsed);

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -30,7 +30,10 @@ interface TestsTabProps {
 
 const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
   const { treeId } = useParams({ from: '/tree/$treeId/' });
-  const { isLoading, data, error } = useTestsTab(treeId ?? '', reqFilter);
+  const { isLoading, data, error } = useTestsTab({
+    treeId: treeId ?? '',
+    filter: reqFilter,
+  });
 
   if (error || !treeId) {
     return (

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -326,7 +326,7 @@ const TreeDetailsFilter = ({
 }: ITreeDetailsFilter): JSX.Element => {
   const { treeId } = useParams({ from: '/tree/$treeId/' });
 
-  const { data, isLoading } = useBuildsTab(treeId);
+  const { data, isLoading } = useBuildsTab({ treeId });
 
   const navigate = useNavigate({
     from: '/tree/$treeId',

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -99,7 +99,7 @@ type StatusCounts = {
   [key in Status]: number | undefined;
 };
 
-type EnvironmentCompatibleCounts = {
+export type EnvironmentCompatibleCounts = {
   [key: string]: number;
 };
 
@@ -139,6 +139,7 @@ export type TTreeTestsFullData = {
   testIssues: TIssue[];
   testEnvironmentCompatible: EnvironmentCompatibleCounts;
   bootEnvironmentCompatible: EnvironmentCompatibleCounts;
+  hardwareUsed: string[];
 };
 
 export type PossibleTabs = Extract<


### PR DESCRIPTION
Adding Hardware Used table in Tree details header

![image](https://github.com/user-attachments/assets/d8470c17-321d-41c2-a5eb-f90a784d323d)

The table data shouldn't change by adding filters
- closes #384 