### PR TITLE
feat: show tooltip with the complete value of Commit/Tag column

### DIFF
--- a/dashboard/src/components/Table/TreeTable.tsx
+++ b/dashboard/src/components/Table/TreeTable.tsx
@@ -94,6 +94,8 @@ const TreeTableRow = (row: TreeTableBody): JSX.Element => {
     [row.id, row.url, row.branch, row.tree_name, row.commitName, origin],
   );
 
+  const tagOrCommitHash = row.commitName ? row.commitName : row.commitHash;
+
   return (
     <TableRow>
       <TableCellWithLink
@@ -117,12 +119,17 @@ const TreeTableRow = (row: TreeTableBody): JSX.Element => {
       >
         {sanitizeTableValue(row.branch, false)}
       </TableCellWithLink>
-      <TableCellWithLink
-        data-target="treeDetails.builds"
-        linkProps={linkProps('treeDetails.builds')}
-      >
-        {sanitizeTableValue(row.commitName ? row.commitName : row.commitHash)}
-      </TableCellWithLink>
+      <Tooltip>
+        <TooltipTrigger>
+          <TableCellWithLink
+            data-target="treeDetails.builds"
+            linkProps={linkProps('treeDetails.builds')}
+          >
+            {sanitizeTableValue(tagOrCommitHash)}
+          </TableCellWithLink>
+        </TooltipTrigger>
+        <TooltipContent>{tagOrCommitHash}</TooltipContent>
+      </Tooltip>
       <TableCellWithLink
         data-target="treeDetails.builds"
         linkProps={linkProps('treeDetails.builds')}


### PR DESCRIPTION
- On TreeListingPage show tooltip with the complete value of `Commit/Tag` column on hover

Close #394 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7f9d4487-520c-4cac-9cd1-f75e486f8500) |![image](https://github.com/user-attachments/assets/6bad4178-1e65-43b6-bdd3-72c8777a8616) |
