### PR TITLE
feat: add status count in hardware tested

### DIFF
--- a/backend/kernelCI_app/views/treeDetailsSlowView.py
+++ b/backend/kernelCI_app/views/treeDetailsSlowView.py
@@ -44,7 +44,7 @@ class TreeDetailsSlow(View):
         self.testArchSummary = {}
         self.testIssues = []
         self.testIssuesTable = {}
-        self.testEnvironmentCompatible = defaultdict(int)
+        self.testEnvironmentCompatible = defaultdict(lambda: defaultdict(int))
         self.bootHistory = []
         self.bootStatusSummary = {}
         self.bootConfigs = {}
@@ -53,7 +53,7 @@ class TreeDetailsSlow(View):
         self.bootArchSummary = {}
         self.bootIssues = []
         self.bootsIssuesTable = {}
-        self.bootEnvironmentCompatible = defaultdict(int)
+        self.bootEnvironmentCompatible = defaultdict(lambda: defaultdict(int))
         self.incidentsIssueRelationship = defaultdict(
             lambda: IncidentInfo(incidentsCount=0)
         )
@@ -255,7 +255,10 @@ class TreeDetailsSlow(View):
             self.bootFailReasons[testError] = self.bootFailReasons.get(testError, 0) + 1
 
         if testEnvironmentCompatible is not None:
-            self.bootEnvironmentCompatible[testEnvironmentCompatible] += 1
+            if testStatus is None:
+                self.bootEnvironmentCompatible[testEnvironmentCompatible]["NULL"] += 1
+            else:
+                self.bootEnvironmentCompatible[testEnvironmentCompatible][testStatus] += 1
 
             self.incidentsIssueRelationship[incident_id]["incidentsCount"] += 1
 
@@ -327,7 +330,10 @@ class TreeDetailsSlow(View):
             self.testFailReasons[testError] = self.testFailReasons.get(testError, 0) + 1
 
         if testEnvironmentCompatible is not None:
-            self.testEnvironmentCompatible[testEnvironmentCompatible] += 1
+            if testStatus is None:
+                self.testEnvironmentCompatible[testEnvironmentCompatible]["NULL"] += 1
+            else:
+                self.testEnvironmentCompatible[testEnvironmentCompatible][testStatus] += 1
 
     def get(self, request, commit_hash: str | None):
         cache_key = "treeDetailsSlow"

--- a/dashboard/src/components/Status/Status.tsx
+++ b/dashboard/src/components/Status/Status.tsx
@@ -8,6 +8,7 @@ interface ITestStatus {
   fail?: number;
   done?: number;
   skip?: number;
+  nullStatus?: number;
   forceNumber?: boolean;
 }
 
@@ -81,6 +82,7 @@ export const GroupedTestStatus = ({
   fail,
   done,
   skip,
+  nullStatus,
 }: ITestStatus): JSX.Element => {
   const { successCount, inconclusiveCount, failedCount } = groupStatus({
     doneCount: done ?? 0,
@@ -89,6 +91,7 @@ export const GroupedTestStatus = ({
     missCount: miss ?? 0,
     passCount: pass ?? 0,
     skipCount: skip ?? 0,
+    nullCount: nullStatus ?? 0,
   });
   return (
     <div className="flex flex-row gap-1">

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -87,20 +87,29 @@ const HardwareTested = ({
       content={
         <ScrollArea className="h-[350px]">
           <DumbListingContent>
-            {environmentCompatible &&
-              Object.entries(environmentCompatible).map(
-                ([hardwareTestedItem, hardwareTestedCount]) => {
-                  return (
-                    <ListingItem
-                      hasBottomBorder
-                      key={hardwareTestedItem}
-                      errors={hardwareTestedCount}
-                      text={hardwareTestedItem}
-                      showNumber={true}
+            {Object.keys(environmentCompatible).map(hardwareTestedName => {
+              const { DONE, FAIL, ERROR, MISS, PASS, SKIP, NULL } =
+                environmentCompatible[hardwareTestedName];
+
+              return (
+                <ListingItem
+                  hasBottomBorder
+                  key={hardwareTestedName}
+                  text={hardwareTestedName}
+                  leftIcon={
+                    <GroupedTestStatus
+                      done={DONE}
+                      fail={FAIL}
+                      error={ERROR}
+                      miss={MISS}
+                      pass={PASS}
+                      skip={SKIP}
+                      nullStatus={NULL}
                     />
-                  );
-                },
-              )}
+                  }
+                />
+              );
+            })}
           </DumbListingContent>
         </ScrollArea>
       }

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -99,10 +99,6 @@ type StatusCounts = {
   [key in Status]: number | undefined;
 };
 
-export type EnvironmentCompatibleCounts = {
-  [key: string]: number;
-};
-
 export type ArchCompilerStatus = {
   arch: string;
   compiler: string;
@@ -119,7 +115,7 @@ export type TTreeTestsData = {
   compilersPerArchitecture: CompilersPerArchitecture;
   platformsWithError: string[];
   errorMessageCounts: ErrorMessageCounts;
-  environmentCompatible: EnvironmentCompatibleCounts;
+  environmentCompatible: PropertyStatusCounts;
 };
 
 export type TTreeTestsFullData = {
@@ -137,8 +133,8 @@ export type TTreeTestsFullData = {
   testHistory: TestHistory[];
   bootIssues: TIssue[];
   testIssues: TIssue[];
-  testEnvironmentCompatible: EnvironmentCompatibleCounts;
-  bootEnvironmentCompatible: EnvironmentCompatibleCounts;
+  testEnvironmentCompatible: PropertyStatusCounts;
+  bootEnvironmentCompatible: PropertyStatusCounts;
   hardwareUsed: string[];
 };
 

--- a/dashboard/src/utils/constants/database.ts
+++ b/dashboard/src/utils/constants/database.ts
@@ -7,6 +7,7 @@ export const status = [
   'PASS',
   'SKIP',
   'DONE',
+  'NULL',
 ] as const;
 
 export const StatusTable = {

--- a/dashboard/src/utils/status.ts
+++ b/dashboard/src/utils/status.ts
@@ -9,6 +9,7 @@ type StatusCount = {
   errorCount: number;
   failCount: number;
   passCount: number;
+  nullCount?: number;
 };
 
 type GroupedStatus = {
@@ -25,7 +26,8 @@ export function groupStatus(counts: StatusCount): GroupedStatus {
       counts.doneCount +
       counts.errorCount +
       counts.missCount +
-      counts.skipCount,
+      counts.skipCount +
+      (counts.nullCount ?? 0),
   };
 }
 


### PR DESCRIPTION
Add status count in hardware tested
![image](https://github.com/user-attachments/assets/f0f3e16f-7782-4731-ba2f-1c343b072aef)

Before just show the amount of occorencies
![image](https://github.com/user-attachments/assets/bd03b266-d0e0-482d-afc6-c0298e050b5d)

- Closes #411