### PR TITLE
fix: make Tree Details Header show full tag and full url on hover

### DIFF
--- a/dashboard/src/components/Table/tableUtils.ts
+++ b/dashboard/src/components/Table/tableUtils.ts
@@ -4,5 +4,7 @@ const truncateTableValue = (value: string): string =>
   value.substring(0, MAX_NUMBER_CHAR) +
   (value.length > MAX_NUMBER_CHAR ? '...' : '');
 
-export const sanitizeTableValue = (value: string, truncate = true): string =>
-  (truncate ? truncateTableValue(value) : value) || '-';
+export const sanitizeTableValue = (
+  value: string | undefined,
+  truncate = true,
+): string => (truncate ? truncateTableValue(value || '') : value) || '-';

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -85,19 +85,16 @@ const TreeHeader = ({
           <TableCell>{gitBranch ?? '-'}</TableCell>
           <TableCell>
             <Tooltip>
-              <TooltipTrigger>
-                {sanitizeTableValue(
-                  tag && tag !== ''
-                    ? tag
-                    : commit && commit !== ''
-                      ? commit
-                      : '-',
-                )}
-              </TooltipTrigger>
-              <TooltipContent>{tag ?? commit}</TooltipContent>
+              <TooltipTrigger>{sanitizeTableValue(tag, false)}</TooltipTrigger>
+              <TooltipContent>{commit}</TooltipContent>
             </Tooltip>
           </TableCell>
-          <TableCell>{gitUrl ?? '-'}</TableCell>
+          <TableCell>
+            <Tooltip>
+              <TooltipTrigger>{sanitizeTableValue(gitUrl)} </TooltipTrigger>
+              <TooltipContent>{gitUrl}</TooltipContent>
+            </Tooltip>
+          </TableCell>
         </TableRow>
       </TableBody>
     </DumbBaseTable>


### PR DESCRIPTION
- Commit/Tag: show full tag; on hover show commit hash
- URL: truncate on 12 chars; on hover show full URL

Close #395 

| | Before | After | 
|---|--------|--------|
| Commit/tab | ![image](https://github.com/user-attachments/assets/ed25d942-def8-4e52-916a-7fedea83287b) | ![image](https://github.com/user-attachments/assets/1d8f2c2c-4f77-4a4c-8c79-8149f0ea4ccf)|
|URL | ![image](https://github.com/user-attachments/assets/b64d9925-fc4f-42c2-af9f-6c9dce0f325d)|![image](https://github.com/user-attachments/assets/3ec5bbf2-dfe3-4c5a-93cd-3816dea1013a)|
