### PR TITLE
feat(issues): add incidents count

### DIFF
--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import Union
+from typing import Union, TypedDict, List, Optional, Dict
 from django.utils import timezone
 from datetime import timedelta
 import re
@@ -7,14 +7,30 @@ import re
 DEFAULT_QUERY_TIME_INTERVAL = {"days": 7}
 
 
-def create_issue(*, issue_id, issue_comment, issue_report_url, incident_id, incident_present):
+class IncidentInfo(TypedDict):
+    incidentsCount: int
+
+
+class Issue(TypedDict):
+    id: str
+    comment: Optional[str]
+    report_url: Optional[str]
+    incidents_info: IncidentInfo
+
+
+def create_issue(
+    *, issue_id: str, issue_comment: Optional[str], issue_report_url: Optional[str]
+) -> Issue:
     return {
         "id": issue_id,
         "comment": issue_comment,
         "report_url": issue_report_url,
-        "incident_id": incident_id,
-        "present": incident_present,
+        "incidents_info": {"incidentsCount": 0},
     }
+
+
+def convert_issues_dict_to_list(issues_dict: Dict[str, Issue]) -> List[Issue]:
+    return list(issues_dict.values())
 
 
 def toIntOrDefault(value, default):

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -1,7 +1,5 @@
 import { useMemo } from 'react';
 
-import { FaRegCircle, FaRegDotCircle } from 'react-icons/fa';
-
 import { FormattedMessage } from 'react-intl';
 
 import { UseQueryResult } from '@tanstack/react-query';
@@ -34,18 +32,14 @@ const IssueSection = ({
     () =>
       data?.map(issue => (
         <Link
-          key={issue.incident_id}
+          key={issue.id}
           to={issue.report_url}
           target="_blank"
           className="flex [&:not(:last-child)]:mb-2 [&:not(:last-child)]:border-b [&:not(:last-child)]:pb-2"
         >
           <ListingItem
+            unknown={issue.incidents_info.incidentsCount}
             text={issue.comment ?? ''}
-            leftIcon={
-              <div className="text-darkGray2">
-                {issue.present ? <FaRegDotCircle /> : <FaRegCircle />}
-              </div>
-            }
           />
         </Link>
       )),

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -1,5 +1,4 @@
 import { FormattedMessage } from 'react-intl';
-import { FaRegDotCircle, FaRegCircle } from 'react-icons/fa';
 import { memo } from 'react';
 
 import { Link } from '@tanstack/react-router';
@@ -274,15 +273,11 @@ const IssuesList = ({ issues, title }: IIssuesList): JSX.Element => {
     <DumbListingContent>
       {issues.map(issue => {
         return (
-          <Link key={issue.incident_id} to={issue.report_url} target="_blank">
+          <Link key={issue.id} to={issue.report_url} target="_blank">
             <ListingItem
+              unknown={issue.incidents_info.incidentsCount}
               hasBottomBorder
               text={issue.comment ?? ''}
-              leftIcon={
-                <div className="text-darkGray2">
-                  {issue.present ? <FaRegDotCircle /> : <FaRegCircle />}
-                </div>
-              }
             />
           </Link>
         );

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -1,5 +1,7 @@
 import { Status } from './database';
 
+type IncidentsInfo = { incidentsCount: number };
+
 export type TPathTests = {
   path_group: string;
   fail_tests: number;
@@ -39,6 +41,5 @@ export type TIssue = {
   id: string;
   comment?: string;
   report_url?: string;
-  present?: boolean;
-  incident_id: string;
+  incidents_info: IncidentsInfo;
 };


### PR DESCRIPTION
Add incidents count to each issue
This PR changes the issues to use a hashtable logic so incidents can belong to a single issue and add incident info there.

Closes #393

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6812ef3f-65d6-44f5-a463-b23604e329d4)  | ![image](https://github.com/user-attachments/assets/e0f76410-0c18-41f0-9f54-6cbf96742422) | 


## How to test

See the before:
https://staging.dashboard.kernelci.org:9000/tree/59cbd4eea48fdbc68fc17a29ad71188fea74b28b?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=redhat&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22master%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Fvirt%2Fkvm%2Fkvm.git%22%2C%22treeName%22%3A%22kvm%22%2C%22commitName%22%3A%22for-linus-1-g59cbd4eea48f%22%2C%22headCommitHash%22%3A%2259cbd4eea48fdbc68fc17a29ad71188fea74b28b%22%7D

See the after:
http://localhost:5173/tree/59cbd4eea48fdbc68fc17a29ad71188fea74b28b?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=redhat&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22master%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Fvirt%2Fkvm%2Fkvm.git%22%2C%22treeName%22%3A%22kvm%22%2C%22commitName%22%3A%22for-linus-1-g59cbd4eea48f%22%2C%22headCommitHash%22%3A%2259cbd4eea48fdbc68fc17a29ad71188fea74b28b%22%7D