### PR TITLE
Fix Filter in History Charts

### DIFF
--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -1,13 +1,111 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponseBadRequest
 from django.db import connection
+from kernelCI_app.utils import (
+    FilterParams,
+    InvalidComparisonOP,
+    getErrorResponseBody,
+)
 
 
 # TODO Move this endpoint to a function so it doesn't
 # have to be another request, it can be called from the tree details endpoint
 class TreeCommitsHistory(APIView):
+    def __init__(self):
+        self.filters_options = {
+            'build': {
+                'table_alias': 'b',
+                'filters': []
+            },
+            'boot': {
+                'table_alias': 't',
+                'filters': []
+            },
+            'test': {
+                'table_alias': 't',
+                'filters': []
+            }
+        }
+        self.field_values = dict()
+
+    # TODO: unite the filters logic
+    def _get_filters(self, filter_params):
+        for f in filter_params.filters:
+            split_filter = f['field'].split('.')
+
+            if len(split_filter) == 1:
+                split_filter.insert(0, 'build')
+
+            table, field = split_filter
+
+            value_name = f"{table}{field.capitalize()}{filter_params.get_comparison_op(f)}"
+
+            op = filter_params.get_comparison_op(f, "raw")
+            self.field_values[value_name] = f['value']
+            clause = f"{self.filters_options[table]['table_alias']}.{field}"
+
+            if op == "IN":
+                clause += f" = ANY(%({value_name})s)"
+            else:
+                clause += f" {op} %({value_name})s"
+            self.filters_options[table]['filters'].append(clause)
+
+            if field in ["config_name", "architecture", "compiler"]:
+                self.filters_options['test']['filters'].append(clause)
+                self.filters_options['boot']['filters'].append(clause)
+
+        build_counts_where = """
+            c.git_repository_branch = %(git_branch_param)s
+            AND c.git_repository_url = %(git_url_param)s
+            AND c.origin = %(origin_param)s"""
+
+        boot_counts_where = """
+            b.start_time >= (
+                SELECT
+                    MIN(earliest_start_time)
+                FROM earliest_commits
+            )
+            AND t.start_time >= (
+                SELECT
+                    MIN(earliest_start_time)
+                FROM earliest_commits
+            )"""
+
+        test_counts_where = """
+            b.start_time >= (
+                SELECT
+                    MIN(earliest_start_time)
+                FROM earliest_commits
+            )
+            AND t.start_time >= (
+                SELECT
+                    MIN(earliest_start_time)
+                FROM earliest_commits
+            )"""
+
+        if len(self.filters_options['build']['filters']) > 0:
+            filter_clauses = f"""
+                AND {" AND ".join(self.filters_options['build']['filters'])}"""
+            build_counts_where += filter_clauses
+
+        if len(self.filters_options['boot']['filters']) > 0:
+            filter_clauses = f"""
+                AND {" AND ".join(self.filters_options['boot']['filters'])}"""
+            boot_counts_where += filter_clauses
+
+        if len(self.filters_options['test']['filters']) > 0:
+            filter_clauses = f"""
+                AND {" AND ".join(self.filters_options['test']['filters'])}"""
+            test_counts_where += filter_clauses
+
+        return (
+            build_counts_where,
+            boot_counts_where,
+            test_counts_where
+        )
+
     def get(self, request, commit_hash):
         origin_param = request.GET.get("origin")
         git_url_param = request.GET.get("git_url")
@@ -27,7 +125,21 @@ class TreeCommitsHistory(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        query = """
+        try:
+            filter_params = FilterParams(request)
+        except InvalidComparisonOP as e:
+            return HttpResponseBadRequest(getErrorResponseBody(str(e)))
+
+        self.field_values = {
+            "commit_hash": commit_hash,
+            "origin_param": origin_param,
+            "git_url_param": git_url_param,
+            "git_branch_param": git_branch_param,
+        }
+
+        build_counts_where, boot_counts_where, test_counts_where = self._get_filters(filter_params)
+
+        query = f"""
         WITH
         relevant_checkouts AS (
             SELECT
@@ -73,55 +185,67 @@ class TreeCommitsHistory(APIView):
                 builds AS b
                 ON c.id = b.checkout_id
             WHERE
-                c.git_repository_branch = %(git_branch_param)s
-                AND c.git_repository_url = %(git_url_param)s
-                AND c.origin = %(origin_param)s
+                {build_counts_where}
+            GROUP BY
+                c.git_commit_hash
+        ),
+        boots_counts AS (
+            SELECT
+                c.git_commit_hash,
+                SUM(CASE WHEN t.status = 'FAIL' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS boots_fail_count,
+                SUM(CASE WHEN t.status = 'ERROR' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS boots_error_count,
+                SUM(CASE WHEN t.status = 'MISS' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS boots_miss_count,
+                SUM(CASE WHEN t.status = 'PASS' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS boots_pass_count,
+                SUM(CASE WHEN t.status = 'DONE' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS boots_done_count,
+                SUM(CASE WHEN t.status = 'SKIP' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS boots_skip_count
+            FROM
+                relevant_checkouts AS c
+            INNER JOIN
+                builds AS b
+                ON
+                c.id = b.checkout_id
+            LEFT JOIN
+                tests AS t
+                ON b.id = t.build_id
+            WHERE
+                {boot_counts_where}
             GROUP BY
                 c.git_commit_hash
         ),
         test_counts AS (
-        SELECT
-            c.git_commit_hash,
-            SUM(CASE WHEN t.status = 'FAIL' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END) AS boots_fail_count,
-            SUM(CASE WHEN t.status = 'ERROR' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END) AS boots_error_count,
-            SUM(CASE WHEN t.status = 'MISS' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END) AS boots_miss_count,
-            SUM(CASE WHEN t.status = 'PASS' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END) AS boots_pass_count,
-            SUM(CASE WHEN t.status = 'DONE' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END) AS boots_done_count,
-            SUM(CASE WHEN t.status = 'SKIP' AND t.path LIKE 'boot%%' THEN 1 ELSE 0 END) AS boots_skip_count,
-            SUM(CASE WHEN t.status = 'FAIL' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
-            AS non_boots_fail_count,
-            SUM(CASE WHEN t.status = 'ERROR' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
-            AS non_boots_error_count,
-            SUM(CASE WHEN t.status = 'MISS' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
-            AS non_boots_miss_count,
-            SUM(CASE WHEN t.status = 'PASS' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
-            AS non_boots_pass_count,
-            SUM(CASE WHEN t.status = 'DONE' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
-            AS non_boots_done_count,
-            SUM(CASE WHEN t.status = 'SKIP' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
-            AS non_boots_skip_count
-        FROM
-            relevant_checkouts AS c
-        INNER JOIN
-            builds AS b
-            ON
-            c.id = b.checkout_id
-        LEFT JOIN
-            tests AS t
-            ON b.id = t.build_id
-        WHERE
-            b.start_time >= (
-                SELECT
-                    MIN(earliest_start_time)
-                FROM earliest_commits
-            )
-            AND t.start_time >= (
-                SELECT
-                    MIN(earliest_start_time)
-                FROM earliest_commits
-            )
-        GROUP BY
-            c.git_commit_hash
+            SELECT
+                c.git_commit_hash,
+                SUM(CASE WHEN t.status = 'FAIL' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS non_boots_fail_count,
+                SUM(CASE WHEN t.status = 'ERROR' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS non_boots_error_count,
+                SUM(CASE WHEN t.status = 'MISS' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS non_boots_miss_count,
+                SUM(CASE WHEN t.status = 'PASS' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS non_boots_pass_count,
+                SUM(CASE WHEN t.status = 'DONE' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS non_boots_done_count,
+                SUM(CASE WHEN t.status = 'SKIP' AND t.path NOT LIKE 'boot%%' THEN 1 ELSE 0 END)
+                AS non_boots_skip_count
+            FROM
+                relevant_checkouts AS c
+            INNER JOIN
+                builds AS b
+                ON
+                c.id = b.checkout_id
+            LEFT JOIN
+                tests AS t
+                ON b.id = t.build_id
+            WHERE
+                {test_counts_where}
+            GROUP BY
+                c.git_commit_hash
         )
         SELECT
             ec.git_commit_hash,
@@ -130,12 +254,12 @@ class TreeCommitsHistory(APIView):
             bc.valid_builds,
             bc.invalid_builds,
             bc.null_builds,
-            tc.boots_fail_count,
-            tc.boots_error_count,
-            tc.boots_miss_count,
-            tc.boots_pass_count,
-            tc.boots_done_count,
-            tc.boots_skip_count,
+            boc.boots_fail_count,
+            boc.boots_error_count,
+            boc.boots_miss_count,
+            boc.boots_pass_count,
+            boc.boots_done_count,
+            boc.boots_skip_count,
             tc.non_boots_fail_count,
             tc.non_boots_error_count,
             tc.non_boots_miss_count,
@@ -144,10 +268,13 @@ class TreeCommitsHistory(APIView):
             tc.non_boots_skip_count
         FROM
             earliest_commits AS ec
-        INNER JOIN
+        LEFT JOIN
             build_counts AS bc
             ON ec.git_commit_hash = bc.git_commit_hash
-        INNER JOIN
+        LEFT JOIN
+            boots_counts AS boc
+            ON ec.git_commit_hash = boc.git_commit_hash
+        LEFT JOIN
             test_counts AS tc
             ON ec.git_commit_hash = tc.git_commit_hash
         ORDER BY
@@ -159,12 +286,7 @@ class TreeCommitsHistory(APIView):
         with connection.cursor() as cursor:
             cursor.execute(
                 query,
-                {
-                    "commit_hash": commit_hash,
-                    "origin_param": origin_param,
-                    "git_url_param": git_url_param,
-                    "git_branch_param": git_branch_param,
-                },
+                self.field_values,
             )
             rows = cursor.fetchall()
 

--- a/dashboard/src/pages/TreeDetails/Tabs/CommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/CommitNavigationGraph.tsx
@@ -14,6 +14,7 @@ import type { TLineChartProps } from '@/components/LineChart/LineChart';
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { MessagesKey } from '@/locales/messages';
 import { formatDate } from '@/utils/utils';
+import { mapFilterToReq } from '@/pages/TreeDetails/TreeDetailsFilter';
 
 const graphDisplaySize = 7;
 
@@ -22,6 +23,7 @@ const CommitNavigationGraph = (): JSX.Element => {
   const {
     origin,
     currentTreeDetailsTab,
+    diffFilter,
     treeInfo: { gitUrl, gitBranch, headCommitHash },
   } = useSearch({ from: '/tree/$treeId/' });
 
@@ -33,12 +35,15 @@ const CommitNavigationGraph = (): JSX.Element => {
     from: '/tree/$treeId',
   });
 
+  const reqFilter = mapFilterToReq(diffFilter);
+
   const { data, status } = useTreeCommitHistory(
     {
       gitBranch: gitBranch ?? '',
       gitUrl: gitUrl ?? '',
       commitHash: headCommitHash ?? '',
       origin: origin,
+      filter: reqFilter,
     },
     {
       enabled: !!gitBranch && !!gitUrl,


### PR DESCRIPTION
Change the Tree Commit History SQL to allow pass filters in history charts.

**How to test**
1. Select a tree of your choice.
2. Play with filters and see the changes in History Chart

![Screenshot from 2024-10-24 12-22-28](https://github.com/user-attachments/assets/d3066ff3-9261-4079-9aad-8e5e23968b7f)

Close #264 