### PR TITLE
feat: on Build Details Page replace tests table by tests table from Tests tab

### DIFF
--- a/backend/kernelCI_app/serializers.py
+++ b/backend/kernelCI_app/serializers.py
@@ -77,20 +77,6 @@ class TreeDetailsSerializer(serializers.Serializer):
     misc = serializers.JSONField()
 
 
-class BuildTestsSerializer(serializers.Serializer):
-    current_path = serializers.CharField()
-    start_time = serializers.DateTimeField()
-    fail_tests = serializers.IntegerField()
-    error_tests = serializers.IntegerField()
-    miss_tests = serializers.IntegerField()
-    pass_tests = serializers.IntegerField()
-    done_tests = serializers.IntegerField()
-    skip_tests = serializers.IntegerField()
-    null_tests = serializers.IntegerField()
-    total_tests = serializers.IntegerField()
-    origins = serializers.ListField()
-
-
 class GroupedTestsSerializer(serializers.Serializer):
     path_group = serializers.CharField()
     fail_tests = serializers.IntegerField()

--- a/backend/kernelCI_app/views/buildTestsView.py
+++ b/backend/kernelCI_app/views/buildTestsView.py
@@ -1,48 +1,25 @@
 from django.http import JsonResponse
 from django.views import View
-from django.db.models import Q, TextField, Sum, Count, Case, When, F, Func, Value, Min
-from django.db.models.functions import Concat
-from django.contrib.postgres.aggregates import ArrayAgg
 
 from kernelCI_app.models import Tests
-from kernelCI_app.serializers import BuildTestsSerializer
 
 
 class BuildTests(View):
 
     def get(self, request, build_id):
-        path = request.GET.get('path', '')
-        path_level = 1
-
-        if path:
-            if not path.endswith('.'):
-                path += '.'
-            path_level += path.count('.')
-            filterQ = Q(path__startswith=path) | Q(path=path.rstrip('.'))
-        else:
-            filterQ = Q(path__startswith=path)
-
-        result = (
-            Tests.objects
-            .filter(filterQ, build=build_id,)
-            .values(
-                path_sublevel=Func(
-                    F('path'), Value('.'), Value(path_level),
-                    function='SPLIT_PART', output_field=TextField()))
-            .annotate(
-                fail_tests=Sum(Case(When(status='FAIL', then=1), default=0)),
-                error_tests=Sum(Case(When(status='ERROR', then=1), default=0)),
-                miss_tests=Sum(Case(When(status='MISS', then=1), default=0)),
-                pass_tests=Sum(Case(When(status='PASS', then=1), default=0)),
-                done_tests=Sum(Case(When(status='DONE', then=1), default=0)),
-                skip_tests=Sum(Case(When(status='SKIP', then=1), default=0)),
-                null_tests=Sum(Case(When(status__isnull=True, then=1), default=0)),
-                total_tests=Count('id'),
-                current_path=Concat(Value(path), F('path_sublevel'), output_field=TextField()),
-                origins=ArrayAgg('origin', distinct=True),
-                start_time=Min('start_time'),
-            )
+        result = Tests.objects.filter(build_id=build_id).values(
+            'id', 'duration', 'status', 'path', 'start_time'
         )
 
-        serializer = BuildTestsSerializer(result, many=True)
-        return JsonResponse(serializer.data, safe=False)
+        camel_case_result = [
+            {
+                'id': test['id'],
+                'duration': test['duration'],
+                'status': test['status'],
+                'path': test['path'],
+                'startTime': test['start_time'],
+            }
+            for test in result
+        ]
+
+        return JsonResponse(camel_case_result, safe=False)

--- a/backend/requests/build-tests-get.sh
+++ b/backend/requests/build-tests-get.sh
@@ -12,35 +12,26 @@ http 'http://localhost:8000/api/build/kernelci:kernelci.org:66a1d00e546da93e297e
 # X-Frame-Options: DENY
 
 # [
-#   {
-#     "current_path": "baseline",
-#     "start_time": "2024-07-25T04:12:19.892000Z",
-#     "fail_tests": 0,
-#     "error_tests": 0,
-#     "miss_tests": 0,
-#     "pass_tests": 88,
-#     "done_tests": 0,
-#     "skip_tests": 0,
-#     "null_tests": 0,
-#     "total_tests": 88,
-#     "origins": [
-#       "kernelci"
-#     ]
-#   },
-#   {
-#     "current_path": "baseline_fvp",
-#     "start_time": "2024-07-25T04:20:06.543000Z",
-#     "fail_tests": 0,
-#     "error_tests": 0,
-#     "miss_tests": 0,
-#     "pass_tests": 4,
-#     "done_tests": 0,
-#     "skip_tests": 0,
-#     "null_tests": 0,
-#     "total_tests": 4,
-#     "origins": [
-#       "kernelci"
-#     ]
-#   }
-# ...
-# ]
+  #   {
+  #     "id": "kernelci:kernelci.org:66a1d0d262f8cae67a7e7095",
+  #     "duration": null,
+  #     "status": "PASS",
+  #     "path": "baseline.login",
+  #     "startTime": "2024-07-25T04:13:06.105Z"
+  #   },
+  #   {
+  #     "id": "kernelci:kernelci.org:66a1d0a38e8d1053a47e707c",
+  #     "duration": null,
+  #     "status": "PASS",
+  #     "path": "baseline.login",
+  #     "startTime": "2024-07-25T04:12:19.892Z"
+  #   },
+  #   {
+  #     "id": "kernelci:kernelci.org:66a1d0a38e8d1053a47e707e",
+  #     "duration": null,
+  #     "status": "PASS",
+  #     "path": "baseline.dmesg.emerg",
+  #     "startTime": "2024-07-25T04:12:19.927Z"
+  #   },
+  #   ...
+  # ]

--- a/dashboard/src/api/buildTests.ts
+++ b/dashboard/src/api/buildTests.ts
@@ -1,25 +1,20 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
-import { TBuildTests } from '@/types/general';
+import { TestHistory } from '@/types/general';
 
 import http from './api';
 
-const fetchBuildTestsData = async (
-  buildId: string,
-  path: string,
-): Promise<TBuildTests[]> => {
-  const params = path ? { path } : {};
-  const res = await http.get(`/api/build/${buildId}/tests`, { params });
+const fetchBuildTestsData = async (buildId: string): Promise<TestHistory[]> => {
+  const res = await http.get(`/api/build/${buildId}/tests`);
 
   return res.data;
 };
 
 export const useBuildTests = (
   buildId: string,
-  path = '',
-): UseQueryResult<TBuildTests[]> => {
+): UseQueryResult<TestHistory[]> => {
   return useQuery({
-    queryKey: ['buildTests', buildId, path],
-    queryFn: () => fetchBuildTestsData(buildId, path),
+    queryKey: ['buildTests', buildId],
+    queryFn: () => fetchBuildTestsData(buildId),
   });
 };

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTable.tsx
@@ -20,7 +20,6 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import {
   possibleTestsTableFilter,
   TestByCommitHash,
-  TestHistory,
   TestsTableFilter,
   TTestByCommitHashResponse,
 } from '@/types/tree/TreeDetails';
@@ -35,6 +34,8 @@ import {
   TableCellWithLink,
   TableRow,
 } from '@/components/ui/table';
+
+import { TestHistory } from '@/types/general';
 
 import BaseTable, { TableHead } from '@/components/Table/BaseTable';
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildsTable.tsx
@@ -127,7 +127,6 @@ const columns: ColumnDef<AccordionItemBuilds>[] = [
         intlDefaultMessage: 'Status',
         tooltipId: 'buildTab.statusTooltip',
       }),
-
     cell: ({ row }): JSX.Element => {
       return buildStatusMap[row.getValue('status') as keyof BuildStatus];
     },

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -1,11 +1,15 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useParams } from '@tanstack/react-router';
+import { useParams, useNavigate, useSearch } from '@tanstack/react-router';
+
+import { useCallback } from 'react';
 
 import { Skeleton } from '@/components/Skeleton';
 
 import { useTestsTab } from '@/api/TreeDetails';
 import BaseCard from '@/components/Cards/BaseCard';
+
+import { TestsTableFilter } from '@/types/tree/TreeDetails';
 
 import {
   MemoizedStatusChart,
@@ -34,6 +38,30 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
     treeId: treeId ?? '',
     filter: reqFilter,
   });
+
+  const { tableFilter } = useSearch({
+    from: '/tree/$treeId/',
+  });
+
+  const navigate = useNavigate({ from: '/tree/$treeId' });
+
+  const onClickFilter = useCallback(
+    (filter: TestsTableFilter): void => {
+      navigate({
+        search: previousParams => {
+          return {
+            ...previousParams,
+            tableFilter: {
+              bootsTable: previousParams.tableFilter.bootsTable,
+              buildsTable: previousParams.tableFilter.buildsTable,
+              testsTable: filter,
+            },
+          };
+        },
+      });
+    },
+    [navigate],
+  );
 
   if (error || !treeId) {
     return (
@@ -124,7 +152,11 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
         </InnerMobileGrid>
       </MobileGrid>
 
-      <TestsTable testHistory={data.testHistory} />
+      <TestsTable
+        testHistory={data.testHistory}
+        onClickFilter={onClickFilter}
+        tableFilter={tableFilter}
+      />
     </div>
   );
 };

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTable.tsx
@@ -13,17 +13,16 @@ import {
 } from '@tanstack/react-table';
 
 import { Fragment, useCallback, useMemo, useState } from 'react';
-import { useNavigate, useSearch } from '@tanstack/react-router';
 
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   possibleTestsTableFilter,
-  TestHistory,
+  TableFilter,
   TestsTableFilter,
 } from '@/types/tree/TreeDetails';
 
-import { TPathTests } from '@/types/general';
+import { TestHistory, TPathTests } from '@/types/general';
 
 import { StatusTable } from '@/utils/constants/database';
 
@@ -47,6 +46,8 @@ import { IndividualTestsTable } from './IndividualTestsTable';
 
 export interface ITestsTable {
   testHistory: TestHistory[];
+  onClickFilter: (filter: TestsTableFilter) => void;
+  tableFilter: TableFilter;
 }
 
 const columns: ColumnDef<TPathTests>[] = [
@@ -89,18 +90,18 @@ const columns: ColumnDef<TPathTests>[] = [
   },
 ];
 
-export function TestsTable({ testHistory }: ITestsTable): JSX.Element {
+export function TestsTable({
+  testHistory,
+  onClickFilter,
+  tableFilter,
+}: ITestsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: 10,
   });
-  const { tableFilter } = useSearch({
-    from: '/tree/$treeId/',
-  });
 
-  const navigate = useNavigate({ from: '/tree/$treeId' });
   const intl = useIntl();
 
   const rawData = useMemo((): TPathTests[] => {
@@ -226,24 +227,6 @@ export function TestsTable({ testHistory }: ITestsTable): JSX.Element {
 
       return count;
     }, [rawData]);
-
-  const onClickFilter = useCallback(
-    (filter: TestsTableFilter): void => {
-      navigate({
-        search: previousParams => {
-          return {
-            ...previousParams,
-            tableFilter: {
-              bootsTable: previousParams.tableFilter.bootsTable,
-              buildsTable: previousParams.tableFilter.buildsTable,
-              testsTable: filter,
-            },
-          };
-        },
-      });
-    },
-    [navigate],
-  );
 
   const filters = useMemo(
     () => [

--- a/dashboard/src/routes/tree/$treeId/build/$buildId/index.tsx
+++ b/dashboard/src/routes/tree/$treeId/build/$buildId/index.tsx
@@ -1,7 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+import { z } from 'zod';
+
 import BuildDetails from '@/pages/BuildDetails/BuildDetails';
+
+import { zTableFilterInfo } from '@/types/tree/TreeDetails';
+
+const buildDetailsSearchSchema = z.object({
+  tableFilter: zTableFilterInfo,
+});
 
 export const Route = createFileRoute('/tree/$treeId/build/$buildId/')({
   component: BuildDetails,
+  validateSearch: buildDetailsSearchSchema,
 });

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -44,3 +44,12 @@ export type TIssue = {
   report_url?: string;
   incidents_info: IncidentsInfo;
 };
+
+export type TestHistory = {
+  startTime: string;
+  status: Status;
+  path: string;
+  id: string;
+  duration?: number;
+  hardware?: string[];
+};

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -24,20 +24,6 @@ export type TIndividualTest = {
   hardware?: string[];
 };
 
-export type TBuildTests = {
-  current_path: string;
-  start_time: string;
-  origins: string[];
-  fail_tests: number;
-  error_tests: number;
-  miss_tests: number;
-  pass_tests: number;
-  done_tests: number;
-  skip_tests: number;
-  null_tests: number;
-  total_tests: number;
-};
-
 export type TIssue = {
   id: string;
   comment?: string;

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 
 import { MessagesKey } from '@/locales/messages';
 
-import { TIssue } from '@/types/general';
+import { TestHistory, TIssue } from '@/types/general';
 
 import type { Status } from '@/types/database';
 
@@ -78,15 +78,6 @@ export interface TTreeDetailsFilter
   }> {
   valid?: string[];
 }
-
-export type TestHistory = {
-  startTime: string;
-  status: Status;
-  path: string;
-  id: string;
-  duration?: number;
-  hardware?: string[];
-};
 
 type CompilersPerArchitecture = {
   [key: string]: string[];
@@ -183,6 +174,8 @@ export const zTableFilterInfo = object({
   bootsTable: zTestsTableFilterValidator,
   testsTable: zTestsTableFilterValidator,
 });
+
+export type TableFilter = z.infer<typeof zTableFilterInfo>;
 
 const zFilterBoolValue = z.record(z.boolean()).optional();
 const zFilterNumberValue = z.number().optional();


### PR DESCRIPTION
- make TestTable more flexible to reuse it on other pages
- use TestTable in BuildDetails page

Close: #386 

### How to tests:
Check out the `Test Results` section of a BuildDetails Page

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ef02e24f-007c-4355-9fa3-2077b422d6c1) | ![image](https://github.com/user-attachments/assets/c640416f-7bc6-4c88-97c0-851ac5996cd1) |
