### PR TITLE
feat: add count to tabs in tree details

### DIFF
--- a/backend/kernelCI_app/views/treeDetailsSlowView.py
+++ b/backend/kernelCI_app/views/treeDetailsSlowView.py
@@ -144,6 +144,8 @@ class TreeDetailsSlow(View):
         path = currentRow[tempColumnDict["tests_path"]]
         testId = currentRow[tempColumnDict["tests_id"]]
         testStatus = currentRow[tempColumnDict["tests_status"]]
+        if (testStatus is None):
+            testStatus = "NULL"
         testDuration = currentRow[tempColumnDict["tests_duration"]]
         buildConfig = currentRow[tempColumnDict["builds_config_name"]]
         buildArch = currentRow[tempColumnDict["builds_architecture"]]
@@ -255,10 +257,7 @@ class TreeDetailsSlow(View):
             self.bootFailReasons[testError] = self.bootFailReasons.get(testError, 0) + 1
 
         if testEnvironmentCompatible is not None:
-            if testStatus is None:
-                self.bootEnvironmentCompatible[testEnvironmentCompatible]["NULL"] += 1
-            else:
-                self.bootEnvironmentCompatible[testEnvironmentCompatible][testStatus] += 1
+            self.bootEnvironmentCompatible[testEnvironmentCompatible][testStatus] += 1
 
             self.incidentsIssueRelationship[incident_id]["incidentsCount"] += 1
 

--- a/dashboard/src/components/ColoredCircle/ColoredCircle.tsx
+++ b/dashboard/src/components/ColoredCircle/ColoredCircle.tsx
@@ -26,7 +26,7 @@ const TooltipWrapper = ({
   }
   return (
     <Tooltip>
-      <TooltipTrigger>{children}</TooltipTrigger>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
       {tooltipText && (
         <TooltipContent>{formatMessage({ id: tooltipText })}</TooltipContent>
       )}

--- a/dashboard/src/components/Status/Status.tsx
+++ b/dashboard/src/components/Status/Status.tsx
@@ -10,70 +10,8 @@ interface ITestStatus {
   skip?: number;
   nullStatus?: number;
   forceNumber?: boolean;
+  hideInconclusive?: boolean;
 }
-
-interface IBuildStatus {
-  valid?: number;
-  invalid?: number;
-  unknown?: number;
-}
-
-export const TestStatus = ({
-  pass,
-  error,
-  miss,
-  fail,
-  done,
-  skip,
-  forceNumber = true,
-}: ITestStatus): JSX.Element => {
-  return (
-    <div className="flex flex-row gap-1">
-      {(forceNumber || Boolean(pass)) && (
-        <ColoredCircle
-          quantity={pass ?? 0}
-          tooltipText="global.pass"
-          backgroundClassName="bg-lightGreen"
-        />
-      )}
-      {(forceNumber || Boolean(error)) && (
-        <ColoredCircle
-          quantity={error ?? 0}
-          tooltipText="global.error"
-          backgroundClassName="bg-lightRed"
-        />
-      )}
-      {(forceNumber || Boolean(miss)) && (
-        <ColoredCircle
-          quantity={miss ?? 0}
-          tooltipText="global.missed"
-          backgroundClassName="bg-lightGray"
-        />
-      )}
-      {(forceNumber || Boolean(fail)) && (
-        <ColoredCircle
-          quantity={fail ?? 0}
-          tooltipText="global.failed"
-          backgroundClassName="bg-yellow"
-        />
-      )}
-      {(forceNumber || Boolean(done)) && (
-        <ColoredCircle
-          quantity={done ?? 0}
-          tooltipText="global.done"
-          backgroundClassName="bg-lightBlue"
-        />
-      )}
-      {(forceNumber || Boolean(skip)) && (
-        <ColoredCircle
-          quantity={skip ?? 0}
-          tooltipText="global.skipped"
-          backgroundClassName="bg-mediumGray"
-        />
-      )}
-    </div>
-  );
-};
 
 export const GroupedTestStatus = ({
   pass,
@@ -83,6 +21,7 @@ export const GroupedTestStatus = ({
   done,
   skip,
   nullStatus,
+  hideInconclusive = false,
 }: ITestStatus): JSX.Element => {
   const { successCount, inconclusiveCount, failedCount } = groupStatus({
     doneCount: done ?? 0,
@@ -109,21 +48,29 @@ export const GroupedTestStatus = ({
           backgroundClassName="bg-lightRed"
         />
       }
-      {
+      {!hideInconclusive && (
         <ColoredCircle
           quantity={inconclusiveCount ?? 0}
           tooltipText="global.inconclusive"
           backgroundClassName="bg-mediumGray"
         />
-      }
+      )}
     </div>
   );
 };
+
+interface IBuildStatus {
+  valid?: number;
+  invalid?: number;
+  unknown?: number;
+  hideInconclusive?: boolean;
+}
 
 export const BuildStatus = ({
   valid,
   invalid,
   unknown,
+  hideInconclusive = false,
 }: IBuildStatus): JSX.Element => {
   return (
     <div className="flex flex-row gap-1">
@@ -137,11 +84,13 @@ export const BuildStatus = ({
         backgroundClassName="bg-lightRed"
         tooltipText="global.failed"
       />
-      <ColoredCircle
-        quantity={unknown ?? 0}
-        tooltipText="global.inconclusive"
-        backgroundClassName="bg-lightGray"
-      />
+      {!hideInconclusive && (
+        <ColoredCircle
+          quantity={unknown ?? 0}
+          tooltipText="global.inconclusive"
+          backgroundClassName="bg-lightGray"
+        />
+      )}
     </div>
   );
 };

--- a/dashboard/src/components/Tabs/Tabs.tsx
+++ b/dashboard/src/components/Tabs/Tabs.tsx
@@ -9,6 +9,7 @@ export interface ITabItem {
   name: MessagesKey;
   content: ReactElement;
   disabled?: boolean;
+  rightElement?: ReactElement;
 }
 
 type TabsProp = ComponentProps<typeof Tabs>;
@@ -37,7 +38,8 @@ const TabsComponent = ({
           key={tab.name}
           value={tab.name}
         >
-          <FormattedMessage id={tab.name} />
+          <FormattedMessage id={tab.name} />{' '}
+          <div className="pl-2">{tab.rightElement}</div>
         </TabsTrigger>
       )),
     [tabs],

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -38,7 +38,7 @@ const ConfigsList = ({
       content={
         <DumbListingContent>
           {Object.keys(configStatusCounts).map(configName => {
-            const { DONE, FAIL, ERROR, MISS, PASS, SKIP } =
+            const { DONE, FAIL, ERROR, MISS, PASS, SKIP, NULL } =
               configStatusCounts[configName];
             return (
               <FilterLink
@@ -58,7 +58,7 @@ const ConfigsList = ({
                       miss={MISS}
                       pass={PASS}
                       skip={SKIP}
-                      forceNumber={false}
+                      nullStatus={NULL}
                     />
                   }
                 />
@@ -185,6 +185,7 @@ const ErrorsSummary = ({
                     miss={statusCounts.MISS}
                     pass={statusCounts.PASS}
                     skip={statusCounts.SKIP}
+                    nullStatus={statusCounts.NULL}
                   />
                 }
                 compilers={currentCompilers}
@@ -211,6 +212,7 @@ const StatusChart = ({ statusCounts, title }: IStatusChart): JSX.Element => {
     missCount: statusCounts.MISS ?? 0,
     passCount: statusCounts.PASS ?? 0,
     skipCount: statusCounts.SKIP ?? 0,
+    nullCount: statusCounts.NULL ?? 0,
   });
 
   const chartElements = [

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -1,6 +1,6 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
-import { useCallback } from 'react';
+import { ReactElement, useCallback } from 'react';
 
 import Tabs, { ITabItem } from '@/components/Tabs/Tabs';
 
@@ -8,20 +8,32 @@ import { zPossibleValidator } from '@/types/tree/TreeDetails';
 
 import { ITreeDetails } from '@/pages/TreeDetails/TreeDetails';
 
+import { MessagesKey } from '@/locales/messages';
+
 import BuildTab from './Build';
 import BootsTab from './Boots';
 import TestsTab from './Tests';
+
+export type TreeDetailsTabRightElement = Record<
+  Extract<
+    MessagesKey,
+    'treeDetails.builds' | 'treeDetails.boots' | 'treeDetails.tests'
+  >,
+  ReactElement
+>;
 
 export interface ITreeDetailsTab {
   treeDetailsData?: ITreeDetails;
   filterListElement?: JSX.Element;
   reqFilter: Record<string, string[]>;
+  countElements: TreeDetailsTabRightElement;
 }
 
 const TreeDetailsTab = ({
   treeDetailsData,
   filterListElement,
   reqFilter,
+  countElements,
 }: ITreeDetailsTab): JSX.Element => {
   const { currentTreeDetailsTab } = useSearch({
     from: '/tree/$treeId/',
@@ -31,18 +43,21 @@ const TreeDetailsTab = ({
     name: 'treeDetails.builds',
     content: <BuildTab treeDetailsData={treeDetailsData} />,
     disabled: false,
+    rightElement: countElements['treeDetails.builds'],
   };
 
   const bootsTab: ITabItem = {
     name: 'treeDetails.boots',
     content: <BootsTab reqFilter={reqFilter} />,
     disabled: false,
+    rightElement: countElements['treeDetails.boots'],
   };
 
   const testsTab: ITabItem = {
     name: 'treeDetails.tests',
     content: <TestsTab reqFilter={reqFilter} />,
     disabled: false,
+    rightElement: countElements['treeDetails.tests'],
   };
 
   const onValueChange: (value: string) => void = useCallback(

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -36,8 +36,15 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 
+import {
+  BuildStatus as BuildStatusComponent,
+  GroupedTestStatus,
+} from '@/components/Status/Status';
+
 import TreeDetailsFilter, { mapFilterToReq } from './TreeDetailsFilter';
-import TreeDetailsTab from './Tabs/TreeDetailsTab';
+import TreeDetailsTab, {
+  TreeDetailsTabRightElement,
+} from './Tabs/TreeDetailsTab';
 
 import TreeDetailsFilterList from './TreeDetailsFilterList';
 import { MemoizedHardwareUsed } from './Tabs/TestCards';
@@ -146,6 +153,43 @@ function TreeDetails(): JSX.Element {
     () => <TreeDetailsFilterList filter={diffFilter} />,
     [diffFilter],
   );
+
+  const tabsCounts: TreeDetailsTabRightElement = useMemo(() => {
+    const { valid, invalid } = buildData?.summary.builds ?? {};
+    const { testStatusSummary } = testsData ?? {};
+
+    const { bootStatusSummary } = testsData ?? {};
+
+    return {
+      'treeDetails.tests': testStatusSummary ? (
+        <GroupedTestStatus
+          fail={testStatusSummary.FAIL}
+          pass={testStatusSummary.PASS}
+          hideInconclusive
+        />
+      ) : (
+        <></>
+      ),
+      'treeDetails.boots': bootStatusSummary ? (
+        <GroupedTestStatus
+          fail={bootStatusSummary.FAIL}
+          pass={bootStatusSummary.PASS}
+          hideInconclusive
+        />
+      ) : (
+        <></>
+      ),
+      'treeDetails.builds': buildData ? (
+        <BuildStatusComponent
+          valid={valid}
+          invalid={invalid}
+          hideInconclusive
+        />
+      ) : (
+        <></>
+      ),
+    };
+  }, [buildData, testsData]);
 
   //TODO: at some point `treeUrl` should be returned in `data`
   const treeUrl = useMemo(() => {
@@ -271,6 +315,7 @@ function TreeDetails(): JSX.Element {
           treeDetailsData={treeDetailsData}
           filterListElement={filterListElement}
           reqFilter={reqFilter}
+          countElements={tabsCounts}
         />
       </div>
     </div>


### PR DESCRIPTION
# Description
Add count to tabs in tree details and also fix the tree detail endpoint null count for test status

## How to test
Go to any tree details and you should see this

![image](https://github.com/user-attachments/assets/869f3e2b-95fc-444d-a646-7a3580d5338e)

Closes #391
