### PR TITLE
fix: build time table cell display

### DIFF
--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildsTable.tsx
@@ -116,6 +116,9 @@ const columns: ColumnDef<AccordionItemBuilds>[] = [
         intlKey: 'treeDetails.buildTime',
         intlDefaultMessage: 'Build Time',
       }),
+    cell: ({ row }): JSX.Element => {
+      return row.getValue('buildTime');
+    },
   },
   {
     accessorKey: 'status',


### PR DESCRIPTION
Fixes the display of "buildTime" in the build details table.

Before: 
![image](https://github.com/user-attachments/assets/43009d9c-0341-49d3-b655-caea7ca57d05)
After:
![image](https://github.com/user-attachments/assets/bfe8bd32-7949-4581-9ff0-ab8db0fd06c4)

Test URL: http://localhost:5173/tree/59cbd4eea48fdbc68fc17a29ad71188fea74b28b?tableFilter={%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22failed%22}&origin=redhat&currentTreeDetailsTab=treeDetails.builds&diffFilter={}&treeInfo={%22gitBranch%22%3A%22master%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Fvirt%2Fkvm%2Fkvm.git%22%2C%22treeName%22%3A%22kvm%22%2C%22commitName%22%3A%22for-linus-1-g59cbd4eea48f%22%2C%22headCommitHash%22%3A%2259cbd4eea48fdbc68fc17a29ad71188fea74b28b%22}

Closes #455 