### PR TITLE
Add filter by hardware in History Chart

### DIFF
--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -124,6 +124,7 @@ class FilterParams:
             if len(request.GET.getlist(k)) > 1:
                 field = filter_term
                 values = request.GET.getlist(k)
+
                 for value in values:
                     self.add_filter(field, value, "in")
                 continue

--- a/dashboard/src/api/TreeDetails.tsx
+++ b/dashboard/src/api/TreeDetails.tsx
@@ -265,16 +265,19 @@ const fetchTreeCommitHistory = async (
   filters: TTreeDetailsFilter,
 ): Promise<TTreeCommitHistoryResponse> => {
   // TODO: remove deprecated function
-  const searchParam = mapFiltersToUrlSearchParams(filters);
+  const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
 
-  searchParam.append('origin', origin);
-  searchParam.append('git_url', gitUrl);
-  searchParam.append('git_branch', gitBranch);
+  const params = {
+    origin,
+    git_url: gitUrl,
+    git_branch: gitBranch,
+    ...filtersFormatted,
+  };
 
   const res = await http.get<TTreeCommitHistoryResponse>(
     `/api/tree/${commitHash}/commits`,
     {
-      params: searchParam,
+      params,
     },
   );
   return res.data;


### PR DESCRIPTION
**How to test**

Go to Tree Details, in Boots or Tests tabs and apply hardwere filters.

Ex.: http://localhost:5173/tree/1bf329c696cf80000f1098bcdc23534e6fe14fe2?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.boots&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.12-rc5-145-g1bf329c696cf%22%2C%22headCommitHash%22%3A%221bf329c696cf80000f1098bcdc23534e6fe14fe2%22%7D

Close #430