### PR TITLE
Fix History Chart Filter

### DIFF
--- a/dashboard/src/pages/TreeDetails/Tabs/CommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/CommitNavigationGraph.tsx
@@ -130,7 +130,8 @@ const CommitNavigationGraph = (): JSX.Element => {
         item.boots_tests.miss_count +
         item.boots_tests.skip_count +
         item.boots_tests.error_count +
-        item.boots_tests.done_count;
+        item.boots_tests.done_count +
+        item.boots_tests.null_count;
       series[0].data?.unshift(item.boots_tests.pass_count);
       series[1].data?.unshift(item.boots_tests.fail_count);
       series[2].data?.unshift(inconclusiveCount);
@@ -140,7 +141,8 @@ const CommitNavigationGraph = (): JSX.Element => {
         item.non_boots_tests.miss_count +
         item.non_boots_tests.skip_count +
         item.non_boots_tests.error_count +
-        item.non_boots_tests.done_count;
+        item.non_boots_tests.done_count +
+        item.non_boots_tests.null_count;
       series[0].data?.unshift(item.non_boots_tests.pass_count);
       series[1].data?.unshift(item.non_boots_tests.fail_count);
       series[2].data?.unshift(inconclusiveCount);

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -275,6 +275,7 @@ export type PaginatedCommitHistoryByTree = {
     pass_count: number;
     done_count: number;
     skip_count: number;
+    null_count: number;
   };
   non_boots_tests: {
     fail_count: number;
@@ -283,6 +284,7 @@ export type PaginatedCommitHistoryByTree = {
     pass_count: number;
     done_count: number;
     skip_count: number;
+    null_count: number;
   };
 };
 


### PR DESCRIPTION
Add null tests count

**How to test**
Compare [localhost](http://localhost:5173/tree/1bf329c696cf80000f1098bcdc23534e6fe14fe2?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%22testStatus%22%3A%7B%22NULL%22%3Atrue%7D%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.12-rc5-145-g1bf329c696cf%22%2C%22headCommitHash%22%3A%221bf329c696cf80000f1098bcdc23534e6fe14fe2%22%7D)  with [dashboard](https://dashboard.kernelci.org/tree/1bf329c696cf80000f1098bcdc23534e6fe14fe2?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%22testStatus%22%3A%7B%22NULL%22%3Atrue%7D%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.12-rc5-145-g1bf329c696cf%22%2C%22headCommitHash%22%3A%221bf329c696cf80000f1098bcdc23534e6fe14fe2%22%7D)

Close #485