### PR TITLE
Feat: count unknown stats

### DIFF
--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -97,9 +97,9 @@ export const createFilter = (
 
   if (data)
     data.builds.forEach(b => {
-      if (b.config_name) configs[b.config_name] = false;
-      if (b.architecture) archs[b.architecture] = false;
-      if (b.compiler) compilers[b.compiler] = false;
+      configs[b.config_name ?? 'Unknown'] = false;
+      archs[b.architecture ?? 'Unknown'] = false;
+      compilers[b.compiler ?? 'Unknown'] = false;
     });
 
   if (testData) testData.hardwareUsed.forEach(h => (hardware[h] = false));


### PR DESCRIPTION
Shows unknown hardware, configs, archs and compilers in the cards for tests and boots tab.

## How to test:
Go to http://localhost:5173/tree/1bf329c696cf80000f1098bcdc23534e6fe14fe2?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.12-rc5-145-g1bf329c696cf%22%2C%22headCommitHash%22%3A%221bf329c696cf80000f1098bcdc23534e6fe14fe2%22%7D
And see the listing of unknown configs, archs and hardwares, try clicking on the configs/archs for filtering or using the filters button.
Compare to the current state at https://staging.dashboard.kernelci.org:9000/tree/1bf329c696cf80000f1098bcdc23534e6fe14fe2?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.tests&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.12-rc5-145-g1bf329c696cf%22%2C%22headCommitHash%22%3A%221bf329c696cf80000f1098bcdc23534e6fe14fe2%22%7D

Closes #464 