### PR TITLE
Feat: clickable hardware filter

### DIFF
--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -96,22 +96,28 @@ const HardwareTested = ({
                 environmentCompatible[hardwareTestedName];
 
               return (
-                <ListingItem
-                  hasBottomBorder
+                <FilterLink
                   key={hardwareTestedName}
-                  text={hardwareTestedName}
-                  leftIcon={
-                    <GroupedTestStatus
-                      done={DONE}
-                      fail={FAIL}
-                      error={ERROR}
-                      miss={MISS}
-                      pass={PASS}
-                      skip={SKIP}
-                      nullStatus={NULL}
-                    />
-                  }
-                />
+                  filterSection="hardware"
+                  filterValue={hardwareTestedName}
+                >
+                  <ListingItem
+                    hasBottomBorder
+                    key={hardwareTestedName}
+                    text={hardwareTestedName}
+                    leftIcon={
+                      <GroupedTestStatus
+                        done={DONE}
+                        fail={FAIL}
+                        error={ERROR}
+                        miss={MISS}
+                        pass={PASS}
+                        skip={SKIP}
+                        nullStatus={NULL}
+                      />
+                    }
+                  />
+                </FilterLink>
               );
             })}
           </DumbListingContent>


### PR DESCRIPTION
Adds a FilterLink wrapper around hardware items in the hardware card for the boots and tests tab.

Test by going to any tree with boots or tests data (that have a hardware linked to any of them), see the "hardware tested" card and click on any item to filter the data by hardware. [Localhost example](http://localhost:5173/tree/1bf329c696cf80000f1098bcdc23534e6fe14fe2?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentTreeDetailsTab=treeDetails.boots&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-kernelci%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Farm64%2Flinux.git%22%2C%22treeName%22%3A%22arm64%22%2C%22commitName%22%3A%22v6.12-rc5-145-g1bf329c696cf%22%2C%22headCommitHash%22%3A%221bf329c696cf80000f1098bcdc23534e6fe14fe2%22%7D).

Closes #454 