### PR TITLE
Feat/add hardware build tab

### DIFF
--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -32,6 +32,7 @@ def get_build(record):
         "start_time": record["build_start_time"],
         "git_repository_url": record["checkout_git_repository_url"],
         "git_repository_branch": record["checkout_git_repository_branch"],
+        "tree_name": record["checkout_tree_name"],
     }
 
 
@@ -152,6 +153,7 @@ class HardwareDetails(View):
             build_start_time=F("build__start_time"),
             checkout_git_repository_url=F("build__checkout__git_repository_url"),
             checkout_git_repository_branch=F("build__checkout__git_repository_branch"),
+            checkout_tree_name=F("build__checkout__tree_name"),
             issue_id=F("build__incidents__issue__id"),
             issue_comment=F("build__incidents__issue__comment"),
             issue_report_url=F("build__incidents__issue__report_url"),

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -1,0 +1,28 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+
+import http from './api';
+
+const fetchHardwareDetails = async (
+  hardwareId: string,
+  daysInterval: number,
+): Promise<THardwareDetails> => {
+  const params = { daysInterval };
+  const res = await http.get<THardwareDetails>(`/api/hardware/${hardwareId}`, {
+    params,
+  });
+
+  return res.data;
+};
+
+export const useHardwareDetails = (
+  hardwareId: string,
+  daysInterval: number,
+): UseQueryResult<THardwareDetails> => {
+  return useQuery({
+    queryKey: ['HardwareDetails', hardwareId, daysInterval],
+    queryFn: () => fetchHardwareDetails(hardwareId, daysInterval),
+  });
+};

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -14,14 +14,17 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 
-import type { ReactElement } from 'react';
-import { Fragment, useCallback, useMemo, useState } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { MdCheck, MdClose } from 'react-icons/md';
-
+import DebounceInput from '@/components/DebounceInput/DebounceInput';
+import BaseTable, { TableHead } from '@/components/Table/BaseTable';
+import { PaginationInfo } from '@/components/Table/PaginationInfo';
+import TableStatusFilter from '@/components/Table/TableStatusFilter';
+import { TableBody, TableCell, TableRow } from '@/components/ui/table';
+import AccordionBuildContent from '@/pages/TreeDetails/Tabs/Build/BuildAccordionContent';
 import type {
   AccordionItemBuilds,
   BuildsTableFilter,
@@ -30,119 +33,16 @@ import {
   possibleBuildsTableFilter,
   zBuildsTableFilterValidator,
 } from '@/types/tree/TreeDetails';
-import { TableHeader } from '@/components/Table/TableHeader';
-import TableStatusFilter from '@/components/Table/TableStatusFilter';
-import BaseTable, { TableHead } from '@/components/Table/BaseTable';
-import { TableBody, TableCell, TableRow } from '@/components/ui/table';
-import { PaginationInfo } from '@/components/Table/PaginationInfo';
-import { TooltipDateTime } from '@/components/TooltipDateTime';
-import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
-import { ItemType } from '@/components/ListingItem/ListingItem';
-import AccordionBuildContent from '@/pages/TreeDetails/Tabs/Build/BuildAccordionContent';
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 
 export interface IBuildsTable {
   buildItems: AccordionItemBuilds[];
+  columns: ColumnDef<AccordionItemBuilds>[];
 }
 
-type BuildStatus = Record<AccordionItemBuilds['status'], ReactElement>;
-
-const buildStatusMap: BuildStatus = {
-  valid: <MdCheck className="text-green" />,
-  invalid: <MdClose className="text-red" />,
-  null: <span>-</span>,
-};
-
-const columns: ColumnDef<AccordionItemBuilds>[] = [
-  {
-    accessorKey: 'config',
-    header: ({ column }): JSX.Element =>
-      TableHeader({
-        column: column,
-        sortable: true,
-        intlKey: 'treeDetails.config',
-        intlDefaultMessage: 'Config',
-      }),
-  },
-  {
-    accessorKey: 'compiler',
-    header: ({ column }): JSX.Element =>
-      TableHeader({
-        column: column,
-        sortable: true,
-        intlKey: 'treeDetails.compiler',
-        intlDefaultMessage: 'Compiler',
-      }),
-  },
-  {
-    accessorKey: 'date',
-    header: ({ column }): JSX.Element =>
-      TableHeader({
-        column: column,
-        sortable: true,
-        intlKey: 'treeDetails.date',
-        intlDefaultMessage: 'Date',
-      }),
-    cell: ({ row }): JSX.Element => (
-      <TooltipDateTime
-        dateTime={row.getValue('date')}
-        lineBreak={true}
-        showLabelTime={true}
-        showLabelTZ={true}
-      />
-    ),
-  },
-  {
-    accessorKey: 'buildErrors',
-    header: ({ column }): JSX.Element =>
-      TableHeader({
-        column: column,
-        sortable: true,
-        intlKey: 'treeDetails.buildErrors',
-        intlDefaultMessage: 'Build Errors',
-      }),
-    cell: ({ row }): JSX.Element => (
-      <ColoredCircle
-        className="max-w-6"
-        quantity={row.getValue('buildErrors')}
-        backgroundClassName={
-          (row.getValue('buildErrors') as number) > 0
-            ? ItemType.Error
-            : ItemType.None
-        }
-      />
-    ),
-  },
-  {
-    accessorKey: 'buildTime',
-    header: ({ column }): JSX.Element =>
-      TableHeader({
-        column: column,
-        sortable: true,
-        intlKey: 'treeDetails.buildTime',
-        intlDefaultMessage: 'Build Time',
-      }),
-    cell: ({ row }): JSX.Element => {
-      return row.getValue('buildTime');
-    },
-  },
-  {
-    accessorKey: 'status',
-    header: ({ column }): JSX.Element =>
-      TableHeader({
-        column: column,
-        sortable: true,
-        intlKey: 'treeDetails.status',
-        intlDefaultMessage: 'Status',
-        tooltipId: 'buildTab.statusTooltip',
-      }),
-    cell: ({ row }): JSX.Element => {
-      return buildStatusMap[row.getValue('status') as keyof BuildStatus];
-    },
-  },
-];
-
-export function BuildsTable({ buildItems }: IBuildsTable): JSX.Element {
+export function BuildsTable({
+  buildItems,
+  columns,
+}: IBuildsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [pagination, setPagination] = useState<PaginationState>({
@@ -336,7 +236,7 @@ export function BuildsTable({ buildItems }: IBuildsTable): JSX.Element {
         </TableRow>
       );
     }
-  }, [modelRows]);
+  }, [columns.length, modelRows]);
 
   return (
     <div className="flex flex-col gap-6 pb-4">

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -153,6 +153,7 @@ export const messages = {
     'global.unknown': 'Unknown',
     'global.url': 'URL',
     'global.valid': 'Valid',
+    'hardwareDetails.treeBranch': 'Tree / Branch',
     'issue.failedToFetch': 'Failed to fetch issues',
     'issue.noIssueFound': 'No issue found.',
     'logSheet.errorsFound': 'Errors found on Kernel.log',

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -33,16 +33,17 @@ interface BuildTab {
 }
 
 const StatusCard = ({
-  treeDetailsData,
+  buildsSummary,
   toggleFilterBySection,
 }: {
   toggleFilterBySection: (
     value: string,
     filterSection: TFilterObjectsKeys,
   ) => void;
-  treeDetailsData?: ITreeDetails;
+  buildsSummary?: ITreeDetails['buildsSummary'];
 }): JSX.Element => {
   const { formatMessage } = useIntl();
+  if (!buildsSummary) return <></>;
   return (
     <BaseCard
       title={formatMessage({ id: 'treeDetails.buildStatus' })}
@@ -52,9 +53,9 @@ const StatusCard = ({
           pieCentralLabel={formatMessage({ id: 'treeDetails.executed' })}
           pieCentralDescription={
             <>
-              {(treeDetailsData?.buildsSummary.invalid ?? 0) +
-                (treeDetailsData?.buildsSummary.valid ?? 0) +
-                (treeDetailsData?.buildsSummary.null ?? 0)}
+              {(buildsSummary.invalid ?? 0) +
+                (buildsSummary.valid ?? 0) +
+                (buildsSummary.null ?? 0)}
             </>
           }
           onLegendClick={(value: string) => {
@@ -62,17 +63,17 @@ const StatusCard = ({
           }}
           elements={[
             {
-              value: treeDetailsData?.buildsSummary.valid ?? 0,
+              value: buildsSummary.valid ?? 0,
               label: 'treeDetails.success',
               color: Colors.Green,
             },
             {
-              value: treeDetailsData?.buildsSummary.invalid ?? 0,
+              value: buildsSummary.invalid ?? 0,
               label: 'treeDetails.failed',
               color: Colors.Red,
             },
             {
-              value: treeDetailsData?.buildsSummary.null ?? 0,
+              value: buildsSummary.null ?? 0,
               label: 'global.inconclusive',
               color: Colors.Gray,
             },
@@ -83,12 +84,13 @@ const StatusCard = ({
   );
 };
 
-const MemoizedStatusCard = memo(StatusCard);
+//TODO: put it in other file to be reused
+export const MemoizedStatusCard = memo(StatusCard);
 
 const ConfigsCard = ({
-  treeDetailsData,
+  configs,
 }: {
-  treeDetailsData?: ITreeDetails;
+  configs: ITreeDetails['configs'];
   toggleFilterBySection: (
     value: string,
     filterSection: TFilterObjectsKeys,
@@ -97,7 +99,7 @@ const ConfigsCard = ({
   const content = useMemo(() => {
     return (
       <DumbListingContent>
-        {treeDetailsData?.configs.map((item, i) => (
+        {configs.map((item, i) => (
           <FilterLink key={i} filterSection="configs" filterValue={item.text}>
             <ListingItem
               text={item.text}
@@ -113,7 +115,7 @@ const ConfigsCard = ({
         ))}
       </DumbListingContent>
     );
-  }, [treeDetailsData?.configs]);
+  }, [configs]);
 
   return (
     <BaseCard
@@ -122,7 +124,8 @@ const ConfigsCard = ({
     />
   );
 };
-const MemoizedConfigsCard = memo(ConfigsCard);
+//TODO: put it in other file to be reused
+export const MemoizedConfigsCard = memo(ConfigsCard);
 
 const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
   const navigate = useNavigate({
@@ -160,7 +163,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
         <div>
           <MemoizedStatusCard
             toggleFilterBySection={toggleFilterBySection}
-            treeDetailsData={treeDetailsData}
+            buildsSummary={treeDetailsData.buildsSummary}
           />
           <MemoizedErrorsSummaryBuild
             summaryBody={treeDetailsData.architectures}
@@ -174,7 +177,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
         <div>
           <CommitNavigationGraph />
           <MemoizedConfigsCard
-            treeDetailsData={treeDetailsData}
+            configs={treeDetailsData.configs}
             toggleFilterBySection={toggleFilterBySection}
           />
         </div>
@@ -183,7 +186,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
         <CommitNavigationGraph />
         <MemoizedStatusCard
           toggleFilterBySection={toggleFilterBySection}
-          treeDetailsData={treeDetailsData}
+          buildsSummary={treeDetailsData.buildsSummary}
         />
         <InnerMobileGrid>
           <MemoizedErrorsSummaryBuild
@@ -191,7 +194,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
             toggleFilterBySection={toggleFilterBySection}
           />
           <MemoizedConfigsCard
-            treeDetailsData={treeDetailsData}
+            configs={treeDetailsData.configs}
             toggleFilterBySection={toggleFilterBySection}
           />
         </InnerMobileGrid>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -29,7 +29,7 @@ import { DesktopGrid, InnerMobileGrid, MobileGrid } from '../TabGrid';
 import { BuildsTable } from './BuildsTable';
 
 interface BuildTab {
-  treeDetailsData?: ITreeDetails;
+  treeDetailsData: ITreeDetails;
 }
 
 const StatusCard = ({
@@ -163,12 +163,12 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
             treeDetailsData={treeDetailsData}
           />
           <MemoizedErrorsSummaryBuild
-            summaryBody={treeDetailsData?.archs ?? []}
+            summaryBody={treeDetailsData.architectures}
             toggleFilterBySection={toggleFilterBySection}
           />
           <MemoizedIssuesList
             title={<FormattedMessage id="global.issues" />}
-            issues={treeDetailsData?.issues || []}
+            issues={treeDetailsData.issues || []}
           />
         </div>
         <div>
@@ -187,7 +187,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
         />
         <InnerMobileGrid>
           <MemoizedErrorsSummaryBuild
-            summaryBody={treeDetailsData?.archs ?? []}
+            summaryBody={treeDetailsData.architectures}
             toggleFilterBySection={toggleFilterBySection}
           />
           <MemoizedConfigsCard
@@ -197,7 +197,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
         </InnerMobileGrid>
         <MemoizedIssuesList
           title={<FormattedMessage id="global.issues" />}
-          issues={treeDetailsData?.issues || []}
+          issues={treeDetailsData.issues}
         />
       </MobileGrid>
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -26,7 +26,7 @@ import FilterLink from '@/pages/TreeDetails/TreeDetailsFilterLink';
 
 import { DesktopGrid, InnerMobileGrid, MobileGrid } from '../TabGrid';
 
-import { BuildsTable } from './BuildsTable';
+import { TreeDetailsBuildsTable } from './TreeDetailsBuildsTable';
 
 interface BuildTab {
   treeDetailsData: ITreeDetails;
@@ -210,7 +210,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
             <FormattedMessage id="treeDetails.builds" />
           </div>
 
-          <BuildsTable buildItems={treeDetailsData.builds} />
+          <TreeDetailsBuildsTable buildItems={treeDetailsData.builds} />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildsTable.tsx
@@ -26,7 +26,10 @@ import type {
   AccordionItemBuilds,
   BuildsTableFilter,
 } from '@/types/tree/TreeDetails';
-import { possibleBuildsTableFilter } from '@/types/tree/TreeDetails';
+import {
+  possibleBuildsTableFilter,
+  zBuildsTableFilterValidator,
+} from '@/types/tree/TreeDetails';
 import { TableHeader } from '@/components/Table/TableHeader';
 import TableStatusFilter from '@/components/Table/TableStatusFilter';
 import BaseTable, { TableHead } from '@/components/Table/BaseTable';
@@ -146,10 +149,11 @@ export function BuildsTable({ buildItems }: IBuildsTable): JSX.Element {
     pageIndex: 0,
     pageSize: 10,
   });
-  const { tableFilter } = useSearch({
-    from: '/tree/$treeId/',
+  const { tableFilter: unsafeTableFilter } = useSearch({
+    strict: false,
   });
-  const selectedFilter = tableFilter.buildsTable;
+
+  const selectedFilter = zBuildsTableFilterValidator.parse(unsafeTableFilter);
 
   const navigate = useNavigate({ from: '/tree/$treeId' });
   const intl = useIntl();

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -1,0 +1,119 @@
+import type { ColumnDef } from '@tanstack/react-table';
+
+import type { ReactElement } from 'react';
+
+import { MdCheck, MdClose } from 'react-icons/md';
+
+import { BuildsTable } from '@/components/BuildsTable/BuildsTable';
+import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
+import { ItemType } from '@/components/ListingItem/ListingItem';
+import { TableHeader } from '@/components/Table/TableHeader';
+import { TooltipDateTime } from '@/components/TooltipDateTime';
+import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
+
+export interface TTreeDetailsBuildsTable {
+  buildItems: AccordionItemBuilds[];
+}
+
+type BuildStatus = Record<AccordionItemBuilds['status'], ReactElement>;
+
+const buildStatusMap: BuildStatus = {
+  valid: <MdCheck className="text-green" />,
+  invalid: <MdClose className="text-red" />,
+  null: <span>-</span>,
+};
+
+const columns: ColumnDef<AccordionItemBuilds>[] = [
+  {
+    accessorKey: 'config',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.config',
+        intlDefaultMessage: 'Config',
+      }),
+  },
+  {
+    accessorKey: 'compiler',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.compiler',
+        intlDefaultMessage: 'Compiler',
+      }),
+  },
+  {
+    accessorKey: 'date',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.date',
+        intlDefaultMessage: 'Date',
+      }),
+    cell: ({ row }): JSX.Element => (
+      <TooltipDateTime
+        dateTime={row.getValue('date')}
+        lineBreak={true}
+        showLabelTime={true}
+        showLabelTZ={true}
+      />
+    ),
+  },
+  {
+    accessorKey: 'buildErrors',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.buildErrors',
+        intlDefaultMessage: 'Build Errors',
+      }),
+    cell: ({ row }): JSX.Element => (
+      <ColoredCircle
+        className="max-w-6"
+        quantity={row.getValue('buildErrors')}
+        backgroundClassName={
+          (row.getValue('buildErrors') as number) > 0
+            ? ItemType.Error
+            : ItemType.None
+        }
+      />
+    ),
+  },
+  {
+    accessorKey: 'buildTime',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.buildTime',
+        intlDefaultMessage: 'Build Time',
+      }),
+    cell: ({ row }): JSX.Element => {
+      return row.getValue('buildTime');
+    },
+  },
+  {
+    accessorKey: 'status',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.status',
+        intlDefaultMessage: 'Status',
+        tooltipId: 'buildTab.statusTooltip',
+      }),
+    cell: ({ row }): JSX.Element => {
+      return buildStatusMap[row.getValue('status') as keyof BuildStatus];
+    },
+  },
+];
+
+export function TreeDetailsBuildsTable({
+  buildItems,
+}: TTreeDetailsBuildsTable): JSX.Element {
+  return <BuildsTable buildItems={buildItems} columns={columns} />;
+}

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -25,7 +25,7 @@ export type TreeDetailsTabRightElement = Record<
 >;
 
 export interface ITreeDetailsTab {
-  treeDetailsData?: ITreeDetails;
+  treeDetailsData: ITreeDetails;
   filterListElement?: JSX.Element;
   reqFilter: Record<string, string[]>;
   countElements: TreeDetailsTabRightElement;

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -6,11 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import { useBuildsTab, useTestsTab } from '@/api/TreeDetails';
 import type { IListingItem } from '@/components/ListingItem/ListingItem';
 import type { ISummaryItem } from '@/components/Summary/Summary';
-import type {
-  AccordionItemBuilds,
-  BuildStatus,
-  BuildsTab,
-} from '@/types/tree/TreeDetails';
+import type { AccordionItemBuilds, BuildsTab } from '@/types/tree/TreeDetails';
 import { Skeleton } from '@/components/Skeleton';
 import {
   Breadcrumb,
@@ -46,6 +42,8 @@ import {
   sanitizeBuildsSummary,
   sanitizeConfigs,
 } from '@/utils/utils';
+
+import type { BuildStatus } from '@/types/general';
 
 import TreeDetailsFilter, { mapFilterToReq } from './TreeDetailsFilter';
 import type { TreeDetailsTabRightElement } from './Tabs/TreeDetailsTab';

--- a/dashboard/src/pages/TreeDetails/treeDetailsUtils.ts
+++ b/dashboard/src/pages/TreeDetails/treeDetailsUtils.ts
@@ -37,8 +37,10 @@ export const useDiffFilterParams = (
   filterSection: TFilterObjectsKeys,
 ): TFilter => {
   const { diffFilter: currentDiffFilter } = useSearch({
-    from: '/tree/$treeId',
+    strict: false,
   });
+
+  if (!currentDiffFilter) return {};
 
   const newFilter = structuredClone(currentDiffFilter) || {};
   // This seems redundant but we do this to keep the pointer to newFilter[filterSection]

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -1,0 +1,30 @@
+import { useParams } from '@tanstack/react-router';
+
+import { Skeleton } from '@mui/material';
+
+import { FormattedMessage } from 'react-intl';
+
+import { useHardwareDetails } from '@/api/hardwareDetails';
+
+import HardwareDetailsTabs from './Tabs/HardwareDetailsTabs';
+
+const DEFAULT_DAYS_INTERVAL = 1;
+
+function HardwareDetails(): JSX.Element {
+  const { hardwareId } = useParams({ from: '/hardware/$hardwareId' });
+  const { data, isLoading } = useHardwareDetails(
+    hardwareId,
+    DEFAULT_DAYS_INTERVAL,
+  );
+
+  if (isLoading || !data)
+    return (
+      <Skeleton>
+        <FormattedMessage id="global.loading" />
+      </Skeleton>
+    );
+
+  return <HardwareDetailsTabs HardwareDetailsData={data} />;
+}
+
+export default HardwareDetails;

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -1,0 +1,98 @@
+import { FormattedMessage } from 'react-intl';
+
+import { useMemo } from 'react';
+
+import { MemoizedErrorsSummaryBuild } from '@/pages/TreeDetails/Tabs/BuildCards';
+
+import { MemoizedIssuesList } from '@/pages/TreeDetails/Tabs/TestCards';
+
+import {
+  MemoizedConfigsCard,
+  MemoizedStatusCard,
+} from '@/pages/TreeDetails/Tabs/Build/BuildTab';
+import {
+  DesktopGrid,
+  InnerMobileGrid,
+  MobileGrid,
+} from '@/pages/TreeDetails/Tabs/TabGrid';
+import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import { sanitizeArchs, sanitizeBuilds, sanitizeConfigs } from '@/utils/utils';
+
+import { HardwareDetailsBuildsTable } from './HardwareDetailsBuildsTable';
+
+interface TBuildTab {
+  builds: THardwareDetails['builds'];
+}
+
+const toggleFilterBySection = console.error;
+
+const BuildTab = ({ builds }: TBuildTab): JSX.Element => {
+  const archSummary = useMemo(
+    () => sanitizeArchs(builds.summary.architectures),
+    [builds.summary.architectures],
+  );
+
+  const configsItems = useMemo(
+    () => sanitizeConfigs(builds.summary.configs),
+    [builds.summary.configs],
+  );
+
+  const buildItems = useMemo(
+    () => sanitizeBuilds(builds.items),
+    [builds.items],
+  );
+
+  return (
+    <div className="flex flex-col gap-8 pt-4">
+      <DesktopGrid>
+        <div>
+          <MemoizedStatusCard
+            toggleFilterBySection={toggleFilterBySection}
+            buildsSummary={builds.summary.builds}
+          />
+          <MemoizedErrorsSummaryBuild
+            summaryBody={archSummary}
+            toggleFilterBySection={toggleFilterBySection}
+          />
+          <MemoizedIssuesList
+            title={<FormattedMessage id="global.issues" />}
+            issues={builds.issues}
+          />
+        </div>
+        <MemoizedConfigsCard
+          configs={configsItems}
+          toggleFilterBySection={toggleFilterBySection}
+        />
+      </DesktopGrid>
+      <MobileGrid>
+        <MemoizedStatusCard
+          toggleFilterBySection={toggleFilterBySection}
+          buildsSummary={builds.summary.builds}
+        />
+        <InnerMobileGrid>
+          <MemoizedErrorsSummaryBuild
+            summaryBody={archSummary}
+            toggleFilterBySection={toggleFilterBySection}
+          />
+          <MemoizedConfigsCard
+            configs={configsItems}
+            toggleFilterBySection={toggleFilterBySection}
+          />
+        </InnerMobileGrid>
+        <MemoizedIssuesList
+          title={<FormattedMessage id="global.issues" />}
+          issues={builds.issues}
+        />
+      </MobileGrid>
+
+      <div className="flex flex-col gap-4">
+        <div className="text-lg">
+          <FormattedMessage id="global.build" />
+        </div>
+        <HardwareDetailsBuildsTable buildItems={buildItems} />
+      </div>
+    </div>
+  );
+};
+
+export default BuildTab;

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -1,0 +1,129 @@
+import type { ColumnDef } from '@tanstack/react-table';
+
+import { MdCheck, MdClose } from 'react-icons/md';
+
+import { BuildsTable } from '@/components/BuildsTable/BuildsTable';
+import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
+import { ItemType } from '@/components/ListingItem/ListingItem';
+import { TableHeader } from '@/components/Table/TableHeader';
+import { TooltipDateTime } from '@/components/TooltipDateTime';
+
+import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
+
+export interface THardwareDetailsBuildsTable {
+  buildItems: AccordionItemBuilds[];
+}
+
+const buildStatusMap = {
+  valid: <MdCheck className="text-green" />,
+  invalid: <MdClose className="text-red" />,
+  null: <span>-</span>,
+};
+
+// TODO: put i18n in global.
+const columns: ColumnDef<AccordionItemBuilds>[] = [
+  {
+    accessorKey: 'treeBranch',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'hardwareDetails.treeBranch',
+        intlDefaultMessage: 'Tree / Branch',
+      }),
+  },
+  {
+    accessorKey: 'config',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.config',
+        intlDefaultMessage: 'Config',
+      }),
+  },
+  {
+    accessorKey: 'compiler',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.compiler',
+        intlDefaultMessage: 'Compiler',
+      }),
+  },
+  {
+    accessorKey: 'date',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.date',
+        intlDefaultMessage: 'Date',
+      }),
+    cell: ({ row }): JSX.Element => (
+      <TooltipDateTime
+        dateTime={row.getValue('date')}
+        lineBreak={true}
+        showLabelTime={true}
+        showLabelTZ={true}
+      />
+    ),
+  },
+  {
+    accessorKey: 'buildErrors',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.buildErrors',
+        intlDefaultMessage: 'Build Errors',
+      }),
+    cell: ({ row }): JSX.Element => (
+      <ColoredCircle
+        className="max-w-6"
+        quantity={row.getValue('buildErrors')}
+        backgroundClassName={
+          (row.getValue('buildErrors') as number) > 0
+            ? ItemType.Error
+            : ItemType.None
+        }
+      />
+    ),
+  },
+  {
+    accessorKey: 'buildTime',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.buildTime',
+        intlDefaultMessage: 'Build Time',
+      }),
+    cell: ({ row }): JSX.Element => {
+      return row.getValue('buildTime');
+    },
+  },
+  {
+    accessorKey: 'status',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeDetails.status',
+        intlDefaultMessage: 'Status',
+        tooltipId: 'buildTab.statusTooltip',
+      }),
+    cell: ({ row }): JSX.Element => {
+      return buildStatusMap[
+        row.getValue('status') as keyof typeof buildStatusMap
+      ];
+    },
+  },
+];
+
+export function HardwareDetailsBuildsTable({
+  buildItems,
+}: THardwareDetailsBuildsTable): JSX.Element {
+  return <BuildsTable buildItems={buildItems} columns={columns} />;
+}

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/index.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/index.tsx
@@ -1,0 +1,3 @@
+import BuildTab from './BuildTab';
+
+export default BuildTab;

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -1,0 +1,79 @@
+import { useNavigate } from '@tanstack/react-router';
+
+import type { ReactElement } from 'react';
+import { useCallback, useMemo } from 'react';
+
+import type { ITabItem } from '@/components/Tabs/Tabs';
+import Tabs from '@/components/Tabs/Tabs';
+
+import { zPossibleValidator } from '@/types/tree/TreeDetails';
+
+import type { MessagesKey } from '@/locales/messages';
+
+import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+
+import BuildTab from './Build';
+
+export type TreeDetailsTabRightElement = Record<
+  Extract<
+    MessagesKey,
+    'treeDetails.builds' | 'treeDetails.boots' | 'treeDetails.tests'
+  >,
+  ReactElement
+>;
+
+export interface IHardwareDetailsTab {
+  HardwareDetailsData: THardwareDetails;
+}
+
+const HardwareDetailsTabs = ({
+  HardwareDetailsData,
+}: IHardwareDetailsTab): JSX.Element => {
+  const navigate = useNavigate({ from: '/hardware/$hardwareId' });
+
+  const onValueChange: (value: string) => void = useCallback(
+    value => {
+      const validatedValue = zPossibleValidator.parse(value);
+      navigate({
+        search: previousParams => {
+          return {
+            ...previousParams,
+            currentTreeDetailsTab: validatedValue,
+          };
+        },
+      });
+    },
+    [navigate],
+  );
+  // TODO: put i18n in global.
+  const tabs: ITabItem[] = useMemo(
+    () => [
+      {
+        name: 'treeDetails.builds',
+        content: <BuildTab builds={HardwareDetailsData.builds} />,
+        disabled: false,
+      },
+      {
+        name: 'treeDetails.boots',
+        content: <h1>Boots Tab</h1>,
+        disabled: false,
+      },
+      {
+        name: 'treeDetails.tests',
+        content: <h1>Tests Tab</h1>,
+        disabled: false,
+      },
+    ],
+    [HardwareDetailsData],
+  );
+
+  return (
+    <Tabs
+      tabs={tabs}
+      value="treeDetails.builds"
+      onValueChange={onValueChange}
+    />
+  );
+};
+
+export default HardwareDetailsTabs;

--- a/dashboard/src/routes/hardware/$hardwareId/index.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/index.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+import HardwareDetails from '@/pages/hardwareDetails/HardwareDetails';
+
 export const Route = createFileRoute('/hardware/$hardwareId/')({
-  component: () => <div>Hello /hardware/$hardware/!</div>,
+  component: HardwareDetails,
 });

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -39,3 +39,38 @@ export type TestHistory = {
   duration?: number;
   hardware?: string[];
 };
+
+interface ITreeDetailsMisc {
+  kernel_type?: string;
+  dtb?: string;
+  modules?: string;
+  system_map?: string;
+}
+
+export type BuildsTabBuild = {
+  id: string;
+  architecture: string;
+  config_name: string;
+  valid: boolean | null;
+  start_time: string;
+  duration: string;
+  compiler: string;
+  config_url: string;
+  log_url: string;
+  git_repository_branch: string;
+  git_repository_url: string;
+  misc: ITreeDetailsMisc | null;
+};
+
+export type BuildStatus = {
+  valid: number;
+  invalid: number;
+  null: number;
+};
+
+export type Architecture = Record<
+  string,
+  BuildStatus & {
+    compilers: string[];
+  }
+>;

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -60,6 +60,7 @@ export type BuildsTabBuild = {
   git_repository_branch: string;
   git_repository_url: string;
   misc: ITreeDetailsMisc | null;
+  tree_name?: string;
 };
 
 export type BuildStatus = {

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -1,0 +1,41 @@
+import type {
+  BuildsTabBuild,
+  BuildStatus,
+  TestHistory,
+  TIssue,
+} from '@/types/general';
+
+type BuildSummary = {
+  builds: BuildStatus;
+  configs: Record<string, BuildStatus>;
+  architectures: Record<
+    string,
+    {
+      valid: number;
+      invalid: number;
+      null: number;
+      compilers: string[];
+    }
+  >;
+};
+
+type BuildsData = {
+  items: BuildsTabBuild[];
+  issues: TIssue[];
+  summary: BuildSummary;
+};
+
+type Tests = {
+  history: TestHistory[];
+  platformsFailing: string[];
+  statusSummary: Record<string, number>;
+  failReasons: Record<string, unknown>;
+  configs: Record<string, Record<string, number>>;
+  issues: TIssue[];
+};
+
+export type THardwareDetails = {
+  builds: BuildsData;
+  tests: Tests;
+  boots: Tests;
+};

--- a/dashboard/src/types/tree/Tree.tsx
+++ b/dashboard/src/types/tree/Tree.tsx
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import type { BuildStatus } from '@/types/general';
+
 export type TreeFastPathResponse = Array<{
   id: string;
   tree_name: string | null;
@@ -15,11 +17,7 @@ export type TreeTableBody = {
   commitHash: string;
   commitName: string;
   patchsetHash: string;
-  buildStatus?: {
-    valid: number;
-    invalid: number;
-    null: number;
-  };
+  buildStatus?: BuildStatus;
   tree_name?: string | null;
   testStatus?: {
     done: number;

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -4,31 +4,15 @@ import type { ReactNode } from 'react';
 
 import type { MessagesKey } from '@/locales/messages';
 
-import type { TestHistory, TIssue } from '@/types/general';
+import type {
+  BuildsTabBuild,
+  BuildStatus,
+  Architecture,
+  TestHistory,
+  TIssue,
+} from '@/types/general';
 
 import type { Status } from '@/types/database';
-
-export type BuildsTabBuild = {
-  id: string;
-  architecture: string;
-  config_name: string;
-  valid: boolean | null;
-  start_time: string;
-  duration: string;
-  compiler: string;
-  config_url: string;
-  log_url: string;
-  git_repository_branch: string;
-  git_repository_url: string;
-  misc: ITreeDetailsMisc | null;
-};
-
-interface ITreeDetailsMisc {
-  kernel_type?: string;
-  dtb?: string;
-  modules?: string;
-  system_map?: string;
-}
 
 export type AccordionItemBuilds = {
   id: string;
@@ -51,23 +35,10 @@ export type BuildsTab = {
   summary: {
     builds: BuildStatus;
     configs: Record<string, BuildStatus>;
-    architectures: TArch;
+    architectures: Architecture;
   };
   issues: TIssue[];
 };
-
-export type BuildStatus = {
-  valid: number;
-  invalid: number;
-  null: number;
-};
-
-type TArch = Record<
-  string,
-  BuildStatus & {
-    compilers: string[];
-  }
->;
 
 export interface TTreeDetailsFilter
   extends Partial<{

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -44,7 +44,7 @@ export interface TTreeDetailsFilter
   extends Partial<{
     [K in keyof Omit<
       BuildsTabBuild,
-      'test_status' | 'misc' | 'valid'
+      'test_status' | 'misc' | 'valid' | 'tree_name'
     >]: BuildsTabBuild[K][];
   }> {
   valid?: string[];

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -28,6 +28,7 @@ export type AccordionItemBuilds = {
   dtb?: string;
   systemMap?: string;
   modules?: string;
+  treeBranch?: string;
 };
 
 export type BuildsTab = {

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -1,5 +1,14 @@
 import { format } from 'date-fns';
 
+import type { IListingItem } from '@/components/ListingItem/ListingItem';
+import type { ISummaryItem } from '@/components/Summary/Summary';
+import type {
+  BuildsTabBuild,
+  BuildStatus,
+  TArch,
+  AccordionItemBuilds,
+} from '@/types/tree/TreeDetails';
+
 export function formatDate(date: Date | string, short?: boolean): string {
   const options: Intl.DateTimeFormatOptions = {
     year: short ? '2-digit' : 'numeric',
@@ -20,3 +29,60 @@ export function formatDate(date: Date | string, short?: boolean): string {
 export const getDateOffset = (date: Date): string => {
   return format(date, 'z');
 };
+
+export const sanitizeArchs = (archs: TArch | undefined): ISummaryItem[] => {
+  if (!archs) return [];
+  return Object.entries(archs).map(([key, value]) => ({
+    arch: {
+      text: key,
+      errors: value.invalid,
+      success: value.valid,
+      unknown: value.null,
+    },
+    compilers: value.compilers,
+  }));
+};
+
+export const sanitizeConfigs = (
+  configs: Record<string, BuildStatus> | undefined,
+): IListingItem[] => {
+  if (!configs) return [];
+
+  return Object.entries(configs).map(([key, value]) => ({
+    text: key,
+    errors: value.invalid,
+    success: value.valid,
+    unknown: value.null,
+  }));
+};
+
+const isBuildError = (build: BuildsTabBuild): number => {
+  return build.valid || build.valid === null ? 0 : 1;
+};
+
+export const sanitizeBuilds = (
+  builds: BuildsTabBuild[] | undefined,
+): AccordionItemBuilds[] => {
+  if (!builds) return [];
+
+  return builds.map(build => ({
+    id: build.id,
+    config: build.config_name,
+    date: build.start_time,
+    buildTime: build.duration,
+    compiler: build.compiler,
+    buildErrors: isBuildError(build),
+    status: build.valid === null ? 'null' : build.valid ? 'valid' : 'invalid',
+    buildLogs: build.log_url,
+    kernelConfig: build.config_url,
+    kernelImage: build.misc ? build.misc['kernel_type'] : undefined,
+    dtb: build.misc ? build.misc['dtb'] : undefined,
+    systemMap: build.misc ? build.misc['system_map'] : undefined,
+    modules: build.misc ? build.misc['modules'] : undefined,
+  }));
+};
+
+export const sanitizeBuildsSummary = (
+  buildsSummary: BuildStatus | undefined,
+): BuildStatus =>
+  buildsSummary ? buildsSummary : { invalid: 0, null: 0, valid: 0 };

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -8,6 +8,7 @@ import type {
   BuildsTabBuild,
   BuildStatus,
 } from '@/types/general';
+import { sanitizeTableValue } from '@/components/Table/tableUtils';
 
 export function formatDate(date: Date | string, short?: boolean): string {
   const options: Intl.DateTimeFormatOptions = {
@@ -81,6 +82,7 @@ export const sanitizeBuilds = (
     dtb: build.misc ? build.misc['dtb'] : undefined,
     systemMap: build.misc ? build.misc['system_map'] : undefined,
     modules: build.misc ? build.misc['modules'] : undefined,
+    treeBranch: `${sanitizeTableValue(build.tree_name)} / ${sanitizeTableValue(build.git_repository_branch)}`,
   }));
 };
 

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -2,12 +2,12 @@ import { format } from 'date-fns';
 
 import type { IListingItem } from '@/components/ListingItem/ListingItem';
 import type { ISummaryItem } from '@/components/Summary/Summary';
+import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
 import type {
+  Architecture,
   BuildsTabBuild,
   BuildStatus,
-  TArch,
-  AccordionItemBuilds,
-} from '@/types/tree/TreeDetails';
+} from '@/types/general';
 
 export function formatDate(date: Date | string, short?: boolean): string {
   const options: Intl.DateTimeFormatOptions = {
@@ -30,7 +30,9 @@ export const getDateOffset = (date: Date): string => {
   return format(date, 'z');
 };
 
-export const sanitizeArchs = (archs: TArch | undefined): ISummaryItem[] => {
+export const sanitizeArchs = (
+  archs: Architecture | undefined,
+): ISummaryItem[] => {
   if (!archs) return [];
   return Object.entries(archs).map(([key, value]) => ({
     arch: {


### PR DESCRIPTION
- add HardwareDetails page with Builds Tab 
- feat: add useHardwareDetails
- refactor: separate BuildsTable columns from the component
- refactor: make BuildTab cards receive only the needed values
- feat: make BuildsTable route independent
- refactor: reorganize types to be reused
- refactor: extract logic from TreeDetails page to reuse

Close #494 #448 

### How to test:
1. run the front-end and back-end servers
2. go to `http://localhost:5173/hardware/<hardwareID>` such as `http://localhost:5173/hardware/libretech,all-h3-cc-h5`
