### PR TITLE
Feat/hardware listing frontend

### DIFF
--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -14,7 +14,7 @@ from kernelCI_app.helpers.date import parseIntervalInDaysGetParameter
 from kernelCI_app.helpers.errorHandling import ExceptionWithJsonResponse
 
 
-DEFAULT_DAYS_INTERVAL = 7
+DEFAULT_DAYS_INTERVAL = 3
 
 
 def properties2List(d, keys):

--- a/dashboard/src/api/Hardware.tsx
+++ b/dashboard/src/api/Hardware.tsx
@@ -1,0 +1,55 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import { useSearch } from '@tanstack/react-router';
+
+import type {
+  HardwareFastResponse,
+  HardwareListingResponse,
+} from '@/types/hardware';
+
+import http from './api';
+const fetchTreeCheckoutData = async (
+  intervalInDays?: number,
+): Promise<HardwareListingResponse> => {
+  const res = await http.get('/api/hardware/', {
+    params: { intervalInDays, mode: 'slow' },
+  });
+  return res.data;
+};
+
+export const useHardwareListingSlow = ({
+  enabled,
+}: {
+  enabled: boolean;
+}): UseQueryResult<HardwareListingResponse> => {
+  const { intervalInDays } = useSearch({ from: '/hardware' });
+
+  const queryKey = ['hardwareListing', intervalInDays];
+
+  return useQuery({
+    queryKey,
+    queryFn: () => fetchTreeCheckoutData(intervalInDays),
+    enabled,
+  });
+};
+
+const fetchHardwareListingFastData = async (
+  intervalInDays?: number,
+): Promise<HardwareFastResponse> => {
+  const res = await http.get('/api/hardware/', {
+    params: { intervalInDays, mode: 'fast' },
+  });
+  return res.data;
+};
+
+export const useHardwareListingFast =
+  (): UseQueryResult<HardwareFastResponse> => {
+    const { intervalInDays } = useSearch({ from: '/hardware' });
+    const queryKey = ['hardwareListingFast', intervalInDays];
+
+    return useQuery({
+      queryKey,
+      queryFn: () => fetchHardwareListingFastData(intervalInDays),
+    });
+  };

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -7,9 +7,9 @@ import http from './api';
 
 const fetchHardwareDetails = async (
   hardwareId: string,
-  daysInterval: number,
+  intervalInDays: number,
 ): Promise<THardwareDetails> => {
-  const params = { daysInterval };
+  const params = { intervalInDays };
   const res = await http.get<THardwareDetails>(`/api/hardware/${hardwareId}`, {
     params,
   });
@@ -19,10 +19,10 @@ const fetchHardwareDetails = async (
 
 export const useHardwareDetails = (
   hardwareId: string,
-  daysInterval: number,
+  intervalInDays: number,
 ): UseQueryResult<THardwareDetails> => {
   return useQuery({
-    queryKey: ['HardwareDetails', hardwareId, daysInterval],
-    queryFn: () => fetchHardwareDetails(hardwareId, daysInterval),
+    queryKey: ['HardwareDetails', hardwareId, intervalInDays],
+    queryFn: () => fetchHardwareDetails(hardwareId, intervalInDays),
   });
 };

--- a/dashboard/src/components/SideMenu/SideMenu.tsx
+++ b/dashboard/src/components/SideMenu/SideMenu.tsx
@@ -5,11 +5,9 @@ import { MdOutlineMonitorHeart } from 'react-icons/md';
 import { ImTree } from 'react-icons/im';
 import { HiOutlineDocumentSearch } from 'react-icons/hi';
 
-import { useSearch, useLocation } from '@tanstack/react-router';
+import { useLocation } from '@tanstack/react-router';
 
 import type { MessagesKey } from '@/locales/messages';
-
-import { zOrigin } from '@/types/tree/Tree';
 
 import { DOCUMENTATION_URL } from '@/utils/constants/general';
 
@@ -17,9 +15,9 @@ import {
   NavigationMenu,
   NavigationMenuItem,
   NavigationMenuList,
-} from '../ui/navigation-menu';
+} from '@/components/ui/navigation-menu';
 
-import { Separator } from '../ui/separator';
+import { Separator } from '@/components/ui/separator';
 
 import SendFeedback from './SendFeedback';
 
@@ -53,8 +51,6 @@ type SideMenuItemProps = {
 const SideMenuItem = ({ item }: SideMenuItemProps): JSX.Element => {
   const { pathname } = useLocation();
 
-  const { origin: unsafeOrigin } = useSearch({ strict: false });
-
   const selectedItemClassName =
     'w-full flex pl-5 py-4 cursor-pointer text-sky-500 bg-black border-l-4 border-sky-500';
   const notSelectedItemClassName =
@@ -71,9 +67,7 @@ const SideMenuItem = ({ item }: SideMenuItemProps): JSX.Element => {
     >
       <NavLink
         to={item.navigateTo}
-        search={{
-          origin: zOrigin.parse(unsafeOrigin),
-        }}
+        search={prevSearch => prevSearch}
         icon={item.icon}
         idIntl={item.idIntl}
       />

--- a/dashboard/src/components/Table/PaginationInfo.tsx
+++ b/dashboard/src/components/Table/PaginationInfo.tsx
@@ -17,21 +17,26 @@ import type { MessagesKey } from '@/locales/messages';
 
 import type { TreeTableBody } from '@/types/tree/Tree';
 
-import { Button } from '../ui/button';
+import type { HardwareTableItem } from '@/types/hardware';
+
+import { Button } from '@/components/ui/button';
 
 import { ItemsPerPageSelector } from './TableInfo';
 
 interface IPaginationInfo {
+  //TODO Use Generic
   table:
     | Table<TestByCommitHash>
     | Table<TPathTests>
     | Table<AccordionItemBuilds>
-    | Table<TreeTableBody>;
+    | Table<TreeTableBody>
+    | Table<HardwareTableItem>;
   data:
     | TestByCommitHash[]
     | TPathTests[]
     | AccordionItemBuilds[]
-    | TreeTableBody[];
+    | TreeTableBody[]
+    | HardwareTableItem[];
   intlLabel: MessagesKey;
 }
 

--- a/dashboard/src/components/Table/TableHeader.tsx
+++ b/dashboard/src/components/Table/TableHeader.tsx
@@ -19,16 +19,19 @@ import { formattedBreakLineValue } from '@/locales/messages';
 
 import type { TreeTableBody } from '@/types/tree/Tree';
 
-import { Button } from '../ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
+import type { HardwareTableItem } from '@/types/hardware';
 
 interface ITableHeader {
+  // TODO Use Generic
   column:
     | Column<TIndividualTest>
     | Column<TestByCommitHash>
     | Column<TPathTests>
     | Column<AccordionItemBuilds>
-    | Column<TreeTableBody>;
+    | Column<TreeTableBody>
+    | Column<HardwareTableItem>;
   sortable: boolean;
   intlKey: MessagesKey;
   intlDefaultMessage: string;

--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useSearch, useNavigate } from '@tanstack/react-router';
+import { useSearch, useNavigate, useLocation } from '@tanstack/react-router';
 import { useCallback, useEffect, useMemo } from 'react';
 
 import Select, { SelectItem } from '@/components/Select/Select';
@@ -52,14 +52,29 @@ const OriginSelect = (): JSX.Element => {
   );
 };
 
+const TitleName = ({ basePath }: { basePath: string }): JSX.Element => {
+  switch (basePath) {
+    case 'tree':
+      return <FormattedMessage id="routes.treeMonitor" />;
+    case 'hardware':
+      return <FormattedMessage id="routes.hardwareMonitor" />;
+    default:
+      return <FormattedMessage id="routes.unknown" />;
+  }
+};
+
 const TopBar = (): JSX.Element => {
+  const { pathname } = useLocation();
+
+  const basePath = pathname.split('/')[1] ?? '';
+
   return (
     <div className="fixed top-0 z-10 mx-52 flex h-20 w-full bg-white px-16">
       <div className="flex flex-row items-center justify-between">
         <span className="mr-14 text-2xl">
-          <FormattedMessage id="routes.treeMonitor" />
+          <TitleName basePath={basePath} />
         </span>
-        <OriginSelect />
+        {basePath === 'tree' && <OriginSelect />}
       </div>
     </div>
   );

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -114,6 +114,7 @@ export const messages = {
     'global.fails': 'Fails',
     'global.filters': 'Filters',
     'global.github': 'GitHub',
+    'global.hardware': 'Hardware',
     'global.inconclusive': 'Inconclusive',
     'global.inconclusiveCount': 'Inconclusive: {count}',
     'global.info': 'Info',
@@ -157,6 +158,7 @@ export const messages = {
     'global.valid': 'Valid',
     'hardware.details': 'Hardware Details',
     'hardware.path': 'Hardware',
+    'hardware.searchPlaceholder': 'Search by hardware name',
     'hardwareDetails.treeBranch': 'Tree / Branch',
     'issue.failedToFetch': 'Failed to fetch issues',
     'issue.noIssueFound': 'No issue found.',
@@ -171,6 +173,7 @@ export const messages = {
     'routes.sendFeedbackMsg':
       'Thank you for your feedback!\nWe greatly appreciate your input. You are welcome to send us the feedback via email or by creating an issue on our GitHub repository.',
     'routes.treeMonitor': 'Trees',
+    'routes.unknown': 'Unknown',
     'tab.name': 'Name',
     'table.itemsPerPage': 'Items per page:',
     'table.of': 'of',

--- a/dashboard/src/pages/Hardware/Hardware.tsx
+++ b/dashboard/src/pages/Hardware/Hardware.tsx
@@ -1,0 +1,56 @@
+import type { ChangeEvent } from 'react';
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { useNavigate, useSearch } from '@tanstack/react-router';
+
+import HardwareListingPage from '@/pages/Hardware/HardwareListingPage';
+
+import DebounceInput from '@/components/DebounceInput/DebounceInput';
+
+const Hardware = (): JSX.Element => {
+  const { hardwareSearch } = useSearch({
+    from: '/hardware',
+  });
+
+  const navigate = useNavigate({ from: '/hardware' });
+
+  const onInputSearchTextChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      navigate({
+        from: '/hardware',
+        search: previousSearch => ({
+          ...previousSearch,
+          hardwareSearch: e.target.value,
+        }),
+      });
+    },
+    [navigate],
+  );
+
+  const intl = useIntl();
+
+  return (
+    <>
+      <div className="w-full bg-lightGray py-10">
+        <HardwareListingPage inputFilter={hardwareSearch ?? ''} />
+      </div>
+      <div className="fixed top-0 z-10 mx-[380px] flex w-full pl-6 pr-12 pt-5">
+        <div className="flex w-2/3 items-center px-6">
+          <DebounceInput
+            debouncedSideEffect={onInputSearchTextChange}
+            className="w-2/3"
+            type="text"
+            startingValue={hardwareSearch}
+            placeholder={intl.formatMessage({
+              id: 'hardware.searchPlaceholder',
+            })}
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Hardware;

--- a/dashboard/src/pages/Hardware/HardwareListingPage.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPage.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+
+import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
+
+import { Toaster } from '@/components/ui/toaster';
+
+import type {
+  HardwareFastItem,
+  HardwareListingItem,
+  HardwareTableItem,
+} from '@/types/hardware';
+
+import { useHardwareListingFast, useHardwareListingSlow } from '@/api/Hardware';
+
+import { HardwareTable } from './HardwareTable';
+
+interface HardwareListingPageProps {
+  inputFilter: string;
+}
+
+function isCompleteHardware(
+  data: HardwareListingItem | HardwareFastItem,
+): data is HardwareListingItem {
+  return (
+    'buildCount' in data &&
+    'testStatusCount' in data &&
+    'bootStatusCount' in data
+  );
+}
+
+const HardwareListingPage = ({
+  inputFilter,
+}: HardwareListingPageProps): JSX.Element => {
+  //TODO: Combine these 2 hooks inside a single hook
+  const { data: fastData, status: fastStatus } = useHardwareListingFast();
+  const { data, error, isLoading } = useHardwareListingSlow({
+    enabled: fastStatus === 'success' && !!fastData,
+  });
+
+  const listItems: HardwareTableItem[] = useMemo(() => {
+    if (!fastData || fastStatus === 'error') return [];
+
+    const hasCompleteData = !isLoading && !!data;
+    const currentData = hasCompleteData ? data.hardware : fastData.hardware;
+
+    return currentData
+      .filter(hardware => {
+        return hardware.hardwareName?.includes(inputFilter);
+      })
+      .map((hardware): HardwareTableItem => {
+        const buildCount = isCompleteHardware(hardware)
+          ? {
+              valid: hardware.buildCount?.valid,
+              invalid: hardware.buildCount?.invalid,
+              null: hardware.buildCount?.null,
+            }
+          : undefined;
+
+        const testStatusCount = isCompleteHardware(hardware)
+          ? {
+              DONE: hardware.testStatusCount.DONE,
+              ERROR: hardware.testStatusCount.ERROR,
+              FAIL: hardware.testStatusCount.FAIL,
+              MISS: hardware.testStatusCount.MISS,
+              PASS: hardware.testStatusCount.PASS,
+              SKIP: hardware.testStatusCount.SKIP,
+              NULL: hardware.testStatusCount.NULL,
+            }
+          : undefined;
+
+        const bootStatusCount = isCompleteHardware(hardware)
+          ? {
+              DONE: hardware.bootStatusCount.DONE,
+              ERROR: hardware.bootStatusCount.ERROR,
+              FAIL: hardware.bootStatusCount.FAIL,
+              MISS: hardware.bootStatusCount.MISS,
+              PASS: hardware.bootStatusCount.PASS,
+              SKIP: hardware.bootStatusCount.SKIP,
+              NULL: hardware.bootStatusCount.NULL,
+            }
+          : undefined;
+
+        return {
+          hardwareName: hardware.hardwareName ?? '',
+          buildCount,
+          testStatusCount,
+          bootStatusCount,
+        };
+      })
+      .sort((a, b) => a.hardwareName.localeCompare(b.hardwareName));
+  }, [data, fastData, inputFilter, isLoading, fastStatus]);
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <QuerySwitcher status={fastStatus} data={fastData}>
+      <Toaster />
+      <div className="flex flex-col gap-6">
+        <HardwareTable treeTableRows={listItems} />
+      </div>
+    </QuerySwitcher>
+  );
+};
+
+export default HardwareListingPage;

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -1,0 +1,249 @@
+import type {
+  ColumnDef,
+  ColumnFiltersState,
+  PaginationState,
+  Row,
+  SortingState,
+} from '@tanstack/react-table';
+
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import { memo, useCallback, useMemo, useState } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import type { LinkProps } from '@tanstack/react-router';
+
+import BaseTable, { TableHead } from '@/components/Table/BaseTable';
+
+import { formattedBreakLineValue } from '@/locales/messages';
+
+import {
+  TableBody,
+  TableCell,
+  TableCellWithLink,
+  TableRow,
+} from '@/components/ui/table';
+
+import { BuildStatus, GroupedTestStatus } from '@/components/Status/Status';
+import { TableHeader } from '@/components/Table/TableHeader';
+import { PaginationInfo } from '@/components/Table/PaginationInfo';
+
+import type { HardwareTableItem } from '@/types/hardware';
+
+import { sumStatus } from '@/utils/status';
+
+import { InputTime } from './InputTime';
+
+// TODO Extract and reuse the table
+
+const columns: ColumnDef<HardwareTableItem>[] = [
+  {
+    accessorKey: 'hardwareName',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'global.name',
+        intlDefaultMessage: 'Hardware',
+      }),
+  },
+  {
+    accessorKey: 'buildCount',
+    accessorFn: ({ buildCount }): number =>
+      buildCount ? sumStatus(buildCount) : 0,
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeTable.build',
+        intlDefaultMessage: 'Build Status',
+        tooltipId: 'buildTab.statusTooltip',
+      }),
+    cell: ({ row }): JSX.Element => {
+      return row.original.buildCount ? (
+        <BuildStatus
+          valid={row.original.buildCount.valid}
+          invalid={row.original.buildCount.invalid}
+          unknown={row.original.buildCount.null}
+        />
+      ) : (
+        <FormattedMessage id="global.loading" defaultMessage="Loading..." />
+      );
+    },
+  },
+  {
+    accessorKey: 'bootStatusCount',
+    accessorFn: ({ bootStatusCount }): number =>
+      bootStatusCount ? sumStatus(bootStatusCount) : 0,
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeTable.bootStatus',
+        intlDefaultMessage: 'Boot Status',
+        tooltipId: 'bootsTab.statusTooltip',
+      }),
+    cell: ({ row }): JSX.Element => {
+      return row.original.bootStatusCount ? (
+        <GroupedTestStatus
+          pass={row.original.bootStatusCount.PASS}
+          skip={row.original.bootStatusCount.SKIP}
+          fail={row.original.bootStatusCount.FAIL}
+          miss={row.original.bootStatusCount.MISS}
+          done={row.original.bootStatusCount.DONE}
+          error={row.original.bootStatusCount.ERROR}
+          nullStatus={row.original.bootStatusCount.NULL}
+        />
+      ) : (
+        <FormattedMessage id="global.loading" defaultMessage="Loading..." />
+      );
+    },
+  },
+  {
+    accessorKey: 'testStatusCount',
+    accessorFn: ({ testStatusCount }): number =>
+      testStatusCount ? sumStatus(testStatusCount) : 0,
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'treeTable.test',
+        intlDefaultMessage: 'Test Status',
+        tooltipId: 'testsTab.statusTooltip',
+      }),
+    cell: ({ row }): JSX.Element => {
+      return row.original.testStatusCount ? (
+        <GroupedTestStatus
+          pass={row.original.testStatusCount.PASS}
+          skip={row.original.testStatusCount.SKIP}
+          fail={row.original.testStatusCount.FAIL}
+          miss={row.original.testStatusCount.MISS}
+          done={row.original.testStatusCount.DONE}
+          error={row.original.testStatusCount.ERROR}
+          nullStatus={row.original.testStatusCount.NULL}
+        />
+      ) : (
+        <FormattedMessage id="global.loading" defaultMessage="Loading..." />
+      );
+    },
+  },
+];
+
+interface ITreeTable {
+  treeTableRows: HardwareTableItem[];
+}
+
+export function HardwareTable({ treeTableRows }: ITreeTable): JSX.Element {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+
+  const getLinkProps = useCallback((row: Row<HardwareTableItem>): LinkProps => {
+    return {
+      to: '/hardware/$hardwareId',
+      params: { hardwareId: row.original.hardwareName },
+      search: previousSearch => previousSearch,
+    };
+  }, []);
+
+  const data = useMemo(() => {
+    return treeTableRows;
+  }, [treeTableRows]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: setPagination,
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    state: {
+      sorting,
+      columnFilters,
+      pagination,
+    },
+  });
+
+  const groupHeaders = table.getHeaderGroups()[0].headers;
+  const tableHeaders = useMemo((): JSX.Element[] => {
+    return groupHeaders.map(header => {
+      return (
+        <TableHead key={header.id}>
+          {header.isPlaceholder
+            ? null
+            : flexRender(header.column.columnDef.header, header.getContext())}
+        </TableHead>
+      );
+    });
+    // TODO: remove exhaustive-deps and change memo (all tables)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupHeaders, sorting]);
+
+  const modelRows = table.getRowModel().rows;
+  const tableBody = useMemo((): JSX.Element[] | JSX.Element => {
+    return modelRows?.length ? (
+      modelRows.map(row => (
+        <TableRow key={row.id}>
+          {row.getVisibleCells().map(cell => {
+            return (
+              <TableCellWithLink
+                key={cell.id}
+                linkClassName="w-full inline-block h-full"
+                linkProps={getLinkProps(row)}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCellWithLink>
+            );
+          })}
+        </TableRow>
+      ))
+    ) : (
+      <TableRow>
+        <TableCell colSpan={columns.length} className="h-24 text-center">
+          <FormattedMessage id="global.noResults" />
+        </TableCell>
+      </TableRow>
+    );
+  }, [getLinkProps, modelRows]);
+
+  const MemoizedInputTime = memo(InputTime);
+
+  return (
+    <div className="flex flex-col gap-6 pb-4">
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-left text-sm text-dimGray">
+          <FormattedMessage
+            id="global.projectUnderDevelopment"
+            values={formattedBreakLineValue}
+          />
+        </span>
+        <div className="flex items-center justify-between gap-10">
+          <MemoizedInputTime />
+          <PaginationInfo
+            table={table}
+            data={data}
+            intlLabel="global.hardware"
+          />
+        </div>
+      </div>
+      <BaseTable headerComponents={tableHeaders}>
+        <TableBody>{tableBody}</TableBody>
+      </BaseTable>
+      <PaginationInfo table={table} data={data} intlLabel="global.trees" />
+    </div>
+  );
+}

--- a/dashboard/src/pages/Hardware/InputTime.tsx
+++ b/dashboard/src/pages/Hardware/InputTime.tsx
@@ -1,0 +1,122 @@
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { useNavigate, useSearch } from '@tanstack/react-router';
+
+import { z } from 'zod';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+
+import type { ControllerRenderProps, FieldError } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
+
+import type { ChangeEvent } from 'react';
+import { useCallback } from 'react';
+
+import { toast } from '@/hooks/useToast';
+
+import DebounceInput from '@/components/DebounceInput/DebounceInput';
+import { DEFAULT_HARDWARE_INTERVAL_IN_DAYS } from '@/utils/constants/hardware';
+
+//TODO transform this component into a versatile component with the other one in Trees to eliminate repetition
+
+export function InputTime(): JSX.Element {
+  const { formatMessage } = useIntl();
+
+  const navigate = useNavigate({ from: '/hardware' });
+  const { intervalInDays: interval } = useSearch({ from: '/hardware' });
+
+  function validateString(val: string): boolean {
+    const convertedNumber = parseInt(val);
+    return !Number.isNaN(convertedNumber) && convertedNumber > 0;
+  }
+
+  const InputTimeSchema = z.object({
+    intervalInDays: z.string().refine(validateString, {
+      message: formatMessage({ id: 'filter.invalid' }),
+    }),
+  });
+
+  const { handleSubmit, control } = useForm<z.infer<typeof InputTimeSchema>>({
+    resolver: zodResolver(InputTimeSchema),
+    defaultValues: {
+      intervalInDays: `${DEFAULT_HARDWARE_INTERVAL_IN_DAYS}`,
+    },
+  });
+
+  const onSubmit = handleSubmit(
+    ({ intervalInDays }) => {
+      navigate({
+        search: previousSearch => ({
+          ...previousSearch,
+          intervalInDays: Number(intervalInDays),
+        }),
+      });
+    },
+    e => {
+      const { dismiss } = toast({
+        title: e.intervalInDays?.message,
+        className: 'border-red bg-red text-slate-50 shadow-xl',
+      });
+
+      // eslint-disable-next-line no-magic-numbers
+      setTimeout(dismiss, 3000);
+    },
+  );
+
+  const onInputTimeTextChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      if (!e.target.value) return;
+      onSubmit();
+    },
+    [onSubmit],
+  );
+
+  const InputTimeComponent = ({
+    field: { onChange, ...rest },
+    fieldError,
+  }: {
+    field: ControllerRenderProps<
+      z.infer<typeof InputTimeSchema>,
+      'intervalInDays'
+    >;
+    fieldError: FieldError | undefined;
+  }): JSX.Element => {
+    const handleInputChange = useCallback(
+      (e: ChangeEvent<HTMLInputElement>) => {
+        onChange(e);
+        onInputTimeTextChange(e);
+      },
+      [onChange],
+    );
+
+    return (
+      <DebounceInput
+        debouncedSideEffect={handleInputChange}
+        type="number"
+        min={1}
+        className={`${fieldError ? 'border-red' : 'border-gray'} mx-[10px] flex w-[100px] flex-1 rounded-md border`}
+        startingValue={
+          interval
+            ? interval.toString()
+            : `${DEFAULT_HARDWARE_INTERVAL_IN_DAYS}`
+        }
+        placeholder="3"
+        {...rest}
+      />
+    );
+  };
+
+  return (
+    <div className="row flex items-center text-sm">
+      <FormattedMessage id="global.last" />
+      <Controller
+        control={control}
+        name="intervalInDays"
+        render={({ field, fieldState: { error: fieldError } }) => (
+          <InputTimeComponent field={field} fieldError={fieldError} />
+        )}
+      />
+      <FormattedMessage id="global.days" />
+    </div>
+  );
+}

--- a/dashboard/src/pages/Hardware/index.tsx
+++ b/dashboard/src/pages/Hardware/index.tsx
@@ -1,0 +1,3 @@
+import Hardware from './Hardware';
+
+export default Hardware;

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -1,4 +1,4 @@
-import { useParams } from '@tanstack/react-router';
+import { useParams, useSearch } from '@tanstack/react-router';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -8,14 +8,10 @@ import { Skeleton } from '@/components/Skeleton';
 
 import HardwareDetailsTabs from './Tabs/HardwareDetailsTabs';
 
-const DEFAULT_DAYS_INTERVAL = 1;
-
 function HardwareDetails(): JSX.Element {
   const { hardwareId } = useParams({ from: '/hardware/$hardwareId' });
-  const { data, isLoading } = useHardwareDetails(
-    hardwareId,
-    DEFAULT_DAYS_INTERVAL,
-  );
+  const { intervalInDays } = useSearch({ from: '/hardware' });
+  const { data, isLoading } = useHardwareDetails(hardwareId, intervalInDays);
 
   if (isLoading || !data)
     return (

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -4,20 +4,10 @@ import { createRootRoute, Outlet } from '@tanstack/react-router';
 // eslint-disable-next-line import/no-extraneous-dependencies
 // import { TanStackRouterDevtools } from '@tanstack/router-devtools';
 
-import { z } from 'zod';
-
 import SideMenu from '@/components/SideMenu/SideMenu';
 import TopBar from '@/components/TopBar/TopBar';
-import { zOrigin } from '@/types/tree/Tree';
-import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
-
-export const RootSearchSchema = z.object({
-  origin: zOrigin,
-  intervalInDays: z.optional(z.number().min(1).catch(DEFAULT_TIME_SEARCH)),
-});
 
 export const Route = createRootRoute({
-  validateSearch: RootSearchSchema,
   component: () => (
     <>
       <div className="h-full w-full">
@@ -29,7 +19,7 @@ export const Route = createRootRoute({
           </div>
         </div>
       </div>
-      {/* <TanStackRouterDevtools /> */}
+      {/*     <TanStackRouterDevtools /> */}
     </>
   ),
 });

--- a/dashboard/src/routes/hardware/index.tsx
+++ b/dashboard/src/routes/hardware/index.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 
+import Hardware from '@/pages/Hardware';
+
 export const Route = createFileRoute('/hardware/')({
-  component: () => <div>Hello /hardware/!</div>,
+  component: Hardware,
 });

--- a/dashboard/src/routes/hardware/route.tsx
+++ b/dashboard/src/routes/hardware/route.tsx
@@ -1,3 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
-export const Route = createFileRoute('/hardware')({});
+import { makeZIntervalInDays } from '@/types/general';
+import { DEFAULT_HARDWARE_INTERVAL_IN_DAYS } from '@/utils/constants/hardware';
+
+const zHardwareSchema = z.object({
+  intervalInDays: makeZIntervalInDays(DEFAULT_HARDWARE_INTERVAL_IN_DAYS),
+  hardwareSearch: z.string().optional().catch(undefined),
+});
+
+export const Route = createFileRoute('/hardware')({
+  validateSearch: zHardwareSchema,
+});

--- a/dashboard/src/routes/tree/route.tsx
+++ b/dashboard/src/routes/tree/route.tsx
@@ -1,3 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-export const Route = createFileRoute('/tree')();
+import { z } from 'zod';
+
+import { zOrigin } from '@/types/tree/Tree';
+import { makeZIntervalInDays } from '@/types/general';
+import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
+
+export const RootSearchSchema = z.object({
+  origin: zOrigin,
+  intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+});
+
+export const Route = createFileRoute('/tree')({
+  validateSearch: RootSearchSchema,
+});

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -1,7 +1,7 @@
+import { z } from 'zod';
+
 import type { Status } from './database';
-
 type IncidentsInfo = { incidentsCount: number };
-
 export type TPathTests = {
   path_group: string;
   fail_tests: number;
@@ -69,6 +69,16 @@ export type BuildStatus = {
   null: number;
 };
 
+export interface StatusCount {
+  PASS?: number;
+  FAIL?: number;
+  MISS?: number;
+  SKIP?: number;
+  ERROR?: number;
+  NULL?: number;
+  DONE?: number;
+}
+
 export type Architecture = Record<
   string,
   BuildStatus & {
@@ -76,6 +86,9 @@ export type Architecture = Record<
   }
 >;
 
+/**
+ * @deprecated use StatusCount
+ */
 export type StatusCounts = {
   [key in Status]: number | undefined;
 };
@@ -85,3 +98,9 @@ export type ArchCompilerStatus = {
   compiler: string;
   status: StatusCounts;
 };
+
+const zIntervalInDaysUncatched = z.number().min(1);
+
+export const makeZIntervalInDays = (
+  defaultValue: number,
+): z.ZodCatch<z.ZodNumber> => zIntervalInDaysUncatched.catch(defaultValue);

--- a/dashboard/src/types/hardware.ts
+++ b/dashboard/src/types/hardware.ts
@@ -1,0 +1,28 @@
+import type { StatusCount } from './general';
+
+export interface HardwareFastItem {
+  hardwareName: string;
+}
+export type HardwareFastResponse = {
+  hardware: HardwareFastItem[];
+};
+
+interface BuildCount {
+  valid: number;
+  invalid: number;
+  null: number;
+}
+
+export interface HardwareRestItem {
+  buildCount: BuildCount;
+  testStatusCount: StatusCount;
+  bootStatusCount: StatusCount;
+}
+
+export type HardwareListingItem = HardwareRestItem & HardwareFastItem;
+
+export interface HardwareListingResponse {
+  hardware: HardwareListingItem[];
+}
+
+export type HardwareTableItem = HardwareFastItem & Partial<HardwareRestItem>;

--- a/dashboard/src/utils/constants/general.ts
+++ b/dashboard/src/utils/constants/general.ts
@@ -6,3 +6,4 @@ export const DOCUMENTATION_URL = 'https://docs.kernelci.org/';
 
 // eslint-disable-next-line no-magic-numbers
 export const ItemsPerPageValues = [10, 20, 30, 40, 50];
+export const DEFAULT_TIME_SEARCH = 7;

--- a/dashboard/src/utils/constants/hardware.ts
+++ b/dashboard/src/utils/constants/hardware.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_HARDWARE_INTERVAL_IN_DAYS = 3;

--- a/dashboard/src/utils/status.ts
+++ b/dashboard/src/utils/status.ts
@@ -1,8 +1,9 @@
 import type { Status } from '@/types/database';
+import type { StatusCount, BuildStatus } from '@/types/general';
 
 type StatusGroups = 'success' | 'failed' | 'inconclusive';
 
-type StatusCount = {
+type GroupStatusCount = {
   doneCount: number;
   missCount: number;
   skipCount: number;
@@ -18,7 +19,7 @@ type GroupedStatus = {
   failedCount: number;
 };
 
-export function groupStatus(counts: StatusCount): GroupedStatus {
+export function groupStatus(counts: GroupStatusCount): GroupedStatus {
   return {
     successCount: counts.passCount,
     failedCount: counts.failCount,
@@ -36,3 +37,12 @@ export const getStatusGroup = (status: Status): StatusGroups => {
   if (status === 'FAIL') return 'failed';
   return 'inconclusive';
 };
+
+type FlexibleStatus = BuildStatus | GroupStatusCount | StatusCount;
+
+export function sumStatus(status: FlexibleStatus): number {
+  return Object.values(status).reduce(
+    (accumulator: number, current) => accumulator + (current ?? 0),
+    0,
+  );
+}


### PR DESCRIPTION
# Description

Add hardware listing page

- Changed DEFAULT_DAYS_INTERVAL from 7 to 3 in hardwareDetailsView.py
- Updated hardwareView.py to include path in test filtering and added
  bootStatusCount
- Created Hardware.tsx for API calls related to hardware
- Modified hardwareDetails.ts to use intervalInDays parameter
- Updated SideMenu.tsx and TopBar.tsx to reflect new hardware routes
- Added new components and pages for hardware monitoring
- Updated locales and messages for hardware monitoring
- Added new types and constants for hardware

Closes #445 #501

## Screenshot
![image](https://github.com/user-attachments/assets/0b6e81c7-e9d8-4e86-b2e1-4a08028bcb90)

## How to test
Click on hardware on the sidebar 