### PR TITLE
Feat: hardware details tree filter

### DIFF
--- a/dashboard/src/api/TreeDetails.tsx
+++ b/dashboard/src/api/TreeDetails.tsx
@@ -51,32 +51,19 @@ const fetchTreeDetailData = async (
   treeSearchParameters: TreeSearchParameters,
   filter: TTreeDetailsFilter | Record<string, never>,
 ): Promise<BuildsTab> => {
-  const searchParam = mapFiltersToUrlSearchParams(filter);
+  const filtersFormatted = mapFiltersKeysToBackendCompatible(filter);
+
+  const params = {
+    origin: treeSearchParameters.origin,
+    git_url: treeSearchParameters.gitUrl,
+    git_branch: treeSearchParameters.gitBranch,
+    ...filtersFormatted,
+  };
 
   assertTreeSearchParameters(treeSearchParameters, 'useBuildsTab');
 
-  searchParam.append('origin', treeSearchParameters.origin);
-  searchParam.append('git_url', treeSearchParameters.gitUrl);
-  searchParam.append('git_branch', treeSearchParameters.gitBranch);
-
-  const res = await http.get(`/api/tree/${treeId}`, { params: searchParam });
+  const res = await http.get(`/api/tree/${treeId}`, { params: params });
   return res.data;
-};
-
-/** @deprecated */
-const mapFiltersToUrlSearchParams = (
-  filter: TTreeDetailsFilter | Record<string, never>,
-): URLSearchParams => {
-  const filterParam = new URLSearchParams();
-
-  Object.keys(filter).forEach(key => {
-    const filterList = filter[key as keyof TTreeDetailsFilter];
-    filterList?.forEach(value =>
-      filterParam.append(`filter_${key}`, value.toString()),
-    );
-  });
-
-  return filterParam;
 };
 
 // TODO, remove this function, is just a step further towards the final implementation
@@ -139,9 +126,6 @@ const fetchTreeTestsData = async (
 
   const res = await http.get<TTreeTestsFullData>(`/api/tree/${treeId}/full`, {
     params: params,
-    paramsSerializer: {
-      indexes: null,
-    },
   });
 
   return res.data;
@@ -264,7 +248,6 @@ const fetchTreeCommitHistory = async (
   gitBranch: string,
   filters: TTreeDetailsFilter,
 ): Promise<TTreeCommitHistoryResponse> => {
-  // TODO: remove deprecated function
   const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
 
   const params = {

--- a/dashboard/src/api/api.ts
+++ b/dashboard/src/api/api.ts
@@ -4,4 +4,7 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export default axios.create({
   baseURL: API_BASE_URL,
+  paramsSerializer: {
+    indexes: null,
+  },
 });

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -10,6 +10,7 @@ type fetchHardwareDetailsBody = {
   startTimestampInSeconds: number;
   endTimestampInSeconds: number;
   origin: TOrigins;
+  selectedTrees: Record<string, string>;
 };
 
 const fetchHardwareDetails = async (
@@ -24,13 +25,30 @@ const fetchHardwareDetails = async (
   return res.data;
 };
 
+const mapIndexesToSelectedTrees = (
+  selectedIndexes: number[],
+): Record<number, string> => {
+  return Object.fromEntries(
+    Array.from(selectedIndexes, index => [index.toString(), 'selected']),
+  );
+};
+
 export const useHardwareDetails = (
   hardwareId: string,
   startTimestampInSeconds: number,
   endTimestampInSeconds: number,
   origin: TOrigins,
+  selectedIndexes: number[],
 ): UseQueryResult<THardwareDetails> => {
-  const body = { origin, startTimestampInSeconds, endTimestampInSeconds };
+  const selectedTrees = mapIndexesToSelectedTrees(selectedIndexes);
+
+  const body: fetchHardwareDetailsBody = {
+    origin,
+    startTimestampInSeconds,
+    endTimestampInSeconds,
+    selectedTrees,
+  };
+
   return useQuery({
     queryKey: ['HardwareDetails', hardwareId, body],
     queryFn: () => fetchHardwareDetails(hardwareId, body),

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -218,7 +218,7 @@ export function TreeTable({ treeTableRows }: ITreeTable): JSX.Element {
         to: '/tree/$treeId',
         params: { treeId: row.original.id },
 
-        search: {
+        search: previousSearch => ({
           tableFilter: {
             bootsTable: possibleTestsTableFilter[0],
             buildsTable: possibleBuildsTableFilter[2],
@@ -234,7 +234,8 @@ export function TreeTable({ treeTableRows }: ITreeTable): JSX.Element {
             commitName: row.original.commitName,
             headCommitHash: row.original.id,
           },
-        },
+          intervalInDays: previousSearch.intervalInDays,
+        }),
       };
     },
     [origin],

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -226,7 +226,15 @@ function TreeDetails(): JSX.Element {
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>
-            <BreadcrumbLink to="/tree" search={searchParams}>
+            <BreadcrumbLink
+              to="/tree"
+              search={previousParams => {
+                return {
+                  intervalInDays: previousParams.intervalInDays,
+                  origin: previousParams.origin,
+                };
+              }}
+            >
               <FormattedMessage id="tree.path" />
             </BreadcrumbLink>
           </BreadcrumbItem>

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -44,7 +44,11 @@ function HardwareDetails(): JSX.Element {
             <BreadcrumbLink
               to="/hardware"
               search={previousParams => {
-                return { ...previousParams, searchParams };
+                return {
+                  intervalInDays: previousParams.intervalInDays,
+                  origin: previousParams.origin,
+                  hardwareSearch: previousParams.hardwareSearch,
+                };
               }}
             >
               <FormattedMessage id="hardware.path" />

--- a/dashboard/src/routes/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/route.tsx
@@ -6,6 +6,7 @@ import { zPossibleValidator, zTableFilterInfo } from '@/types/tree/TreeDetails';
 
 const hardwareDetailsSearchSchema = z.object({
   currentPageTab: zPossibleValidator,
+  treeIndexes: z.array(z.number().int()).optional(),
   tableFilter: zTableFilterInfo.catch({
     bootsTable: 'all',
     buildsTable: 'all',

--- a/dashboard/src/routes/hardware/route.tsx
+++ b/dashboard/src/routes/hardware/route.tsx
@@ -3,12 +3,10 @@ import { z } from 'zod';
 
 import { makeZIntervalInDays } from '@/types/general';
 import { DEFAULT_HARDWARE_INTERVAL_IN_DAYS } from '@/utils/constants/hardware';
-import { zTableFilterInfoValidator } from '@/types/tree/TreeDetails';
 
 const zHardwareSchema = z.object({
   intervalInDays: makeZIntervalInDays(DEFAULT_HARDWARE_INTERVAL_IN_DAYS),
   hardwareSearch: z.string().optional().catch(undefined),
-  tableFilter: zTableFilterInfoValidator,
 });
 
 export const Route = createFileRoute('/hardware')({

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import type {
   ArchCompilerStatus,
   BuildsTabBuild,
@@ -51,3 +53,48 @@ export type THardwareDetails = {
   boots: Tests;
   trees: Trees[];
 };
+
+// TODO: move to general types
+const zFilterBoolValue = z.record(z.boolean()).optional();
+const zFilterNumberValue = z.number().optional();
+
+export const zFilterObjectsKeys = z.enum([
+  'configs',
+  'archs',
+  'compilers',
+  'buildStatus',
+  'bootStatus',
+  'testStatus',
+]);
+export const zFilterNumberKeys = z.enum([
+  'buildDurationMin',
+  'buildDurationMax',
+  'bootDurationMin',
+  'bootDurationMax',
+  'testDurationMin',
+  'testDurationMax',
+]);
+
+export type TFilterKeys =
+  | z.infer<typeof zFilterObjectsKeys>
+  | z.infer<typeof zFilterNumberKeys>;
+
+export const zDiffFilter = z
+  .union([
+    z.object({
+      configs: zFilterBoolValue,
+      archs: zFilterBoolValue,
+      buildStatus: zFilterBoolValue,
+      compilers: zFilterBoolValue,
+      bootStatus: zFilterBoolValue,
+      testStatus: zFilterBoolValue,
+      buildDurationMax: zFilterNumberValue,
+      buildDurationMin: zFilterNumberValue,
+      bootDurationMin: zFilterNumberValue,
+      bootDurationMax: zFilterNumberValue,
+      testDurationMin: zFilterNumberValue,
+      testDurationMax: zFilterNumberValue,
+    } satisfies Record<TFilterKeys, unknown>),
+    z.record(z.never()),
+  ])
+  .catch({});


### PR DESCRIPTION
Enables filtering for trees in the Hardware Details page and selection for the header table.

## How to test:
Enable dev feature flag before running the front-end by running `export VITE_FEATURE_FLAG_SHOW_DEV=true`
Enter the hardware details page and try out the row selection, check the url to see how it is sent to the backend and you may try to change the selection manually by changing the url. 

PIGGYBACKING: fixes unnecessary and wrongfully passed search parameters when clicking on the breadcrumbs.

Closes #500 
Part of #446 