### PR TITLE
Feat: add path filter to tree details

### DIFF
--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -106,7 +106,10 @@ class FilterParams:
         "gte": ["gte", ">="],
         "lt": ["lt", "<"],
         "lte": ["lte", "<="],
+        "like": ["like", "LIKE"],
     }
+
+    string_like_filters = ["test.path"]
 
     def __init__(self, request):
         self.filters = []
@@ -127,6 +130,10 @@ class FilterParams:
 
                 for value in values:
                     self.add_filter(field, value, "in")
+                continue
+
+            if filter_term in self.string_like_filters:
+                self.add_filter(filter_term, request.GET.get(k), "like")
                 continue
 
             match = self.filter_reg.match(filter_term)

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -70,6 +70,9 @@ class TreeCommitsHistory(APIView):
             self.field_values[value_name] = filter['value']
             if op == "IN":
                 clause += f" = ANY(%({value_name})s)"
+            elif op == "LIKE":
+                self.field_values[value_name] = f"%{filter['value']}%"
+                clause += f" {op} %({value_name})s"
             else:
                 clause += f" {op} %({value_name})s"
 

--- a/backend/kernelCI_app/views/treeDetailsSlowView.py
+++ b/backend/kernelCI_app/views/treeDetailsSlowView.py
@@ -27,6 +27,7 @@ class TreeDetailsSlow(View):
         self.filterTreeDetailsCompiler = set()
         self.filterArchitecture = set()
         self.filterHardware = set()
+        self.filterPath = ""
         self.filter_handlers = {
             "boot.status": self.__handle_boot_status,
             "boot.duration": self.__handle_boot_duration,
@@ -36,6 +37,7 @@ class TreeDetailsSlow(View):
             "compiler": self.__handle_compiler,
             "architecture": self.__handle_architecture,
             "test.hardware": self.__handle_hardware,
+            "test.path": self.__handle_path,
         }
 
         self.testHistory = []
@@ -94,6 +96,9 @@ class TreeDetailsSlow(View):
 
     def __handle_hardware(self, current_filter):
         self.filterHardware.add(current_filter["value"])
+
+    def __handle_path(self, current_filter):
+        self.filterPath = current_filter["value"]
 
     def __processFilters(self, request):
         try:
@@ -470,8 +475,13 @@ class TreeDetailsSlow(View):
             ) = currentRowData
 
             self.hardwareUsed.add(testEnvironmentCompatible)
+
             if (
                 (
+                    self.filterPath != ""
+                    and (self.filterPath not in path)
+                )
+                or (
                     len(self.filterHardware) > 0
                     and (testEnvironmentCompatible not in self.filterHardware)
                 )

--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -118,6 +118,7 @@ interface IBootsTable {
   filter: TestsTableFilter;
   getRowLink: (testId: TestHistory['id']) => LinkProps;
   onClickFilter: (newFilter: TestsTableFilter) => void;
+  updatePathFilter: (pathFilter: string) => void;
 }
 
 const TableCellComponent = ({
@@ -196,6 +197,7 @@ export function BootsTable({
   filter,
   getRowLink,
   onClickFilter,
+  updatePathFilter,
 }: IBootsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [pagination, setPagination] = useState<PaginationState>({
@@ -311,20 +313,40 @@ export function BootsTable({
       ?.setFilterValue(filter !== 'all' ? filter : undefined);
   }, [filter, table]);
 
+  // TODO: there should be a filtering for the frontend before the backend AND that filtering should consider the individual tests inside each test "batch" (the data from individualTestsTables), not only the rows of the external table
   const onSearchChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      table.setGlobalFilter(String(e.target.value)),
-    [table],
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.value !== undefined) {
+        updatePathFilter(e.target.value);
+      }
+      // TODO: only use the frontend filtering when the backend filter function is undefined (like in BuildDetails page)
+      table.setGlobalFilter(String(e.target.value));
+    },
+    [table, updatePathFilter],
   );
 
   const groupHeaders = table.getHeaderGroups()[0]?.headers;
   const tableHeaders = useMemo((): JSX.Element[] => {
     return groupHeaders.map(header => {
+      const headerComponent = header.isPlaceholder
+        ? null
+        : flexRender(header.column.columnDef.header, header.getContext());
       return (
-        <TableHead key={header.id}>
-          {header.isPlaceholder
-            ? null
-            : flexRender(header.column.columnDef.header, header.getContext())}
+        <TableHead key={header.id} className="border-b px-2 font-bold">
+          {header.id === 'path' ? (
+            <div className="flex items-center">
+              {headerComponent}
+              {/* TODO: add startingValue with the currentPathFilter from the diffFilter param, same for TestsTable */}
+              <DebounceInput
+                debouncedSideEffect={onSearchChange}
+                className="w-50 font-normal"
+                type="text"
+                placeholder={intl.formatMessage({ id: 'global.search' })}
+              />
+            </div>
+          ) : (
+            headerComponent
+          )}
         </TableHead>
       );
     });
@@ -416,15 +438,7 @@ export function BootsTable({
       navigationLogsActions={navigationLogsActions}
       onOpenChange={onOpenChange}
     >
-      <div className="flex justify-between">
-        <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
-        <DebounceInput
-          debouncedSideEffect={onSearchChange}
-          className="w-50"
-          type="text"
-          placeholder={intl.formatMessage({ id: 'global.search' })}
-        />
-      </div>
+      <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
       <BaseTable headerComponents={tableHeaders}>
         <TableBody>{tableRows}</TableBody>
       </BaseTable>

--- a/dashboard/src/components/Cards/HardwareUsed.tsx
+++ b/dashboard/src/components/Cards/HardwareUsed.tsx
@@ -24,6 +24,7 @@ const HardwareUsed = ({ hardwareUsed, title }: IHardwareUsed): JSX.Element => {
   return (
     <BaseCard
       title={title}
+      className="mb-0"
       content={
         <div className="flex flex-row flex-wrap gap-4 p-4">
           {hardwareSorted}

--- a/dashboard/src/components/Tabs/Tabs.tsx
+++ b/dashboard/src/components/Tabs/Tabs.tsx
@@ -39,7 +39,7 @@ const TabsComponent = ({
           key={tab.name}
           value={tab.name}
         >
-          <FormattedMessage id={tab.name} />{' '}
+          <FormattedMessage id={tab.name} />
           <div className="pl-2">{tab.rightElement}</div>
         </TabsTrigger>
       )),
@@ -63,10 +63,12 @@ const TabsComponent = ({
       defaultValue={defaultTab}
       className="w-full"
     >
-      <TabsList className="w-full justify-start bg-transparent">
-        {tabsTrigger}
-      </TabsList>
-      <div className="border-t border-darkGray py-6">{filterListElement}</div>
+      <div className="sticky top-16 z-[5] rounded-md bg-lightGray pb-6 pt-12">
+        <TabsList className="w-full justify-start rounded-none border-b border-darkGray bg-transparent">
+          {tabsTrigger}
+        </TabsList>
+        {filterListElement && <div className="pt-6">{filterListElement}</div>}
+      </div>
 
       {tabsContent}
     </Tabs>

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -47,15 +47,17 @@ export interface ITestsTable {
   columns?: ColumnDef<TPathTests>[];
   innerColumns?: ColumnDef<TIndividualTest>[];
   getRowLink: (testId: TestHistory['id']) => LinkProps;
+  updatePathFilter?: (pathFilter: string) => void;
 }
 
 export function TestsTable({
   testHistory,
   onClickFilter,
   filter,
-  getRowLink,
   columns = defaultColumns,
   innerColumns = defaultInnerColumns,
+  getRowLink,
+  updatePathFilter,
 }: ITestsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
@@ -253,20 +255,39 @@ export function TestsTable({
     [filterCount, intl, filter],
   );
 
+  // TODO: there should be a filtering for the frontend before the backend AND that filtering should consider the individual tests inside each test "batch" (the data from individualTestsTables), not only the rows of the external table
   const onSearchChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      table.setGlobalFilter(String(e.target.value)),
-    [table],
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.value !== undefined && updatePathFilter) {
+        updatePathFilter(e.target.value);
+      }
+      // TODO: remove this frontend filter when the hardwareDetails backend filtering gets in place
+      table.setGlobalFilter(String(e.target.value));
+    },
+    [table, updatePathFilter],
   );
 
   const groupHeaders = table.getHeaderGroups()[0]?.headers;
   const tableHeaders = useMemo((): JSX.Element[] => {
     return groupHeaders.map(header => {
+      const headerComponent = header.isPlaceholder
+        ? null
+        : flexRender(header.column.columnDef.header, header.getContext());
       return (
         <TableHead key={header.id} className="border-b px-2 font-bold">
-          {header.isPlaceholder
-            ? null
-            : flexRender(header.column.columnDef.header, header.getContext())}
+          {header.id === 'path_group' ? (
+            <div className="flex items-center">
+              {headerComponent}
+              <DebounceInput
+                debouncedSideEffect={onSearchChange}
+                className="w-50 font-normal"
+                type="text"
+                placeholder={intl.formatMessage({ id: 'global.search' })}
+              />
+            </div>
+          ) : (
+            headerComponent
+          )}
         </TableHead>
       );
     });
@@ -316,15 +337,7 @@ export function TestsTable({
 
   return (
     <div className="flex flex-col gap-6 pb-4">
-      <div className="flex justify-between">
-        <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
-        <DebounceInput
-          debouncedSideEffect={onSearchChange}
-          className="w-50"
-          type="text"
-          placeholder={intl.formatMessage({ id: 'global.search' })}
-        />
-      </div>
+      <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
       <BaseTable headerComponents={tableHeaders}>
         <TableBody>{tableRows}</TableBody>
       </BaseTable>

--- a/dashboard/src/components/ui/tabs.tsx
+++ b/dashboard/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-10 items-center justify-center rounded-md bg-slate-100 p-1 text-slate-500 dark:bg-slate-800 dark:text-slate-400',
+      'inline-flex h-10 items-center justify-center rounded-md bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400',
       className,
     )}
     {...props}
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300',
+      'ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300',
       className,
     )}
     {...props}

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -38,6 +38,21 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
 
   const navigate = useNavigate({ from: '/tree/$treeId/' });
 
+  const updatePathFilter = useCallback(
+    (pathFilter: string) => {
+      navigate({
+        search: previousSearch => ({
+          ...previousSearch,
+          diffFilter: {
+            ...previousSearch.diffFilter,
+            path: pathFilter === '' ? undefined : { [pathFilter]: true },
+          },
+        }),
+      });
+    },
+    [navigate],
+  );
+
   const onClickFilter = useCallback(
     (newFilter: TestsTableFilter): void => {
       navigate({
@@ -165,6 +180,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
         onClickFilter={onClickFilter}
         testHistory={data.bootHistory}
         getRowLink={getRowLink}
+        updatePathFilter={updatePathFilter}
       />
     </div>
   );

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -44,6 +44,21 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
 
   const navigate = useNavigate({ from: '/tree/$treeId' });
 
+  const updatePathFilter = useCallback(
+    (pathFilter: string) => {
+      navigate({
+        search: previousSearch => ({
+          ...previousSearch,
+          diffFilter: {
+            ...previousSearch.diffFilter,
+            path: pathFilter === '' ? undefined : { [pathFilter]: true },
+          },
+        }),
+      });
+    },
+    [navigate],
+  );
+
   const getRowLink = useCallback(
     (bootId: string): LinkProps => {
       return {
@@ -170,6 +185,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
         onClickFilter={onClickFilter}
         filter={tableFilter.testsTable}
         getRowLink={getRowLink}
+        updatePathFilter={updatePathFilter}
       />
     </div>
   );

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -149,7 +149,10 @@ function TreeDetails(): JSX.Element {
   }, [isBuildTab, testsIsLoading, buildIsLoading]);
 
   const filterListElement = useMemo(
-    () => <TreeDetailsFilterList filter={diffFilter} />,
+    () =>
+      Object.keys(diffFilter).length !== 0 ? (
+        <TreeDetailsFilterList filter={diffFilter} />
+      ) : undefined,
     [diffFilter],
   );
 
@@ -267,9 +270,11 @@ function TreeDetails(): JSX.Element {
           />
         </div>
       </QuerySwitcher>
-      <div className="relative mt-10 flex flex-col pb-2">
-        <div className="absolute right-0 top-[-16px]">
-          <TreeDetailsFilter paramFilter={diffFilter} treeUrl={treeUrl} />
+      <div className="flex flex-col pb-2">
+        <div className="sticky top-[4.5rem] z-10">
+          <div className="absolute right-0 top-2 py-4">
+            <TreeDetailsFilter paramFilter={diffFilter} treeUrl={treeUrl} />
+          </div>
         </div>
         <TreeDetailsTab
           treeDetailsData={treeDetailsData}

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -47,6 +47,7 @@ const filterFieldMap = {
   'test.duration_[gte]': 'testDurationMin',
   'test.duration_[lte]': 'testDurationMax',
   'test.hardware': 'hardware',
+  'test.path': 'path',
 } as const satisfies Record<TRequestFiltersValues, TFilterKeys>;
 
 export const mapFilterToReq = (

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilterList.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilterList.tsx
@@ -40,6 +40,9 @@ const TreeDetailsFilterList = ({
 
       if (typeof fieldSection === 'object') {
         delete fieldSection[value];
+        if (Object.keys(fieldSection).length === 0) {
+          delete newFilter[field];
+        }
       } else {
         delete newFilter[field];
       }

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -75,7 +75,10 @@ function HardwareDetails(): JSX.Element {
   );
 
   const filterListElement = useMemo(
-    () => <HardwareDetailsFilterList filter={diffFilter} />,
+    () =>
+      Object.keys(diffFilter).length !== 0 ? (
+        <HardwareDetailsFilterList filter={diffFilter} />
+      ) : undefined,
     [diffFilter],
   );
 
@@ -160,13 +163,15 @@ function HardwareDetails(): JSX.Element {
           selectedIndexes={treeIndexes}
           updateTreeFilters={updateTreeFilters}
         />
-        <div className="relative pt-2">
-          <div className="absolute right-0 top-0">
-            <HardwareDetailsFilter
-              paramFilter={diffFilter}
-              hardwareName={hardwareId}
-              data={data}
-            />
+        <div className="flex flex-col pb-2">
+          <div className="sticky top-[4.5rem] z-10">
+            <div className="absolute right-0 top-2 py-4">
+              <HardwareDetailsFilter
+                paramFilter={diffFilter}
+                hardwareName={hardwareId}
+                data={data}
+              />
+            </div>
           </div>
           <HardwareDetailsTabs
             HardwareDetailsData={data}

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilterList.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilterList.tsx
@@ -42,6 +42,9 @@ const HardwareDetailsFilterList = ({
 
       if (typeof fieldSection === 'object') {
         delete fieldSection[value];
+        if (Object.keys(fieldSection).length === 0) {
+          delete newFilter[field];
+        }
       } else {
         delete newFilter[field];
       }

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -145,7 +145,9 @@ const ErrorsSummary = ({
 export const MemoizedErrorsSummary = memo(ErrorsSummary);
 
 const BootsTab = ({ boots, hardwareId }: TBootsTab): JSX.Element => {
-  const { tableFilter } = useSearch({ from: '/hardware/$hardwareId' });
+  const { tableFilter } = useSearch({
+    from: '/hardware/$hardwareId',
+  });
 
   const getRowLink = useCallback(
     (bootId: string): LinkProps => ({
@@ -160,6 +162,21 @@ const BootsTab = ({ boots, hardwareId }: TBootsTab): JSX.Element => {
   );
 
   const navigate = useNavigate({ from: '/hardware/$hardwareId' });
+
+  const updatePathFilter = useCallback(
+    (pathFilter: string) => {
+      navigate({
+        search: previousSearch => ({
+          ...previousSearch,
+          diffFilter: {
+            ...previousSearch.diffFilter,
+            path: pathFilter === '' ? undefined : { [pathFilter]: true },
+          },
+        }),
+      });
+    },
+    [navigate],
+  );
 
   const onClickFilter = useCallback(
     (newFilter: TestsTableFilter): void => {
@@ -227,6 +244,7 @@ const BootsTab = ({ boots, hardwareId }: TBootsTab): JSX.Element => {
         filter={tableFilter.bootsTable}
         testHistory={boots.history}
         onClickFilter={onClickFilter}
+        updatePathFilter={updatePathFilter}
       />
     </div>
   );

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/HardwareDetailsTestsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/HardwareDetailsTestsTable.tsx
@@ -94,6 +94,7 @@ const HardwareDetailsTestTable = ({
   onClickFilter,
   testHistory,
   hardwareId,
+  updatePathFilter,
 }: IHardwareDetailsTestTable): JSX.Element => {
   const getRowLink = useCallback(
     (bootId: string): LinkProps => ({
@@ -114,6 +115,7 @@ const HardwareDetailsTestTable = ({
       testHistory={testHistory}
       innerColumns={innerColumns}
       getRowLink={getRowLink}
+      updatePathFilter={updatePathFilter}
     />
   );
 };

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -27,9 +27,27 @@ interface TTestsTab {
 }
 
 const TestsTab = ({ tests, hardwareId }: TTestsTab): JSX.Element => {
-  const { tableFilter } = useSearch({ from: '/hardware/$hardwareId' });
+  const { tableFilter } = useSearch({
+    from: '/hardware/$hardwareId',
+  });
 
   const navigate = useNavigate({ from: '/hardware/$hardwareId' });
+
+  // TODO: move inside the same hook for the tables, passing navigate, in order to not repeat the same code in each tab of each monitor
+  const updatePathFilter = useCallback(
+    (pathFilter: string) => {
+      navigate({
+        search: previousSearch => ({
+          ...previousSearch,
+          diffFilter: {
+            ...previousSearch.diffFilter,
+            path: pathFilter === '' ? undefined : { [pathFilter]: true },
+          },
+        }),
+      });
+    },
+    [navigate],
+  );
 
   const onClickFilter = useCallback(
     (newFilter: TestsTableFilter): void => {
@@ -97,6 +115,7 @@ const TestsTab = ({ tests, hardwareId }: TTestsTab): JSX.Element => {
         filter={tableFilter.testsTable}
         hardwareId={hardwareId}
         onClickFilter={onClickFilter}
+        updatePathFilter={updatePathFilter}
       />
     </div>
   );

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -66,6 +66,7 @@ export const zFilterObjectsKeys = z.enum([
   'bootStatus',
   'testStatus',
   'trees',
+  'path',
 ]);
 export const zFilterNumberKeys = z.enum([
   'buildDurationMin',
@@ -96,6 +97,7 @@ export const zDiffFilter = z
       testDurationMin: zFilterNumberValue,
       testDurationMax: zFilterNumberValue,
       trees: zFilterBoolValue,
+      path: zFilterBoolValue,
     } satisfies Record<TFilterKeys, unknown>),
     z.record(z.never()),
   ])

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -158,6 +158,7 @@ export const zFilterObjectsKeys = z.enum([
   'bootStatus',
   'testStatus',
   'hardware',
+  'path',
 ]);
 export const zFilterNumberKeys = z.enum([
   'buildDurationMin',
@@ -182,6 +183,7 @@ export const zDiffFilter = z
       bootStatus: zFilterBoolValue,
       testStatus: zFilterBoolValue,
       hardware: zFilterBoolValue,
+      path: zFilterBoolValue,
       buildDurationMax: zFilterNumberValue,
       buildDurationMin: zFilterNumberValue,
       bootDurationMin: zFilterNumberValue,

--- a/dashboard/src/utils/filters.ts
+++ b/dashboard/src/utils/filters.ts
@@ -7,6 +7,7 @@ const requestFilters = {
     'test.duration_[gte]',
     'test.duration_[lte]',
     'test.hardware',
+    'test.path',
     'boot.status',
     'boot.duration_[gte]',
     'boot.duration_[lte]',


### PR DESCRIPTION
- Updates UI to make tab change and filter list sticky
- Updates UI to put path searchbox within the column
- Adds filtering by test path to treeDetails page

## How to test:
Go to tests or boots tab in any treeDetails page with boots or tests data,
Scroll down to see the sticky tab selection and filter listing,
Type something in the searchbox alongside the path column,
After a certain delay, the whole page will be filtered by passing a new diffFilter,
Check the filter listing and the diffFilter search param,
The returned data should be filtered by path, including individual tests under the external tests table.

Closes #524 