### PR TITLE
feat(IssuesList): add a counter for unknown issues

### DIFF
--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -123,11 +123,19 @@ def generate_test_dict():
         "failReasons": defaultdict(int),
         "configs": defaultdict(lambda: defaultdict(int)),
         "issues": {},
+        "failedWithUnknownIssues": 0,
     }
 
 
 def is_record_in_tree_head(record, tree):
     return record["build__checkout__git_commit_hash"] == tree["headGitCommitHash"]
+
+
+def update_unknown_issues(tests_or_boots, status, builds, is_build_processed, build_is_valid):
+    if status == "FAIL":
+        tests_or_boots["failedWithUnknownIssues"] += 1
+    if not is_build_processed and build_is_valid is False:
+        builds["failedWithUnknownIssues"] += 1
 
 
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/
@@ -181,7 +189,7 @@ class HardwareDetails(View):
 
     def sanitize_records(self, records, selected_trees, filters):
         processed_builds = set()
-        builds = {"items": [], "issues": {}}
+        builds = {"items": [], "issues": {}, "failedWithUnknownIssues": 0}
 
         filters_map = self.get_filters(filters)
 
@@ -223,7 +231,8 @@ class HardwareDetails(View):
                     tests_or_boots["archSummary"][archKey] = archSummary
                 archSummary["status"][status] += 1
 
-            if build_id not in processed_builds:
+            is_build_processed = build_id in processed_builds
+            if not is_build_processed:
                 processed_builds.add(build_id)
                 build = get_build(r, current_tree["index"])
 
@@ -235,6 +244,10 @@ class HardwareDetails(View):
                 update_issues(builds["issues"], currentIssue)
                 if not jump_test:
                     update_issues(tests_or_boots["issues"], currentIssue)
+            else:
+                update_unknown_issues(
+                    tests_or_boots, r["status"], builds, is_build_processed, r["build__valid"]
+                )
 
         builds["summary"] = create_details_build_summary(builds["items"])
         properties2List(builds, ["issues"])

--- a/backend/kernelCI_app/views/treeDetailsSlowView.py
+++ b/backend/kernelCI_app/views/treeDetailsSlowView.py
@@ -64,6 +64,8 @@ class TreeDetailsSlow(View):
             lambda: IncidentInfo(incidentsCount=0)
         )
         self.hardwareUsed = set()
+        self.failedTestsWithUnknownIssues = 0
+        self.failedBootsWithUnknownIssues = 0
 
     def __handle_boot_status(self, current_filter):
         self.filterBootStatus.add(current_filter["value"])
@@ -255,11 +257,13 @@ class TreeDetailsSlow(View):
             if currentIssue:
                 currentIssue["incidents_info"]["incidentsCount"] += 1
             else:
-                self.testIssuesTable[issue_id] = create_issue(
+                self.bootsIssuesTable[issue_id] = create_issue(
                     issue_id=issue_id,
                     issue_comment=issue_comment,
                     issue_report_url=issue_report_url,
                 )
+        elif testStatus == "FAIL":
+            self.failedBootsWithUnknownIssues += 1
 
         if testId in self.processedTests:
             return
@@ -340,6 +344,9 @@ class TreeDetailsSlow(View):
                     issue_comment=issue_comment,
                     issue_report_url=issue_report_url,
                 )
+        elif testStatus == "FAIL":
+            self.failedTestsWithUnknownIssues += 1
+
         if testId in self.processedTests:
             return
         self.processedTests.add(testId)
@@ -539,6 +546,8 @@ class TreeDetailsSlow(View):
                 "bootEnvironmentCompatible": self.bootEnvironmentCompatible,
                 "incidentsIssueRelationship": self.incidentsIssueRelationship,
                 "hardwareUsed": list(self.hardwareUsed),
+                "failedTestsWithUnknownIssues": self.failedTestsWithUnknownIssues,
+                "failedBootsWithUnknownIssues": self.failedBootsWithUnknownIssues,
             },
             safe=False,
         )

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -2,6 +2,8 @@ import { memo } from 'react';
 
 import { Link } from '@tanstack/react-router';
 
+import { useIntl } from 'react-intl';
+
 import type { IBaseCard } from '@/components/Cards/BaseCard';
 import BaseCard from '@/components/Cards/BaseCard';
 import { DumbListingContent } from '@/components/ListingContent/ListingContent';
@@ -13,11 +15,20 @@ import type { TIssue } from '@/types/general';
 
 interface IIssuesList {
   issues: TIssue[];
+  failedWithUnknownIssues?: number;
   title: IBaseCard['title'];
 }
 
-const IssuesList = ({ issues, title }: IIssuesList): JSX.Element => {
-  const hasIssue = issues.length > 0;
+const IssuesList = ({
+  issues,
+  failedWithUnknownIssues,
+  title,
+}: IIssuesList): JSX.Element => {
+  const intl = useIntl();
+  failedWithUnknownIssues = failedWithUnknownIssues
+    ? failedWithUnknownIssues
+    : undefined;
+  const hasIssue = issues.length > 0 || failedWithUnknownIssues;
 
   const titleElement = (
     <span>
@@ -26,7 +37,7 @@ const IssuesList = ({ issues, title }: IIssuesList): JSX.Element => {
         <ColoredCircle
           className="ml-2 font-normal"
           backgroundClassName={ItemType.Error}
-          quantity={issues.length}
+          quantity={issues.length + (failedWithUnknownIssues ? 1 : 0)}
         />
       )}
     </span>
@@ -49,6 +60,12 @@ const IssuesList = ({ issues, title }: IIssuesList): JSX.Element => {
           </WrapperLink>
         );
       })}
+      {failedWithUnknownIssues && (
+        <ListingItem
+          unknown={failedWithUnknownIssues}
+          text={intl.formatMessage({ id: 'global.unknown' })}
+        />
+      )}
     </DumbListingContent>
   );
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -139,6 +139,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
           <MemoizedIssuesList
             title={<FormattedMessage id="global.issues" />}
             issues={data.bootIssues}
+            failedWithUnknownIssues={data.failedBootsWithUnknownIssues}
           />
         </div>
         <div>
@@ -168,6 +169,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
             <MemoizedIssuesList
               title={<FormattedMessage id="global.issues" />}
               issues={data.bootIssues}
+              failedWithUnknownIssues={data.failedBootsWithUnknownIssues}
             />
           </div>
           <div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -172,6 +172,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
           <MemoizedIssuesList
             title={<FormattedMessage id="global.issues" />}
             issues={treeDetailsData.issues || []}
+            failedWithUnknownIssues={treeDetailsData.failedWithUnknownIssues}
           />
         </div>
         <div>
@@ -201,6 +202,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
         <MemoizedIssuesList
           title={<FormattedMessage id="global.issues" />}
           issues={treeDetailsData.issues}
+          failedWithUnknownIssues={treeDetailsData.failedWithUnknownIssues}
         />
       </MobileGrid>
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -143,6 +143,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
           <MemoizedIssuesList
             title={<FormattedMessage id="global.issues" />}
             issues={data.testIssues}
+            failedWithUnknownIssues={data.failedTestsWithUnknownIssues}
           />
         </div>
         <div>
@@ -172,6 +173,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
             <MemoizedIssuesList
               title={<FormattedMessage id="global.issues" />}
               issues={data.testIssues}
+              failedWithUnknownIssues={data.failedTestsWithUnknownIssues}
             />
           </div>
           <div>

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -59,6 +59,7 @@ export interface ITreeDetails {
   buildsSummary: BuildStatus;
   builds: AccordionItemBuilds[];
   issues: BuildsTab['issues'];
+  failedWithUnknownIssues?: number;
 }
 
 interface ITreeHeader {
@@ -213,6 +214,7 @@ function TreeDetails(): JSX.Element {
       builds: sanitizeBuilds(buildData?.builds),
       buildsSummary: sanitizeBuildsSummary(buildData?.summary.builds),
       issues: buildData?.issues || [],
+      failedWithUnknownIssues: buildData?.failedWithUnknownIssues,
     }),
     [buildData],
   );

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -217,6 +217,7 @@ const BootsTab = ({ boots, hardwareId }: TBootsTab): JSX.Element => {
           <MemoizedIssuesList
             title={<FormattedMessage id="global.issues" />}
             issues={boots.issues}
+            failedWithUnknownIssues={boots.failedWithUnknownIssues}
           />
         </div>
       </DesktopGrid>
@@ -238,6 +239,7 @@ const BootsTab = ({ boots, hardwareId }: TBootsTab): JSX.Element => {
             <MemoizedIssuesList
               title={<FormattedMessage id="global.issues" />}
               issues={boots.issues}
+              failedWithUnknownIssues={boots.failedWithUnknownIssues}
             />
           </div>
         </InnerMobileGrid>

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -298,6 +298,7 @@ const BuildTab = ({ builds, hardwareId }: TBuildTab): JSX.Element => {
           <MemoizedIssuesList
             title={<FormattedMessage id="global.issues" />}
             issues={builds.issues}
+            failedWithUnknownIssues={builds.failedWithUnknownIssues}
           />
         </div>
         <MemoizedConfigsCard
@@ -323,6 +324,7 @@ const BuildTab = ({ builds, hardwareId }: TBuildTab): JSX.Element => {
         <MemoizedIssuesList
           title={<FormattedMessage id="global.issues" />}
           issues={builds.issues}
+          failedWithUnknownIssues={builds.failedWithUnknownIssues}
         />
       </MobileGrid>
 

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -87,6 +87,7 @@ const TestsTab = ({ tests, hardwareId }: TTestsTab): JSX.Element => {
           <MemoizedIssuesList
             title={<FormattedMessage id="global.issues" />}
             issues={tests.issues}
+            failedWithUnknownIssues={tests.failedWithUnknownIssues}
           />
         </div>
       </DesktopGrid>
@@ -108,6 +109,7 @@ const TestsTab = ({ tests, hardwareId }: TTestsTab): JSX.Element => {
             <MemoizedIssuesList
               title={<FormattedMessage id="global.issues" />}
               issues={tests.issues}
+              failedWithUnknownIssues={tests.failedWithUnknownIssues}
             />
           </div>
         </InnerMobileGrid>

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -27,6 +27,7 @@ type BuildsData = {
   items: BuildsTabBuild[];
   issues: TIssue[];
   summary: BuildSummary;
+  failedWithUnknownIssues: number;
 };
 
 type Tests = {
@@ -37,6 +38,7 @@ type Tests = {
   failReasons: Record<string, unknown>;
   configs: Record<string, StatusCounts>;
   issues: TIssue[];
+  failedWithUnknownIssues: number;
 };
 
 export type Trees = {

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -40,6 +40,7 @@ export type BuildsTab = {
     architectures: Architecture;
   };
   issues: TIssue[];
+  failedWithUnknownIssues: number;
 };
 
 export interface TTreeDetailsFilter
@@ -91,6 +92,8 @@ export type TTreeTestsFullData = {
   testEnvironmentCompatible: PropertyStatusCounts;
   bootEnvironmentCompatible: PropertyStatusCounts;
   hardwareUsed: string[];
+  failedTestsWithUnknownIssues: number;
+  failedBootsWithUnknownIssues: number;
 };
 
 const possibleTabs = ['global.builds', 'global.boots', 'global.tests'] as const;


### PR DESCRIPTION
Add a counter containing the number of failed tests with no linked issues. To do it, add an optional parameter to `IssuesList` that accept the number of total failed tests/builds/boots. If the parameter is not present the behaviour of the Issues List is equal as it was before, otherwise it adds a new line to the list containing the number of unknown issues.

Close #544