### PR TITLE
Feat: add arch column on buildsTable

### DIFF
--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -181,6 +181,7 @@ export function BuildsTable({
     return buildItems?.map(row => ({
       ...row,
       config: row.config ?? '-',
+      architecture: row.architecture ?? '-',
       compiler: row.compiler ?? '-',
       buildTime: row.buildTime ? (
         <span>

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -90,6 +90,7 @@ export const messages = {
     'filter.treeSubtitle': 'Please select one or more Trees:',
     'filter.treeURL': 'Tree URL',
     'global.allCount': 'All: {count}',
+    'global.arch': 'Arch',
     'global.architecture': 'Architecture',
     'global.boots': 'Boots',
     'global.branch': 'Branch',

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -40,6 +40,16 @@ const columns: ColumnDef<AccordionItemBuilds>[] = [
       }),
   },
   {
+    accessorKey: 'architecture',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'global.arch',
+        intlDefaultMessage: 'Arch',
+      }),
+  },
+  {
     accessorKey: 'compiler',
     header: ({ column }): JSX.Element =>
       TableHeader({

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -51,6 +51,16 @@ const columns: ColumnDef<AccordionItemBuilds>[] = [
       }),
   },
   {
+    accessorKey: 'architecture',
+    header: ({ column }): JSX.Element =>
+      TableHeader({
+        column: column,
+        sortable: true,
+        intlKey: 'global.arch',
+        intlDefaultMessage: 'Arch',
+      }),
+  },
+  {
     accessorKey: 'compiler',
     header: ({ column }): JSX.Element =>
       TableHeader({

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -19,6 +19,7 @@ import type { Status } from '@/types/database';
 export type AccordionItemBuilds = {
   id: string;
   config?: string;
+  architecture?: string;
   compiler?: string;
   date?: string;
   buildErrors?: number;

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -71,6 +71,7 @@ export const sanitizeBuilds = (
   return builds.map(build => ({
     id: build.id,
     config: build.config_name,
+    architecture: build.architecture,
     date: build.start_time,
     buildTime: build.duration,
     compiler: build.compiler,


### PR DESCRIPTION
Adds an "arch" column to the build execution list aka buildsTable.
Added as the second column to follow the arch summary card, which shows the architecture before the compiler.

## How to test
Go to a hardwareDetails page or TreeDetails page with build data, scroll down, check the arch column in the buildsTable.

Closes #590