### PR TITLE
fix(side-menu): stop parameters from contaminating

### DIFF
--- a/dashboard/src/components/SideMenu/SideMenu.tsx
+++ b/dashboard/src/components/SideMenu/SideMenu.tsx
@@ -67,7 +67,9 @@ const SideMenuItem = ({ item }: SideMenuItemProps): JSX.Element => {
     >
       <NavLink
         to={item.navigateTo}
-        search={prevSearch => prevSearch}
+        search={prevSearch => ({
+          origin: prevSearch.origin,
+        })}
         icon={item.icon}
         idIntl={item.idIntl}
       />


### PR DESCRIPTION
When you click the sidebar unnecessary parameters are contaminating the
other session

Closes #607
