### PR TITLE
feat(HardwareDetails page): add CommitNavigationGraph to all tabs

### DIFF
--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -198,6 +198,11 @@ class TreeCommitsHistory(APIView):
                 git_repository_branch = %(git_branch_param)s
                 AND git_repository_url = %(git_url_param)s
                 AND origin = %(origin_param)s
+                AND start_time <= (
+                    SELECT MAX(start_time) as head_start_time
+                    FROM checkouts
+                    WHERE git_commit_hash = %(commit_hash)s
+                )
             ORDER BY
                 start_time DESC
         ),

--- a/backend/requests/hardware-details-post.sh
+++ b/backend/requests/hardware-details-post.sh
@@ -6,7 +6,6 @@ Content-Type:application/json \
         "1": "selected"
     },
     "origin": "maestro",
-    "startTimestampInSeconds": 1731275753,
-    "endTimestampInSeconds": 1731448553
+    "limitTimestampInSeconds": 1731448553
 }'
 

--- a/backend/requests/hardware-details-post.sh
+++ b/backend/requests/hardware-details-post.sh
@@ -2,7 +2,7 @@ http POST http://localhost:8000/api/hardware/fsl,imx6q-sabrelite \
 Content-Type:application/json \
 <<< '{
     "selectedTrees": {
-        "0": "selected",
+        "0": "894861d67a0f883c2fa20a8ce58634c15d0a27dd",
         "1": "selected"
     },
     "origin": "maestro",

--- a/dashboard/src/api/commitHistory.ts
+++ b/dashboard/src/api/commitHistory.ts
@@ -1,0 +1,76 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+
+import type {
+  TTreeCommitHistoryResponse,
+  TTreeDetailsFilter,
+} from '@/types/tree/TreeDetails';
+
+import { getTargetFilter } from '@/utils/filters';
+import { mapFiltersKeysToBackendCompatible } from '@/utils/utils';
+
+import http from './api';
+
+const fetchCommitHistory = async (
+  commitHash: string,
+  origin: string,
+  gitUrl: string,
+  gitBranch: string,
+  filters: TTreeDetailsFilter,
+): Promise<TTreeCommitHistoryResponse> => {
+  const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
+
+  const params = {
+    origin,
+    git_url: gitUrl,
+    git_branch: gitBranch,
+    ...filtersFormatted,
+  };
+
+  const res = await http.get<TTreeCommitHistoryResponse>(
+    `/api/tree/${commitHash}/commits`,
+    {
+      params,
+    },
+  );
+  return res.data;
+};
+
+export const useCommitHistory = (
+  {
+    commitHash,
+    origin,
+    gitUrl,
+    gitBranch,
+    filter,
+  }: {
+    commitHash: string;
+    origin: string;
+    gitUrl: string;
+    gitBranch: string;
+    filter: TTreeDetailsFilter;
+  },
+  { enabled = true },
+): UseQueryResult<TTreeCommitHistoryResponse> => {
+  const testFilter = getTargetFilter(filter, 'test');
+  const treeDetailsFilter = getTargetFilter(filter, 'treeDetails');
+
+  const filters = {
+    ...treeDetailsFilter,
+    ...testFilter,
+  };
+
+  return useQuery({
+    queryKey: [
+      'treeCommitHistory',
+      commitHash,
+      origin,
+      gitUrl,
+      gitBranch,
+      filters,
+    ],
+    enabled,
+    queryFn: () =>
+      fetchCommitHistory(commitHash, origin, gitUrl, gitBranch, filters),
+  });
+};

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import type {
   THardwareDetails,
   THardwareDetailsFilter,
+  TTreeCommits,
 } from '@/types/hardware/hardwareDetails';
 import { getTargetFilter } from '@/types/hardware/hardwareDetails';
 import type { TOrigins } from '@/types/general';
@@ -47,12 +48,21 @@ const fetchHardwareDetails = async (
   return res.data;
 };
 
+const TREE_SELECT_HEAD_VALUE = 'head';
+
 const mapIndexesToSelectedTrees = (
   selectedIndexes: number[],
-): Record<number, string> => {
-  return Object.fromEntries(
-    Array.from(selectedIndexes, index => [index.toString(), 'selected']),
-  );
+  treeCommits: TTreeCommits = {},
+): Record<string, string> => {
+  const selectedTrees: Record<string, string> = {};
+
+  selectedIndexes.forEach(idx => {
+    const key = idx.toString();
+    const value = treeCommits[key] || TREE_SELECT_HEAD_VALUE;
+    selectedTrees[key] = value;
+  });
+
+  return selectedTrees;
 };
 
 export const useHardwareDetails = (
@@ -62,11 +72,11 @@ export const useHardwareDetails = (
   origin: TOrigins,
   filter: { [key: string]: string[] },
   selectedIndexes: number[],
+  treeCommits: TTreeCommits,
 ): UseQueryResult<THardwareDetails> => {
   const detailsFilter = getTargetFilter(filter, 'hardwareDetails');
   const filtersFormatted = mapFiltersKeysToBackendCompatible(detailsFilter);
-
-  const selectedTrees = mapIndexesToSelectedTrees(selectedIndexes);
+  const selectedTrees = mapIndexesToSelectedTrees(selectedIndexes, treeCommits);
 
   const body: fetchHardwareDetailsBody = {
     origin,

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -12,8 +12,7 @@ import type { TOrigins } from '@/types/general';
 import http from './api';
 
 type fetchHardwareDetailsBody = {
-  startTimestampInSeconds: number;
-  endTimestampInSeconds: number;
+  limitTimestampInSeconds: number;
   origin: TOrigins;
   selectedTrees: Record<string, string>;
   filter?: Record<string, string[]>;
@@ -67,8 +66,7 @@ const mapIndexesToSelectedTrees = (
 
 export const useHardwareDetails = (
   hardwareId: string,
-  startTimestampInSeconds: number,
-  endTimestampInSeconds: number,
+  limitTimestampInSeconds: number,
   origin: TOrigins,
   filter: { [key: string]: string[] },
   selectedIndexes: number[],
@@ -80,8 +78,7 @@ export const useHardwareDetails = (
 
   const body: fetchHardwareDetailsBody = {
     origin,
-    startTimestampInSeconds,
-    endTimestampInSeconds,
+    limitTimestampInSeconds,
     selectedTrees,
     filter: filtersFormatted,
   };

--- a/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
+++ b/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
@@ -2,42 +2,46 @@ import { useIntl } from 'react-intl';
 
 import { memo, useMemo } from 'react';
 
-import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
-
 import { z } from 'zod';
 
 import { Colors } from '@/components/StatusChart/StatusCharts';
 import { LineChart } from '@/components/LineChart';
 import BaseCard from '@/components/Cards/BaseCard';
-import { useTreeCommitHistory } from '@/api/TreeDetails';
 import type { TLineChartProps } from '@/components/LineChart/LineChart';
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import type { MessagesKey } from '@/locales/messages';
 import { formatDate } from '@/utils/utils';
 import { mapFilterToReq } from '@/pages/TreeDetails/TreeDetailsFilter';
+import type { TFilter } from '@/types/tree/TreeDetails';
+import { useCommitHistory } from '@/api/commitHistory';
 
 const graphDisplaySize = 7;
 
-const CommitNavigationGraph = (): JSX.Element => {
+interface ICommitNavigationGraph {
+  origin: string;
+  currentPageTab: string;
+  diffFilter: TFilter;
+  gitUrl?: string;
+  gitBranch?: string;
+  headCommitHash?: string;
+  treeId?: string;
+  onMarkClick: (commitHash: string, commitName?: string) => void;
+}
+const CommitNavigationGraph = ({
+  origin,
+  currentPageTab,
+  diffFilter,
+  gitUrl,
+  gitBranch,
+  headCommitHash,
+  treeId,
+  onMarkClick,
+}: ICommitNavigationGraph): JSX.Element => {
   const { formatMessage } = useIntl();
-  const {
-    origin,
-    currentPageTab,
-    diffFilter,
-    treeInfo: { gitUrl, gitBranch, headCommitHash },
-  } = useSearch({ from: '/tree/$treeId/' });
-
-  const { treeId } = useParams({
-    from: '/tree/$treeId/',
-  });
-
-  const navigate = useNavigate({
-    from: '/tree/$treeId',
-  });
 
   const reqFilter = mapFilterToReq(diffFilter);
 
-  const { data, status } = useTreeCommitHistory(
+  const { data, status } = useCommitHistory(
     {
       gitBranch: gitBranch ?? '',
       gitUrl: gitUrl ?? '',
@@ -252,20 +256,7 @@ const CommitNavigationGraph = (): JSX.Element => {
               const commitHash = commitData[commitIndex].commitHash;
               const commitName = commitData[commitIndex].commitName;
               if (commitHash) {
-                navigate({
-                  to: '/tree/$treeId',
-                  params: {
-                    treeId: commitHash,
-                  },
-                  search: previousParams => ({
-                    ...previousParams,
-                    treeInfo: {
-                      ...previousParams.treeInfo,
-                      commitName: commitName,
-                      commitHash: commitHash,
-                    },
-                  }),
-                });
+                onMarkClick(commitHash, commitName);
               }
             }}
           />

--- a/dashboard/src/pages/Hardware/HardwareListingPage.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPage.tsx
@@ -106,8 +106,7 @@ const HardwareListingPage = ({
       <div className="flex flex-col gap-6">
         <HardwareTable
           treeTableRows={listItems}
-          startTimestampInSeconds={startTimestampInSeconds}
-          endTimestampInSeconds={endTimestampInSeconds}
+          limitTimestampInSeconds={endTimestampInSeconds}
         />
       </div>
     </QuerySwitcher>

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -139,14 +139,12 @@ const columns: ColumnDef<HardwareTableItem>[] = [
 
 interface ITreeTable {
   treeTableRows: HardwareTableItem[];
-  startTimestampInSeconds: number;
-  endTimestampInSeconds: number;
+  limitTimestampInSeconds: number;
 }
 
 export function HardwareTable({
   treeTableRows,
-  startTimestampInSeconds,
-  endTimestampInSeconds,
+  limitTimestampInSeconds,
 }: ITreeTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -163,12 +161,11 @@ export function HardwareTable({
         params: { hardwareId: row.original.hardwareName },
         search: previousSearch => ({
           ...previousSearch,
-          startTimestampInSeconds,
-          endTimestampInSeconds,
+          limitTimestampInSeconds,
         }),
       };
     },
-    [endTimestampInSeconds, startTimestampInSeconds],
+    [limitTimestampInSeconds],
   );
 
   const data = useMemo(() => {

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -15,7 +15,6 @@ import {
   MobileGrid,
 } from '@/pages/TreeDetails/Tabs/TabGrid';
 
-import CommitNavigationGraph from '@/pages/TreeDetails/Tabs/CommitNavigationGraph';
 import { BootsTable } from '@/components/BootsTable/BootsTable';
 import MemoizedStatusChart from '@/components/Cards/StatusChart';
 import MemoizedConfigList from '@/components/Cards/ConfigsList';
@@ -23,6 +22,8 @@ import MemoizedErrorsSummary from '@/components/Cards/ErrorsSummary';
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
 import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+
+import TreeCommitNavigationGraph from '@/pages/TreeDetails/Tabs/TreeCommitNavigationGraph';
 
 interface BootsTabProps {
   reqFilter: Record<string, string[]>;
@@ -142,7 +143,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
           />
         </div>
         <div>
-          <CommitNavigationGraph />
+          <TreeCommitNavigationGraph />
           <MemoizedHardwareTested
             title={<FormattedMessage id="bootsTab.hardwareTested" />}
             environmentCompatible={data.bootEnvironmentCompatible}
@@ -154,7 +155,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
           title={<FormattedMessage id="bootsTab.bootStatus" />}
           statusCounts={data.bootStatusSummary}
         />
-        <CommitNavigationGraph />
+        <TreeCommitNavigationGraph />
         <InnerMobileGrid>
           <div>
             <MemoizedConfigList

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -13,7 +13,6 @@ import type { TFilterObjectsKeys } from '@/types/tree/TreeDetails';
 import type { ITreeDetails } from '@/pages/TreeDetails/TreeDetails';
 import BaseCard from '@/components/Cards/BaseCard';
 
-import CommitNavigationGraph from '@/pages/TreeDetails/Tabs/CommitNavigationGraph';
 import { MemoizedErrorsSummaryBuild } from '@/pages/TreeDetails/Tabs/BuildCards';
 
 import { BuildStatus } from '@/components/Status/Status';
@@ -24,7 +23,13 @@ import FilterLink from '@/pages/TreeDetails/TreeDetailsFilterLink';
 
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
-import { DesktopGrid, InnerMobileGrid, MobileGrid } from '../TabGrid';
+import TreeCommitNavigationGraph from '@/pages/TreeDetails/Tabs/TreeCommitNavigationGraph';
+
+import {
+  DesktopGrid,
+  InnerMobileGrid,
+  MobileGrid,
+} from '@/pages/TreeDetails/Tabs/TabGrid';
 
 import { TreeDetailsBuildsTable } from './TreeDetailsBuildsTable';
 
@@ -175,7 +180,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
           />
         </div>
         <div>
-          <CommitNavigationGraph />
+          <TreeCommitNavigationGraph />
           <MemoizedConfigsCard
             configs={treeDetailsData.configs}
             toggleFilterBySection={toggleFilterBySection}
@@ -183,7 +188,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
         </div>
       </DesktopGrid>
       <MobileGrid>
-        <CommitNavigationGraph />
+        <TreeCommitNavigationGraph />
         <MemoizedStatusCard
           toggleFilterBySection={toggleFilterBySection}
           buildsSummary={treeDetailsData.buildsSummary}

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -17,7 +17,6 @@ import {
   InnerMobileGrid,
   MobileGrid,
 } from '@/pages/TreeDetails/Tabs/TabGrid';
-import CommitNavigationGraph from '@/pages/TreeDetails/Tabs/CommitNavigationGraph';
 
 import MemoizedStatusChart from '@/components/Cards/StatusChart';
 import MemoizedConfigList from '@/components/Cards/ConfigsList';
@@ -26,6 +25,8 @@ import MemoizedIssuesList from '@/components/Cards/IssuesList';
 import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
 
 import { TestsTable } from '@/components/TestsTable/TestsTable';
+
+import TreeCommitNavigationGraph from '@/pages/TreeDetails/Tabs/TreeCommitNavigationGraph';
 
 interface TestsTabProps {
   reqFilter: Record<string, string[]>;
@@ -146,7 +147,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
           />
         </div>
         <div>
-          <CommitNavigationGraph />
+          <TreeCommitNavigationGraph />
           <MemoizedHardwareTested
             title={<FormattedMessage id="testsTab.hardwareTested" />}
             environmentCompatible={data.testEnvironmentCompatible}
@@ -158,7 +159,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
           title={<FormattedMessage id="testsTab.testStatus" />}
           statusCounts={data.testStatusSummary}
         />
-        <CommitNavigationGraph />
+        <TreeCommitNavigationGraph />
         <InnerMobileGrid>
           <div>
             <MemoizedConfigList

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
@@ -1,0 +1,57 @@
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+
+import { useCallback } from 'react';
+
+import CommitNavigationGraph from '@/components/CommitNavigationGraph/CommitNavigationGraph';
+
+const TreeCommitNavigationGraph = (): React.ReactNode => {
+  const {
+    origin,
+    currentPageTab,
+    diffFilter,
+    treeInfo: { gitUrl, gitBranch, headCommitHash },
+  } = useSearch({ from: '/tree/$treeId/' });
+
+  const { treeId } = useParams({
+    from: '/tree/$treeId/',
+  });
+
+  const navigate = useNavigate({
+    from: '/tree/$treeId',
+  });
+
+  const markClickHandle = useCallback(
+    (commitHash: string, commitName?: string) => {
+      navigate({
+        to: '/tree/$treeId',
+        params: {
+          treeId: commitHash,
+        },
+        search: previousParams => ({
+          ...previousParams,
+          treeInfo: {
+            ...previousParams.treeInfo,
+            commitName: commitName,
+            commitHash: commitHash,
+          },
+        }),
+      });
+    },
+    [navigate],
+  );
+
+  return (
+    <CommitNavigationGraph
+      origin={origin}
+      gitBranch={gitBranch}
+      gitUrl={gitUrl}
+      treeId={treeId}
+      headCommitHash={headCommitHash}
+      onMarkClick={markClickHandle}
+      diffFilter={diffFilter}
+      currentPageTab={currentPageTab}
+    />
+  );
+};
+
+export default TreeCommitNavigationGraph;

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -42,12 +42,14 @@ const sanitizeTreeItems = (treeItems: Trees[]): Trees[] =>
 function HardwareDetails(): JSX.Element {
   const {
     treeIndexes,
+    treeCommits,
     startTimestampInSeconds,
     endTimestampInSeconds,
     diffFilter,
+    origin,
   } = useSearch({ from: '/hardware/$hardwareId' });
+
   const { hardwareId } = useParams({ from: '/hardware/$hardwareId' });
-  const { origin } = useSearch({ from: '/hardware' });
 
   const navigate = useNavigate({ from: '/hardware/$hardwareId' });
 
@@ -72,6 +74,7 @@ function HardwareDetails(): JSX.Element {
     origin,
     reqFilter,
     treeIndexes ?? [],
+    treeCommits,
   );
 
   const filterListElement = useMemo(
@@ -174,7 +177,7 @@ function HardwareDetails(): JSX.Element {
             </div>
           </div>
           <HardwareDetailsTabs
-            HardwareDetailsData={data}
+            hardwareDetailsData={data}
             hardwareId={hardwareId}
             filterListElement={filterListElement}
             countElements={tabsCounts}

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -43,8 +43,7 @@ function HardwareDetails(): JSX.Element {
   const {
     treeIndexes,
     treeCommits,
-    startTimestampInSeconds,
-    endTimestampInSeconds,
+    limitTimestampInSeconds,
     diffFilter,
     origin,
   } = useSearch({ from: '/hardware/$hardwareId' });
@@ -69,8 +68,7 @@ function HardwareDetails(): JSX.Element {
 
   const { data, isLoading } = useHardwareDetails(
     hardwareId,
-    startTimestampInSeconds,
-    endTimestampInSeconds,
+    limitTimestampInSeconds,
     origin,
     reqFilter,
     treeIndexes ?? [],

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
@@ -27,7 +27,7 @@ import { PaginationInfo } from '@/components/Table/PaginationInfo';
 import { IndeterminateCheckbox } from '@/components/Checkbox/IndeterminateCheckbox';
 import { useDebounce } from '@/hooks/useDebounce';
 
-const DEBOUNCE_INTERVAL = 1000;
+const DEBOUNCE_INTERVAL = 2000;
 
 interface IHardwareHeader {
   treeItems: Trees[];

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -33,11 +33,14 @@ import { DumbSummary } from '@/components/Summary/Summary';
 
 import type { ArchCompilerStatus } from '@/types/general';
 
-import FilterLink from '../../HardwareDetailsFilterLink';
-import { MemoizedSummaryItem } from '../Build/BuildTab';
+import FilterLink from '@/pages/hardwareDetails/HardwareDetailsFilterLink';
+
+import { MemoizedSummaryItem } from '@/pages/hardwareDetails/Tabs/Build/BuildTab';
+import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph';
 
 interface TBootsTab {
   boots: THardwareDetails['boots'];
+  trees: THardwareDetails['trees'];
   hardwareId: string;
 }
 
@@ -144,7 +147,7 @@ const ErrorsSummary = ({
 //TODO: put it in other file to be reused
 export const MemoizedErrorsSummary = memo(ErrorsSummary);
 
-const BootsTab = ({ boots, hardwareId }: TBootsTab): JSX.Element => {
+const BootsTab = ({ boots, trees, hardwareId }: TBootsTab): JSX.Element => {
   const { tableFilter, diffFilter } = useSearch({
     from: '/hardware/$hardwareId',
   });
@@ -219,12 +222,14 @@ const BootsTab = ({ boots, hardwareId }: TBootsTab): JSX.Element => {
             issues={boots.issues}
           />
         </div>
+        <HardwareCommitNavigationGraph trees={trees} hardwareId={hardwareId} />
       </DesktopGrid>
       <MobileGrid>
         <MemoizedStatusChart
           title={<FormattedMessage id="bootsTab.bootStatus" />}
           statusCounts={boots.statusSummary}
         />
+        <HardwareCommitNavigationGraph trees={trees} hardwareId={hardwareId} />
         <InnerMobileGrid>
           <div>
             <MemoizedConfigList

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -30,12 +30,15 @@ import ListingItem from '@/components/ListingItem/ListingItem';
 
 import { TableCell, TableCellWithLink, TableRow } from '@/components/ui/table';
 
-import FilterLink from '../../HardwareDetailsFilterLink';
+import FilterLink from '@/pages/hardwareDetails/HardwareDetailsFilterLink';
+
+import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph';
 
 import { HardwareDetailsBuildsTable } from './HardwareDetailsBuildsTable';
 
 interface TBuildTab {
   builds: THardwareDetails['builds'];
+  trees: THardwareDetails['trees'];
   hardwareId: string;
 }
 
@@ -235,7 +238,7 @@ const ConfigsCard = ({
 //TODO: put it in other file to be reused
 export const MemoizedConfigsCard = memo(ConfigsCard);
 
-const BuildTab = ({ builds, hardwareId }: TBuildTab): JSX.Element => {
+const BuildTab = ({ builds, trees, hardwareId }: TBuildTab): JSX.Element => {
   /* const navigate = useNavigate({
     from: '/hardware/$hardwareId/',
   }); */
@@ -300,12 +303,19 @@ const BuildTab = ({ builds, hardwareId }: TBuildTab): JSX.Element => {
             issues={builds.issues}
           />
         </div>
-        <MemoizedConfigsCard
-          configs={configsItems}
-          toggleFilterBySection={toggleFilterBySection}
-        />
+        <div>
+          <HardwareCommitNavigationGraph
+            trees={trees}
+            hardwareId={hardwareId}
+          />
+          <MemoizedConfigsCard
+            configs={configsItems}
+            toggleFilterBySection={toggleFilterBySection}
+          />
+        </div>
       </DesktopGrid>
       <MobileGrid>
+        <HardwareCommitNavigationGraph trees={trees} hardwareId={hardwareId} />
         <MemoizedStatusCard
           toggleFilterBySection={toggleFilterBySection}
           buildsSummary={builds.summary.builds}

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
@@ -1,0 +1,64 @@
+import { useNavigate, useSearch } from '@tanstack/react-router';
+
+import { useCallback, useMemo } from 'react';
+
+import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import CommitNavigationGraph from '@/components/CommitNavigationGraph/CommitNavigationGraph';
+
+interface ICommitNavigationGraph {
+  trees: THardwareDetails['trees'];
+  hardwareId: string;
+}
+const HardwareCommitNavigationGraph = ({
+  trees,
+  hardwareId,
+}: ICommitNavigationGraph): React.ReactNode => {
+  const { diffFilter, treeIndexes, origin, currentPageTab, treeCommits } =
+    useSearch({
+      from: '/hardware/$hardwareId',
+    });
+
+  const navigate = useNavigate({ from: '/hardware/$hardwareId/' });
+
+  const diffFilterWithHardware = useMemo(
+    () => ({ ...diffFilter, hardware: { [hardwareId]: true } }),
+    [diffFilter, hardwareId],
+  );
+
+  const treeIdx =
+    trees.length === 1 ? 0 : treeIndexes?.length === 1 ? treeIndexes[0] : null;
+  const tree = treeIdx !== null && trees[treeIdx];
+
+  const markClickHandle = useCallback(
+    (commitHash: string) => {
+      if (treeIdx === null) return;
+
+      navigate({
+        search: current => ({
+          ...current,
+          treeCommits: { ...current.treeCommits, [treeIdx]: commitHash },
+        }),
+      });
+    },
+    [navigate, treeIdx],
+  );
+
+  if (!tree) return <></>;
+
+  const treeId = treeCommits?.[treeIdx] ?? tree['headGitCommitHash'];
+
+  return (
+    <CommitNavigationGraph
+      origin={origin}
+      gitBranch={tree.gitRepositoryBranch}
+      gitUrl={tree.gitRepositoryUrl}
+      treeId={treeId}
+      headCommitHash={tree.headGitCommitHash}
+      onMarkClick={markClickHandle}
+      diffFilter={diffFilterWithHardware}
+      currentPageTab={currentPageTab}
+    />
+  );
+};
+
+export default HardwareCommitNavigationGraph;

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -20,14 +20,14 @@ export type TreeDetailsTabRightElement = Record<
 >;
 
 export interface IHardwareDetailsTab {
-  HardwareDetailsData: THardwareDetails;
+  hardwareDetailsData: THardwareDetails;
   hardwareId: string;
   filterListElement?: JSX.Element;
   countElements: TreeDetailsTabRightElement;
 }
 
 const HardwareDetailsTabs = ({
-  HardwareDetailsData,
+  hardwareDetailsData,
   hardwareId,
   filterListElement,
   countElements,
@@ -59,7 +59,8 @@ const HardwareDetailsTabs = ({
         name: 'global.builds',
         content: (
           <BuildTab
-            builds={HardwareDetailsData.builds}
+            builds={hardwareDetailsData.builds}
+            trees={hardwareDetailsData.trees}
             hardwareId={hardwareId}
           />
         ),
@@ -69,7 +70,11 @@ const HardwareDetailsTabs = ({
       {
         name: 'global.boots',
         content: (
-          <BootsTab boots={HardwareDetailsData.boots} hardwareId={hardwareId} />
+          <BootsTab
+            boots={hardwareDetailsData.boots}
+            hardwareId={hardwareId}
+            trees={hardwareDetailsData.trees}
+          />
         ),
         rightElement: countElements['global.boots'],
         disabled: false,
@@ -77,18 +82,23 @@ const HardwareDetailsTabs = ({
       {
         name: 'global.tests',
         content: (
-          <TestsTab tests={HardwareDetailsData.tests} hardwareId={hardwareId} />
+          <TestsTab
+            tests={hardwareDetailsData.tests}
+            hardwareId={hardwareId}
+            trees={hardwareDetailsData.trees}
+          />
         ),
         rightElement: countElements['global.tests'],
         disabled: false,
       },
     ],
     [
-      HardwareDetailsData.boots,
-      HardwareDetailsData.builds,
-      HardwareDetailsData.tests,
-      countElements,
+      hardwareDetailsData.builds,
+      hardwareDetailsData.trees,
+      hardwareDetailsData.boots,
+      hardwareDetailsData.tests,
       hardwareId,
+      countElements,
     ],
   );
 

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -17,16 +17,22 @@ import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
 
 import type { TestsTableFilter } from '@/types/tree/TreeDetails';
 
-import { MemoizedConfigList, MemoizedErrorsSummary } from '../Boots/BootsTab';
+import {
+  MemoizedConfigList,
+  MemoizedErrorsSummary,
+} from '@/pages/hardwareDetails/Tabs/Boots/BootsTab';
+
+import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph';
 
 import HardwareDetailsTestTable from './HardwareDetailsTestsTable';
 
 interface TTestsTab {
   tests: THardwareDetails['tests'];
+  trees: THardwareDetails['trees'];
   hardwareId: string;
 }
 
-const TestsTab = ({ tests, hardwareId }: TTestsTab): JSX.Element => {
+const TestsTab = ({ tests, trees, hardwareId }: TTestsTab): JSX.Element => {
   const { tableFilter, diffFilter } = useSearch({
     from: '/hardware/$hardwareId',
   });
@@ -89,12 +95,14 @@ const TestsTab = ({ tests, hardwareId }: TTestsTab): JSX.Element => {
             issues={tests.issues}
           />
         </div>
+        <HardwareCommitNavigationGraph trees={trees} hardwareId={hardwareId} />
       </DesktopGrid>
       <MobileGrid>
         <MemoizedStatusChart
           title={<FormattedMessage id="bootsTab.bootStatus" />}
           statusCounts={tests.statusSummary}
         />
+        <HardwareCommitNavigationGraph trees={trees} hardwareId={hardwareId} />
         <InnerMobileGrid>
           <div>
             <MemoizedConfigList

--- a/dashboard/src/routes/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/route.tsx
@@ -14,8 +14,7 @@ const hardwareDetailsSearchSchema = z.object({
   treeIndexes: z.array(z.number().int()).optional(),
   treeCommits: zTreeCommits,
   tableFilter: zTableFilterInfoValidator,
-  startTimestampInSeconds: z.number(),
-  endTimestampInSeconds: z.number(),
+  limitTimestampInSeconds: z.number(),
   diffFilter: zDiffFilter,
 });
 

--- a/dashboard/src/routes/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/route.tsx
@@ -7,11 +7,12 @@ import {
   zTableFilterInfoValidator,
 } from '@/types/tree/TreeDetails';
 
-import { zDiffFilter } from '@/types/hardware/hardwareDetails';
+import { zDiffFilter, zTreeCommits } from '@/types/hardware/hardwareDetails';
 
 const hardwareDetailsSearchSchema = z.object({
   currentPageTab: zPossibleTabValidator,
   treeIndexes: z.array(z.number().int()).optional(),
+  treeCommits: zTreeCommits,
   tableFilter: zTableFilterInfoValidator,
   startTimestampInSeconds: z.number(),
   endTimestampInSeconds: z.number(),

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -65,6 +65,7 @@ export const zFilterObjectsKeys = z.enum([
   'buildStatus',
   'bootStatus',
   'testStatus',
+  'hardware',
   'trees',
   'path',
   'bootPath',
@@ -92,6 +93,7 @@ export const zDiffFilter = z
       compilers: zFilterBoolValue,
       bootStatus: zFilterBoolValue,
       testStatus: zFilterBoolValue,
+      hardware: zFilterBoolValue,
       buildDurationMax: zFilterNumberValue,
       buildDurationMin: zFilterNumberValue,
       bootDurationMin: zFilterNumberValue,
@@ -176,3 +178,6 @@ export const getTargetFilter = (
 
   return acc;
 };
+
+export const zTreeCommits = z.record(z.string()).optional();
+export type TTreeCommits = z.infer<typeof zTreeCommits>;

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -2,7 +2,10 @@ import { format } from 'date-fns';
 
 import type { IListingItem } from '@/components/ListingItem/ListingItem';
 import type { ISummaryItem } from '@/components/Summary/Summary';
-import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
+import type {
+  AccordionItemBuilds,
+  TTreeDetailsFilter,
+} from '@/types/tree/TreeDetails';
 import type {
   Architecture,
   BuildsTabBuild,
@@ -91,3 +94,21 @@ export const sanitizeBuildsSummary = (
   buildsSummary: BuildStatus | undefined,
 ): BuildStatus =>
   buildsSummary ? buildsSummary : { invalid: 0, null: 0, valid: 0 };
+
+// TODO, remove this function, is just a step further towards the final implementation
+export const mapFiltersKeysToBackendCompatible = (
+  filter: TTreeDetailsFilter | Record<string, never>,
+): Record<string, string[]> => {
+  const filterParam: { [key: string]: string[] } = {};
+
+  Object.keys(filter).forEach(key => {
+    const filterList = filter[key as keyof TTreeDetailsFilter];
+    filterList?.forEach(value => {
+      if (!filterParam[`filter_${key}`])
+        filterParam[`filter_${key}`] = [value.toString()];
+      else filterParam[`filter_${key}`].push(value.toString());
+    });
+  });
+
+  return filterParam;
+};


### PR DESCRIPTION
- refactor: make CommitNavigationGraph route-agnostic
- fix: commit history should be counted from the head backwards
- feat: add filter by commit hash in hardwareDetails endpoint
- feat: add CommitNavigationGraph to HardwareDetails tabs
- feat: increase tree selection debounce to 2s
- feat: the hardwareDetails endpoint only need a limit time


Close #477 

### How To test:

1. Go to any HardwareDetails page
2. Let just one three selected
3. Navigate to the commit history using the CommitNavigationGraph

> Note: the status count is not correct for the builds tab, this is because of the way that the endpoint commitHistory currently works. We have issue #601 to fix this, which will be resolved soon