### PR TITLE
feat: add new routes for tests and builds

### DIFF
--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -36,7 +36,7 @@ const BlueFolderIcon = (): JSX.Element => (
 );
 
 interface BuildDetailsProps {
-  breadcrumb: JSX.Element;
+  breadcrumb?: JSX.Element;
   buildId?: string;
   onClickFilter: (filter: TestsTableFilter) => void;
   tableFilter: TableFilter;

--- a/dashboard/src/components/LinkWithIcon/LinkWithIcon.tsx
+++ b/dashboard/src/components/LinkWithIcon/LinkWithIcon.tsx
@@ -9,6 +9,7 @@ export interface ILinkWithIcon {
   linkText?: string | ReactElement;
   link?: string;
   icon?: ReactElement;
+  linkComponent?: ReactElement;
   onClick?: () => void;
 }
 
@@ -17,6 +18,7 @@ const LinkWithIcon = ({
   linkText,
   icon,
   link,
+  linkComponent,
   onClick,
 }: ILinkWithIcon): JSX.Element => {
   const WrapperLink = link ? 'a' : 'div';
@@ -25,16 +27,18 @@ const LinkWithIcon = ({
       <span className="font-bold">
         <FormattedMessage id={title} />
       </span>
-      <WrapperLink
-        className="flex flex-row items-center gap-1"
-        href={link}
-        target="_blank"
-        rel="noreferrer"
-        onClick={onClick}
-      >
-        {linkText}
-        {icon}
-      </WrapperLink>
+      {linkComponent ?? (
+        <WrapperLink
+          className="flex flex-row items-center gap-1"
+          href={link}
+          target="_blank"
+          rel="noreferrer"
+          onClick={onClick}
+        >
+          {linkText}
+          {icon}
+        </WrapperLink>
+      )}
     </div>
   );
 };

--- a/dashboard/src/components/Section/Section.tsx
+++ b/dashboard/src/components/Section/Section.tsx
@@ -30,6 +30,7 @@ export const Subsection = ({ infos }: ISubsection): JSX.Element => {
               key={info.title?.toString()}
               title={info.title}
               link={info.link}
+              linkComponent={info.linkComponent}
               linkText={info.linkText}
               icon={
                 info.link && !info.icon ? (

--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -1,6 +1,12 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useSearch, useNavigate, useLocation } from '@tanstack/react-router';
+import {
+  useSearch,
+  useNavigate,
+  useLocation,
+  useRouterState,
+} from '@tanstack/react-router';
+
 import { useCallback, useEffect, useMemo } from 'react';
 
 import Select, { SelectItem } from '@/components/Select/Select';
@@ -72,6 +78,10 @@ const TitleName = ({ basePath }: { basePath: string }): JSX.Element => {
       return <FormattedMessage id="routes.treeMonitor" />;
     case 'hardware':
       return <FormattedMessage id="routes.hardwareMonitor" />;
+    case 'build':
+      return <FormattedMessage id="routes.buildDetails" />;
+    case 'test':
+      return <FormattedMessage id="routes.testDetails" />;
     default:
       return <FormattedMessage id="routes.unknown" />;
   }
@@ -79,8 +89,9 @@ const TitleName = ({ basePath }: { basePath: string }): JSX.Element => {
 
 const TopBar = (): JSX.Element => {
   const { pathname } = useLocation();
-
-  const basePath = pathname.split('/')[1] ?? '';
+  const redirectFrom = useRouterState({ select: s => s.location.state.from });
+  const splitPath = pathname.split('/')[1] ?? '';
+  const basePath = redirectFrom ?? splitPath;
 
   return (
     <div className="fixed top-0 z-10 mx-52 flex h-20 w-full bg-white px-16">
@@ -88,7 +99,9 @@ const TopBar = (): JSX.Element => {
         <span className="mr-14 text-2xl">
           <TitleName basePath={basePath} />
         </span>
-        <OriginSelect basePath={basePath} />
+        {(basePath === 'tree' || basePath === 'hardware') && (
+          <OriginSelect basePath={basePath} />
+        )}
       </div>
     </div>
   );

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -172,10 +172,12 @@ export const messages = {
     'logSheet.fileSize': 'File Size',
     'logSheet.indexOf': 'Index of {link}',
     'logSheet.title': 'Logs Viewer',
+    'routes.buildDetails': 'Build',
     'routes.hardwareMonitor': 'Hardware',
     'routes.sendFeedback': 'Send us Feedback',
     'routes.sendFeedbackMsg':
       'Thank you for your feedback!\nWe greatly appreciate your input. You are welcome to send us the feedback via email or by creating an issue on our GitHub repository.',
+    'routes.testDetails': 'Test',
     'routes.treeMonitor': 'Trees',
     'routes.unknown': 'Unknown',
     'tab.name': 'Name',

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -20,6 +20,8 @@ import { routeTree } from './routeTree.gen';
 import './index.css';
 import { isDev } from './lib/utils/vite';
 import { ToastProvider } from './components/ui/toast';
+import type { RedirectFrom } from './types/general';
+
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace FormatjsIntl {
@@ -32,6 +34,11 @@ declare global {
 declare module '@tanstack/react-router' {
   interface Register {
     router: typeof router;
+  }
+
+  interface HistoryState {
+    id?: string;
+    from?: RedirectFrom;
   }
 }
 

--- a/dashboard/src/pages/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetails.tsx
@@ -1,0 +1,74 @@
+import { useCallback } from 'react';
+
+import type { LinkProps } from '@tanstack/react-router';
+import {
+  useSearch,
+  useParams,
+  useNavigate,
+  useRouterState,
+} from '@tanstack/react-router';
+
+import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import BuildDetails from '@/components/BuildDetails/BuildDetails';
+
+import { RedirectFrom } from '@/types/general';
+
+import TreeBuildDetails from '@/pages/TreeBuildDetails';
+import HardwareBuildDetails from '@/pages/HardwareBuildDetails';
+
+const BuildDetailsPage = (): JSX.Element => {
+  const searchParams = useSearch({ from: '/build/$buildId' });
+  const { buildId } = useParams({ from: '/build/$buildId' });
+  const navigate = useNavigate({ from: '/build/$buildId' });
+  const historyState = useRouterState({ select: s => s.location.state });
+
+  const getTestTableRowLink = useCallback(
+    (testId: string): LinkProps => ({
+      to: '/test/$testId',
+      params: {
+        testId: testId,
+      },
+      search: s => s,
+    }),
+    [],
+  );
+
+  const onClickFilter = useCallback(
+    (filter: TestsTableFilter): void => {
+      navigate({
+        search: previousParams => {
+          return {
+            ...previousParams,
+            tableFilter: {
+              bootsTable: previousParams.tableFilter.bootsTable,
+              buildsTable: previousParams.tableFilter.buildsTable,
+              testsTable: filter,
+            },
+          };
+        },
+      });
+    },
+    [navigate],
+  );
+
+  if (historyState.id !== undefined) {
+    if (historyState.from === RedirectFrom.Tree) {
+      return <TreeBuildDetails />;
+    }
+
+    if (historyState.from === RedirectFrom.Hardware) {
+      return <HardwareBuildDetails />;
+    }
+  }
+
+  return (
+    <BuildDetails
+      buildId={buildId}
+      onClickFilter={onClickFilter}
+      tableFilter={searchParams.tableFilter}
+      getTestTableRowLink={getTestTableRowLink}
+    />
+  );
+};
+
+export default BuildDetailsPage;

--- a/dashboard/src/pages/BuildDetails/index.tsx
+++ b/dashboard/src/pages/BuildDetails/index.tsx
@@ -1,0 +1,3 @@
+import BuildDetailsPage from './BuildDetails';
+
+export default BuildDetailsPage;

--- a/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
+++ b/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
@@ -1,7 +1,12 @@
 import { FormattedMessage } from 'react-intl';
 
 import type { LinkProps } from '@tanstack/react-router';
-import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+import {
+  useNavigate,
+  useParams,
+  useRouterState,
+  useSearch,
+} from '@tanstack/react-router';
 
 import { useCallback } from 'react';
 
@@ -18,12 +23,9 @@ import BuildDetails from '@/components/BuildDetails/BuildDetails';
 import type { TestsTableFilter } from '@/types/tree/TreeDetails';
 
 const HardwareBuildDetails = (): JSX.Element => {
-  const searchParams = useSearch({
-    from: '/hardware/$hardwareId/build/$buildId/',
-  });
-  const { buildId, hardwareId } = useParams({
-    from: '/hardware/$hardwareId/build/$buildId/',
-  });
+  const searchParams = useSearch({ from: '/build/$buildId' });
+  const { buildId } = useParams({ from: '/build/$buildId' });
+  const hardwareId = useRouterState({ select: s => s.location.state.id });
 
   const navigate = useNavigate({
     from: '/hardware/$hardwareId/build/$buildId',

--- a/dashboard/src/pages/HardwareTestDetails/HardwareTestDetails.tsx
+++ b/dashboard/src/pages/HardwareTestDetails/HardwareTestDetails.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSearch } from '@tanstack/react-router';
+import { useParams, useRouterState, useSearch } from '@tanstack/react-router';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -14,17 +14,13 @@ import {
 import TestDetails from '@/components/TestDetails/TestDetails';
 
 const HardwareTestDetails = (): JSX.Element => {
-  const searchParams = useSearch({
-    from: '/hardware/$hardwareId/test/$testId/',
-  });
-  const { testId, hardwareId } = useParams({
-    from: '/hardware/$hardwareId/test/$testId/',
-  });
+  const searchParams = useSearch({ from: '/test/$testId/' });
+  const { testId } = useParams({ from: '/test/$testId/' });
+  const hardwareId = useRouterState({ select: s => s.location.state.id });
 
   return (
     <TestDetails
       testId={testId}
-      context="hardware"
       breadcrumb={
         <Breadcrumb className="pb-6 pt-6">
           <BreadcrumbList>

--- a/dashboard/src/pages/TestDetails/TestDetails.tsx
+++ b/dashboard/src/pages/TestDetails/TestDetails.tsx
@@ -1,0 +1,27 @@
+import { useParams, useRouterState } from '@tanstack/react-router';
+
+import TestDetails from '@/components/TestDetails/TestDetails';
+
+import { RedirectFrom } from '@/types/general';
+
+import TreeTestDetails from '@/pages/TreeTestDetails';
+import HardwareTestDetails from '@/pages/HardwareTestDetails';
+
+const TestDetailsPage = (): JSX.Element => {
+  const historyState = useRouterState({ select: s => s.location.state });
+  const { testId } = useParams({ from: '/test/$testId' });
+
+  if (historyState.id !== undefined) {
+    if (historyState.from === RedirectFrom.Tree) {
+      return <TreeTestDetails />;
+    }
+
+    if (historyState.from === RedirectFrom.Hardware) {
+      return <HardwareTestDetails />;
+    }
+  }
+
+  return <TestDetails testId={testId} />;
+};
+
+export default TestDetailsPage;

--- a/dashboard/src/pages/TestDetails/index.tsx
+++ b/dashboard/src/pages/TestDetails/index.tsx
@@ -1,0 +1,3 @@
+import TestDetailsPage from './TestDetails';
+
+export default TestDetailsPage;

--- a/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
+++ b/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
@@ -1,7 +1,12 @@
 import { FormattedMessage } from 'react-intl';
 
 import type { LinkProps } from '@tanstack/react-router';
-import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+import {
+  useNavigate,
+  useParams,
+  useRouterState,
+  useSearch,
+} from '@tanstack/react-router';
 
 import { useCallback } from 'react';
 
@@ -18,10 +23,9 @@ import BuildDetails from '@/components/BuildDetails/BuildDetails';
 import type { TestsTableFilter } from '@/types/tree/TreeDetails';
 
 const TreeBuildDetails = (): JSX.Element => {
-  const searchParams = useSearch({ from: '/tree/$treeId/build/$buildId/' });
-  const { buildId, treeId } = useParams({
-    from: '/tree/$treeId/build/$buildId/',
-  });
+  const searchParams = useSearch({ from: '/build/$buildId' });
+  const { buildId } = useParams({ from: '/build/$buildId' });
+  const treeId = useRouterState({ select: s => s.location.state.id });
 
   const navigate = useNavigate({ from: '/tree/$treeId/build/$buildId' });
 

--- a/dashboard/src/pages/TreeTestDetails/TreeTestDetails.tsx
+++ b/dashboard/src/pages/TreeTestDetails/TreeTestDetails.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSearch } from '@tanstack/react-router';
+import { useParams, useRouterState, useSearch } from '@tanstack/react-router';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -14,13 +14,13 @@ import {
 import TestDetails from '@/components/TestDetails/TestDetails';
 
 const TreeTestDetails = (): JSX.Element => {
-  const searchParams = useSearch({ from: '/tree/$treeId/test/$testId/' });
-  const { testId, treeId } = useParams({ from: '/tree/$treeId/test/$testId/' });
+  const searchParams = useSearch({ from: '/test/$testId/' });
+  const { testId } = useParams({ from: '/test/$testId/' });
+  const treeId = useRouterState({ select: s => s.location.state.id });
 
   return (
     <TestDetails
       testId={testId}
-      context="tree"
       breadcrumb={
         <Breadcrumb className="pb-6 pt-6">
           <BreadcrumbList>

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -17,9 +17,13 @@ import { Route as IndexImport } from './routes/index'
 import { Route as TreeIndexImport } from './routes/tree/index'
 import { Route as HardwareIndexImport } from './routes/hardware/index'
 import { Route as TreeTreeIdRouteImport } from './routes/tree/$treeId/route'
+import { Route as TestTestIdRouteImport } from './routes/test/$testId/route'
 import { Route as HardwareHardwareIdRouteImport } from './routes/hardware/$hardwareId/route'
+import { Route as BuildBuildIdRouteImport } from './routes/build/$buildId/route'
 import { Route as TreeTreeIdIndexImport } from './routes/tree/$treeId/index'
+import { Route as TestTestIdIndexImport } from './routes/test/$testId/index'
 import { Route as HardwareHardwareIdIndexImport } from './routes/hardware/$hardwareId/index'
+import { Route as BuildBuildIdIndexImport } from './routes/build/$buildId/index'
 import { Route as HardwareHardwareIdTestRouteImport } from './routes/hardware/$hardwareId/test/route'
 import { Route as HardwareHardwareIdBuildRouteImport } from './routes/hardware/$hardwareId/build/route'
 import { Route as HardwareHardwareIdBootRouteImport } from './routes/hardware/$hardwareId/boot/route'
@@ -65,9 +69,19 @@ const TreeTreeIdRouteRoute = TreeTreeIdRouteImport.update({
   getParentRoute: () => TreeRouteRoute,
 } as any)
 
+const TestTestIdRouteRoute = TestTestIdRouteImport.update({
+  path: '/test/$testId',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const HardwareHardwareIdRouteRoute = HardwareHardwareIdRouteImport.update({
   path: '/$hardwareId',
   getParentRoute: () => HardwareRouteRoute,
+} as any)
+
+const BuildBuildIdRouteRoute = BuildBuildIdRouteImport.update({
+  path: '/build/$buildId',
+  getParentRoute: () => rootRoute,
 } as any)
 
 const TreeTreeIdIndexRoute = TreeTreeIdIndexImport.update({
@@ -75,9 +89,19 @@ const TreeTreeIdIndexRoute = TreeTreeIdIndexImport.update({
   getParentRoute: () => TreeTreeIdRouteRoute,
 } as any)
 
+const TestTestIdIndexRoute = TestTestIdIndexImport.update({
+  path: '/',
+  getParentRoute: () => TestTestIdRouteRoute,
+} as any)
+
 const HardwareHardwareIdIndexRoute = HardwareHardwareIdIndexImport.update({
   path: '/',
   getParentRoute: () => HardwareHardwareIdRouteRoute,
+} as any)
+
+const BuildBuildIdIndexRoute = BuildBuildIdIndexImport.update({
+  path: '/',
+  getParentRoute: () => BuildBuildIdRouteRoute,
 } as any)
 
 const HardwareHardwareIdTestRouteRoute =
@@ -175,12 +199,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TreeRouteImport
       parentRoute: typeof rootRoute
     }
+    '/build/$buildId': {
+      id: '/build/$buildId'
+      path: '/build/$buildId'
+      fullPath: '/build/$buildId'
+      preLoaderRoute: typeof BuildBuildIdRouteImport
+      parentRoute: typeof rootRoute
+    }
     '/hardware/$hardwareId': {
       id: '/hardware/$hardwareId'
       path: '/$hardwareId'
       fullPath: '/hardware/$hardwareId'
       preLoaderRoute: typeof HardwareHardwareIdRouteImport
       parentRoute: typeof HardwareRouteImport
+    }
+    '/test/$testId': {
+      id: '/test/$testId'
+      path: '/test/$testId'
+      fullPath: '/test/$testId'
+      preLoaderRoute: typeof TestTestIdRouteImport
+      parentRoute: typeof rootRoute
     }
     '/tree/$treeId': {
       id: '/tree/$treeId'
@@ -224,12 +262,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HardwareHardwareIdTestRouteImport
       parentRoute: typeof HardwareHardwareIdRouteImport
     }
+    '/build/$buildId/': {
+      id: '/build/$buildId/'
+      path: '/'
+      fullPath: '/build/$buildId/'
+      preLoaderRoute: typeof BuildBuildIdIndexImport
+      parentRoute: typeof BuildBuildIdRouteImport
+    }
     '/hardware/$hardwareId/': {
       id: '/hardware/$hardwareId/'
       path: '/'
       fullPath: '/hardware/$hardwareId/'
       preLoaderRoute: typeof HardwareHardwareIdIndexImport
       parentRoute: typeof HardwareHardwareIdRouteImport
+    }
+    '/test/$testId/': {
+      id: '/test/$testId/'
+      path: '/'
+      fullPath: '/test/$testId/'
+      preLoaderRoute: typeof TestTestIdIndexImport
+      parentRoute: typeof TestTestIdRouteImport
     }
     '/tree/$treeId/': {
       id: '/tree/$treeId/'
@@ -340,6 +392,12 @@ export const routeTree = rootRoute.addChildren({
     }),
     TreeIndexRoute,
   }),
+  BuildBuildIdRouteRoute: BuildBuildIdRouteRoute.addChildren({
+    BuildBuildIdIndexRoute,
+  }),
+  TestTestIdRouteRoute: TestTestIdRouteRoute.addChildren({
+    TestTestIdIndexRoute,
+  }),
 })
 
 /* prettier-ignore-end */
@@ -352,7 +410,9 @@ export const routeTree = rootRoute.addChildren({
       "children": [
         "/",
         "/hardware",
-        "/tree"
+        "/tree",
+        "/build/$buildId",
+        "/test/$testId"
       ]
     },
     "/": {
@@ -372,6 +432,12 @@ export const routeTree = rootRoute.addChildren({
         "/tree/"
       ]
     },
+    "/build/$buildId": {
+      "filePath": "build/$buildId/route.tsx",
+      "children": [
+        "/build/$buildId/"
+      ]
+    },
     "/hardware/$hardwareId": {
       "filePath": "hardware/$hardwareId/route.tsx",
       "parent": "/hardware",
@@ -380,6 +446,12 @@ export const routeTree = rootRoute.addChildren({
         "/hardware/$hardwareId/build",
         "/hardware/$hardwareId/test",
         "/hardware/$hardwareId/"
+      ]
+    },
+    "/test/$testId": {
+      "filePath": "test/$testId/route.tsx",
+      "children": [
+        "/test/$testId/"
       ]
     },
     "/tree/$treeId": {
@@ -423,9 +495,17 @@ export const routeTree = rootRoute.addChildren({
         "/hardware/$hardwareId/test/$testId/"
       ]
     },
+    "/build/$buildId/": {
+      "filePath": "build/$buildId/index.tsx",
+      "parent": "/build/$buildId"
+    },
     "/hardware/$hardwareId/": {
       "filePath": "hardware/$hardwareId/index.tsx",
       "parent": "/hardware/$hardwareId"
+    },
+    "/test/$testId/": {
+      "filePath": "test/$testId/index.tsx",
+      "parent": "/test/$testId"
     },
     "/tree/$treeId/": {
       "filePath": "tree/$treeId/index.tsx",

--- a/dashboard/src/routes/build/$buildId/index.tsx
+++ b/dashboard/src/routes/build/$buildId/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import BuildDetailsPage from '@/pages/BuildDetails';
+
+export const Route = createFileRoute('/build/$buildId/')({
+  component: () => <BuildDetailsPage />,
+});

--- a/dashboard/src/routes/build/$buildId/route.tsx
+++ b/dashboard/src/routes/build/$buildId/route.tsx
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { zTableFilterInfoValidator } from '@/types/tree/TreeDetails';
+
+const buildDetailsSearchSchema = z.object({
+  tableFilter: zTableFilterInfoValidator,
+});
+
+export const Route = createFileRoute('/build/$buildId')({
+  validateSearch: buildDetailsSearchSchema,
+});

--- a/dashboard/src/routes/hardware/$hardwareId/build/$buildId/index.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/build/$buildId/index.tsx
@@ -1,7 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
-import HardwareBuildDetails from '@/pages/HardwareBuildDetails';
+import { RedirectFrom } from '@/types/general';
 
 export const Route = createFileRoute('/hardware/$hardwareId/build/$buildId/')({
-  component: () => <HardwareBuildDetails />,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({ params, deps }) => {
+    throw redirect({
+      to: '/build/$buildId',
+      search: deps.search,
+      state: { id: params.hardwareId, from: RedirectFrom.Hardware },
+    });
+  },
 });

--- a/dashboard/src/routes/hardware/$hardwareId/test/$testId/index.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/test/$testId/index.tsx
@@ -1,7 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
-import HardwareTestDetails from '@/pages/HardwareTestDetails';
+import { RedirectFrom } from '@/types/general';
 
 export const Route = createFileRoute('/hardware/$hardwareId/test/$testId/')({
-  component: () => <HardwareTestDetails />,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({ params, deps }) => {
+    throw redirect({
+      to: '/test/$testId',
+      search: deps.search,
+      state: { id: params.hardwareId, from: RedirectFrom.Hardware },
+    });
+  },
 });

--- a/dashboard/src/routes/test/$testId/index.tsx
+++ b/dashboard/src/routes/test/$testId/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import TestDetailsPage from '@/pages/TestDetails/TestDetails';
+
+export const Route = createFileRoute('/test/$testId/')({
+  component: () => <TestDetailsPage />,
+});

--- a/dashboard/src/routes/test/$testId/route.tsx
+++ b/dashboard/src/routes/test/$testId/route.tsx
@@ -1,0 +1,3 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/test/$testId')();

--- a/dashboard/src/routes/tree/$treeId/build/$buildId/index.tsx
+++ b/dashboard/src/routes/tree/$treeId/build/$buildId/index.tsx
@@ -1,15 +1,22 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
 import { zTableFilterInfoValidator } from '@/types/tree/TreeDetails';
-import TreeBuildDetails from '@/pages/TreeBuildDetails';
+import { RedirectFrom } from '@/types/general';
 
 const buildDetailsSearchSchema = z.object({
   tableFilter: zTableFilterInfoValidator,
 });
 
 export const Route = createFileRoute('/tree/$treeId/build/$buildId/')({
-  component: () => <TreeBuildDetails />,
   validateSearch: buildDetailsSearchSchema,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({ params, deps }) => {
+    throw redirect({
+      to: '/build/$buildId',
+      search: deps.search,
+      state: { id: params.treeId, from: RedirectFrom.Tree },
+    });
+  },
 });

--- a/dashboard/src/routes/tree/$treeId/test/$testId/index.tsx
+++ b/dashboard/src/routes/tree/$treeId/test/$testId/index.tsx
@@ -1,7 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
-import TreeTestDetails from '@/pages/TreeTestDetails/TreeTestDetails';
+import { RedirectFrom } from '@/types/general';
 
 export const Route = createFileRoute('/tree/$treeId/test/$testId/')({
-  component: () => <TreeTestDetails />,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({ params, deps }) => {
+    throw redirect({
+      to: '/test/$testId',
+      search: deps.search,
+      state: { id: params.treeId, from: RedirectFrom.Tree },
+    });
+  },
 });

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -273,3 +273,8 @@ export const getTargetFilter = (
 
   return accumulator;
 };
+
+export enum RedirectFrom {
+  Tree = 'tree',
+  Hardware = 'hardware',
+}


### PR DESCRIPTION
Add two new routes /test/$testId and /build/$buildId, removing the need of accessing tests or builds through /hardware or /tree. Also, redirects the old routes to the new ones.

Closes #555