### PR TITLE
Feat: async filters

### DIFF
--- a/dashboard/src/api/TreeDetails.tsx
+++ b/dashboard/src/api/TreeDetails.tsx
@@ -100,6 +100,7 @@ export const useBuildsTab = ({
     queryFn: () =>
       fetchTreeDetailData(treeId, treeSearchParameters, detailsFilter),
     enabled,
+    placeholderData: previousData => previousData,
   });
 };
 
@@ -156,6 +157,7 @@ export const useTestsTab = ({
         ...treeDetailsFilter,
       }),
     enabled,
+    placeholderData: previousData => previousData,
   });
 };
 

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -79,5 +79,6 @@ export const useHardwareDetails = (
   return useQuery({
     queryKey: ['HardwareDetails', hardwareId, body],
     queryFn: () => fetchHardwareDetails(hardwareId, body),
+    placeholderData: previousData => previousData,
   });
 };

--- a/dashboard/src/components/FilterList/FilterList.tsx
+++ b/dashboard/src/components/FilterList/FilterList.tsx
@@ -3,9 +3,12 @@ import { IoClose } from 'react-icons/io5';
 import classNames from 'classnames';
 import { useIntl } from 'react-intl';
 
+import { LoadingCircle } from '@/components/ui/loading-circle';
+
 import { Button } from '../ui/button';
 
 export interface IFilterList {
+  isLoading: boolean;
   items: string[];
   onClickItem: (item: string, itemIdx: number) => void;
   onClickCleanAll: () => void;
@@ -72,6 +75,7 @@ const FilterItem = ({
 };
 
 const FilterList = ({
+  isLoading,
   items,
   onClickItem,
   onClickCleanAll,
@@ -97,7 +101,7 @@ const FilterList = ({
   }
 
   return (
-    <div className="flex flex-wrap gap-4">
+    <div className="flex flex-wrap items-center gap-4">
       {buttonList}
       <FilterButton
         className="hover:bg-darkGray2"
@@ -105,6 +109,7 @@ const FilterList = ({
         variant="primary"
         onClick={onClickCleanAll}
       />
+      {isLoading && <LoadingCircle />}
     </div>
   );
 };

--- a/dashboard/src/components/ui/loading-circle.tsx
+++ b/dashboard/src/components/ui/loading-circle.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export const LoadingCircle = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      className,
+      'text-surface inline-block h-6 w-6 animate-spin rounded-full border-[3px] border-solid border-x-current border-y-current border-e-transparent text-blue motion-reduce:animate-[spin_1.5s_linear_infinite]',
+    )}
+    role="status"
+    {...props}
+  />
+);

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -128,6 +128,7 @@ function TreeDetails(): JSX.Element {
     isLoading: buildIsLoading,
     data: buildData,
     status: buildStatus,
+    isPlaceholderData: buildIsPlaceholderData,
   } = useBuildsTab({
     treeId: treeId ?? '',
     filter: reqFilter,
@@ -138,11 +139,16 @@ function TreeDetails(): JSX.Element {
     isLoading: testsIsLoading,
     data: testsData,
     status: testStatus,
+    isPlaceholderData: testIsPlaceholderData,
   } = useTestsTab({
     treeId: treeId ?? '',
     filter: reqFilter,
     enabled: !isBuildTab || (buildStatus === 'success' && !!buildData),
   });
+
+  const isPlaceholderData = useMemo(() => {
+    return isBuildTab ? buildIsPlaceholderData : testIsPlaceholderData;
+  }, [buildIsPlaceholderData, isBuildTab, testIsPlaceholderData]);
 
   const isLoading = useMemo(() => {
     return isBuildTab ? buildIsLoading : testsIsLoading;
@@ -151,9 +157,12 @@ function TreeDetails(): JSX.Element {
   const filterListElement = useMemo(
     () =>
       Object.keys(diffFilter).length !== 0 ? (
-        <TreeDetailsFilterList filter={diffFilter} />
+        <TreeDetailsFilterList
+          filter={diffFilter}
+          isLoading={isPlaceholderData}
+        />
       ) : undefined,
-    [diffFilter],
+    [diffFilter, isPlaceholderData],
   );
 
   const tabsCounts: TreeDetailsTabRightElement = useMemo(() => {

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilterList.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilterList.tsx
@@ -7,6 +7,7 @@ import type { TFilter, TFilterKeys } from '@/types/tree/TreeDetails';
 
 interface ITreeDetailsFilterList {
   filter: TFilter;
+  isLoading: boolean;
 }
 
 const createFlatFilter = (filter: TFilter): string[] => {
@@ -26,6 +27,7 @@ const createFlatFilter = (filter: TFilter): string[] => {
 
 const TreeDetailsFilterList = ({
   filter,
+  isLoading = false,
 }: ITreeDetailsFilterList): JSX.Element => {
   const flatFilter = useMemo(() => createFlatFilter(filter), [filter]);
   const navigate = useNavigate({ from: '/tree/$treeId' });
@@ -72,6 +74,7 @@ const TreeDetailsFilterList = ({
 
   return (
     <FilterList
+      isLoading={isLoading}
       items={flatFilter}
       onClickItem={onClickItem}
       onClickCleanAll={onClickCleanALl}

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -65,7 +65,7 @@ function HardwareDetails(): JSX.Element {
     [navigate],
   );
 
-  const { data, isLoading } = useHardwareDetails(
+  const { data, isLoading, isPlaceholderData } = useHardwareDetails(
     hardwareId,
     startTimestampInSeconds,
     endTimestampInSeconds,
@@ -77,9 +77,12 @@ function HardwareDetails(): JSX.Element {
   const filterListElement = useMemo(
     () =>
       Object.keys(diffFilter).length !== 0 ? (
-        <HardwareDetailsFilterList filter={diffFilter} />
+        <HardwareDetailsFilterList
+          isLoading={isPlaceholderData}
+          filter={diffFilter}
+        />
       ) : undefined,
-    [diffFilter],
+    [diffFilter, isPlaceholderData],
   );
 
   const tabsCounts: TreeDetailsTabRightElement = useMemo(() => {

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilterList.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilterList.tsx
@@ -8,6 +8,7 @@ import FilterList from '@/components/FilterList/FilterList';
 import type { TFilter, TFilterKeys } from '@/types/hardware/hardwareDetails';
 
 interface ITreeDetailsFilterList {
+  isLoading: boolean;
   filter: TFilter;
 }
 
@@ -27,6 +28,7 @@ const createFlatFilter = (filter: TFilter): string[] => {
 };
 
 const HardwareDetailsFilterList = ({
+  isLoading,
   filter,
 }: ITreeDetailsFilterList): JSX.Element => {
   const flatFilter = useMemo(() => createFlatFilter(filter), [filter]);
@@ -74,6 +76,7 @@ const HardwareDetailsFilterList = ({
 
   return (
     <FilterList
+      isLoading={isLoading}
       items={flatFilter}
       onClickItem={onClickItem}
       onClickCleanAll={onClickCleanALl}


### PR DESCRIPTION
Adds a loading circle and async loading for treeDetails and hardwareDetails filtering.

## How to test
Go to treeDetails page or hardwareDetails page and add any filter, the page won't show the "Loading" screen anymore, instead it will show a loading circle in the filterListing and will only update the page after the data has been fetched.
This works not only for the test path filtering but also for any other filter, although with the path filter it's more noticeable.

Closes #585