### PR TITLE
change: widen the modal and improve visibility

### DIFF
--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -156,7 +156,7 @@ const TableRowComponent = ({
   getRowLink: (testId: TestHistory['id']) => LinkProps;
   openLogSheet: (index: number) => void;
 }): JSX.Element => {
-  const className = index === currentLog ? 'bg-lightBlue' : undefined;
+  const className = index === currentLog ? 'bg-sky-200' : undefined;
 
   return (
     <TableRow

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -121,7 +121,7 @@ const TableRowComponent = ({
   onClickShowBuild: IAccordionItems['onClickShowBuild'];
   isExpanded: boolean;
 }): JSX.Element => {
-  const className = index === currentLog ? 'bg-lightBlue' : undefined;
+  const className = index === currentLog ? 'bg-sky-200' : undefined;
 
   return (
     <Fragment key={row.id}>

--- a/dashboard/src/components/Filter/CodeBlock.tsx
+++ b/dashboard/src/components/Filter/CodeBlock.tsx
@@ -72,7 +72,7 @@ const Code = ({
     <>
       <pre
         className={cn(
-          'w-full max-w-[calc(100vw_-_398px)] overflow-x-auto rounded-md bg-[#DDDDDD] p-4 font-mono text-[#767676]',
+          'w-full max-w-[100vw] overflow-x-auto rounded-md bg-[#DDDDDD] p-4 font-mono text-sm leading-4 text-[#767676]',
           className,
         )}
       >

--- a/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
+++ b/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
@@ -69,7 +69,7 @@ const TableRowComponent = ({
   currentLog?: number;
   openLogSheet: (index: number) => void;
 }): JSX.Element => {
-  const className = index === currentLog ? 'bg-lightBlue' : undefined;
+  const className = index === currentLog ? 'bg-sky-200' : undefined;
 
   const linkProps: LinkProps = useMemo(() => {
     return getRowLink(row.original.id);

--- a/dashboard/src/components/ui/sheet.tsx
+++ b/dashboard/src/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/60  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/dashboard/src/pages/TreeDetails/Tabs/LogSheet.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/LogSheet.tsx
@@ -122,7 +122,7 @@ export const LogSheet = ({
     { enabled: !!logUrl },
   );
   return (
-    <SheetContent className="flex w-[25rem] flex-col sm:w-full sm:max-w-[44rem]">
+    <SheetContent className="flex flex-col sm:w-full sm:max-w-[clamp(650px,75vw,1300px)]">
       <SheetHeader className="mb-3">
         <SheetTitle className="text-[1.75rem]">
           <FormattedMessage id="logSheet.title" />


### PR DESCRIPTION
Increase the log sheet modal width and also improve the visibility of the log that's being shown by using a darker color to highlight the table row and by decreasing the opacity of the sheet overlay.

Closes #595

## Visual Reference

Before
![image](https://github.com/user-attachments/assets/b9666dee-82bb-4756-b583-605a836c8e5c)

After

![Captura de tela de 2024-11-29 12-03-51](https://github.com/user-attachments/assets/7364307d-687c-4f60-bc63-4ab450659dea)
![image](https://github.com/user-attachments/assets/610887eb-3499-4f00-9b33-e9f4398e7a22)



