### PR TITLE
feat: show 8 commit hash chars in the Commit Graph

### DIFF
--- a/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
+++ b/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
@@ -15,7 +15,7 @@ import { mapFilterToReq } from '@/pages/TreeDetails/TreeDetailsFilter';
 import type { TFilter } from '@/types/tree/TreeDetails';
 import { useCommitHistory } from '@/api/commitHistory';
 
-const graphDisplaySize = 7;
+const graphDisplaySize = 8;
 
 interface ICommitNavigationGraph {
   origin: string;
@@ -210,12 +210,11 @@ const CommitNavigationGraph = ({
                     })
                     .parse(possibleIndexNumber);
 
-                  const name = commitData[parsedPossibleIndex].commitName;
                   isCurrentCommit =
                     treeId === commitData[parsedPossibleIndex].commitHash;
-                  displayText = (
-                    name ?? commitData[parsedPossibleIndex].commitHash
-                  ).slice(0, graphDisplaySize);
+                  displayText = commitData[
+                    parsedPossibleIndex
+                  ]?.commitHash.slice(0, graphDisplaySize);
                 }
 
                 return (


### PR DESCRIPTION
Change from showing 7 commit name characters for each point in the graph in the x-Axis to showing 8 commit hash characters for each point in the graph.

Closes #589 

# Visual Reference

Before
![image](https://github.com/user-attachments/assets/5dc69cad-e4d3-4a29-be8d-d6f59e32ba51)

After
![image](https://github.com/user-attachments/assets/a70fac33-1090-40d2-b236-734629fc2f4d)
