### PR TITLE
fix: null pointer for checkout without commit hash

### DIFF
--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -198,6 +198,7 @@ class TreeCommitsHistory(APIView):
                 git_repository_branch = %(git_branch_param)s
                 AND git_repository_url = %(git_url_param)s
                 AND origin = %(origin_param)s
+                AND git_commit_hash IS NOT NULL
                 AND start_time <= (
                     SELECT MAX(start_time) as head_start_time
                     FROM checkouts


### PR DESCRIPTION
Fix checkouts that has no commit hash, we don't want that, the whole point of a checkout is to have a commit hash
it was being spitted by the redhat origin


Closes #644

## How to test

- Staging
https://staging.dashboard.kernelci.org:9000/tree/8c212fb0b0e1aa8e1a5cf84c17fced714df48c4b?tableFilter=%7B%22bootsTable%22%3A%22all%22%2C%22buildsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=redhat&currentPageTab=global.builds&diffFilter=%7B%7D&treeInfo=%7B%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fstable%2Flinux-stable-rc.git%22%2C%22gitBranch%22%3A%22queue%2F6.11%22%2C%22treeName%22%3A%22upstream-stable-queue%22%2C%22commitName%22%3A%22v6.11.10-804-g8c212fb0b0e1%22%2C%22headCommitHash%22%3A%228c212fb0b0e1aa8e1a5cf84c17fced714df48c4b%22%7D&intervalInDays=7


- Local
http://localhost:5173/tree/46f209be657130cebf413dc62d280aa2b34f05bd?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22all%22%2C%22testsTable%22%3A%22all%22%7D&origin=redhat&currentPageTab=global.builds&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22queue%2F6.11%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fstable%2Flinux-stable-rc.git%22%2C%22treeName%22%3A%22upstream-stable-queue%22%2C%22commitName%22%3A%22v6.11.10-804-g46f209be6571%22%2C%22headCommitHash%22%3A%2246f209be657130cebf413dc62d280aa2b34f05bd%22%7D&intervalInDays=7
