### PR TITLE
fix(treeCommitsHistory): fetch distinct hashes

### DIFF
--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -208,7 +208,7 @@ class TreeCommitsHistory(APIView):
                 start_time DESC
         ),
         earliest_commits AS (
-            SELECT
+            SELECT DISTINCT ON (git_commit_hash)
                 git_commit_hash,
                 git_commit_name,
                 MAX(start_time) AS earliest_start_time
@@ -218,8 +218,7 @@ class TreeCommitsHistory(APIView):
                 git_commit_hash,
                 git_commit_name
             ORDER BY
-                earliest_start_time DESC
-            LIMIT 6
+                git_commit_hash
         ),
         build_counts AS (
             SELECT


### PR DESCRIPTION
Select distinct rows on git_commit_hash since there can exist multiple rows in checkouts with equal git commit hashes, tree and branch but with different checkouts IDs. This distinct git_commit_hash needs to be selected from a different CTE then the one used to count the builds/boots/tests status to keep the values correct in the graph

Closes #611