### PR TITLE
Feat (hardwareDetails): Issues Filter

### DIFF
--- a/backend/kernelCI_app/helpers/filters.py
+++ b/backend/kernelCI_app/helpers/filters.py
@@ -1,0 +1,50 @@
+from typing import Optional
+from kernelCI_app.utils import UNKNOWN_STRING
+
+
+def is_build_invalid(build_valid: Optional[bool]) -> bool:
+    return build_valid is None or build_valid is False
+
+
+def is_known_issue(issue_id: Optional[str]) -> bool:
+    return issue_id is not None and issue_id is not UNKNOWN_STRING
+
+
+def is_issue_from_test(incident_test_id: Optional[str], is_known_issue: bool) -> bool:
+    return incident_test_id is not None or not is_known_issue
+
+
+def is_issue_filtered_out(issue_id: Optional[str], issue_filters: set) -> bool:
+    return issue_id not in issue_filters
+
+
+def should_filter_test_issue(
+    issue_filters: set, issue_id: Optional[str], incident_test_id: Optional[str]
+) -> bool:
+    has_issue_filter = len(issue_filters) > 0
+
+    is_known_issue_result = is_known_issue(issue_id)
+    is_issue_from_tests_result = is_issue_from_test(
+        incident_test_id, is_known_issue_result
+    )
+
+    is_issue_filtered_out_result = is_issue_filtered_out(issue_id, issue_filters)
+
+    return (
+        has_issue_filter and is_issue_from_tests_result and is_issue_filtered_out_result
+    )
+
+
+def should_increment_test_issue(
+    issue_id: Optional[str], incident_test_id: Optional[str]
+) -> bool:
+    is_known_issue_result = is_known_issue(issue_id=issue_id)
+    is_exclusively_build_issue = is_known_issue_result and incident_test_id is None
+    if is_exclusively_build_issue:
+        issue_id = UNKNOWN_STRING
+
+    is_unknown_issue = issue_id is UNKNOWN_STRING
+    is_known_test_issue = incident_test_id is not None
+    is_issue_from_test = is_known_test_issue or is_unknown_issue
+
+    return is_issue_from_test

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -6,7 +6,8 @@ from django.http import HttpResponseBadRequest
 import re
 
 DEFAULT_QUERY_TIME_INTERVAL = {"days": 7}
-NULL_STRINGS = set(["null", "Unknown", "NULL"])
+UNKNOWN_STRING = "Unknown"
+NULL_STRINGS = set(["null", UNKNOWN_STRING, "NULL"])
 
 
 class IncidentInfo(TypedDict):

--- a/dashboard/src/components/Tabs/Filters.tsx
+++ b/dashboard/src/components/Tabs/Filters.tsx
@@ -154,11 +154,14 @@ const CheckboxSection = ({
 
   return (
     <>
-      {checkboxSectionsProps.map((props, i) => (
-        <DrawerSection key={props.title} hideSeparator={i === 0}>
-          <FilterCheckboxSection {...props} />
-        </DrawerSection>
-      ))}
+      {checkboxSectionsProps.map(
+        (props, i) =>
+          Object.entries(props.items ?? {}).length > 0 && (
+            <DrawerSection key={props.title} hideSeparator={i === 0}>
+              <FilterCheckboxSection {...props} />
+            </DrawerSection>
+          ),
+      )}
     </>
   );
 };

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -44,6 +44,10 @@ export const createFilter = (
     testStatus[s] = false;
   });
 
+  const buildIssue: TFilterValues = {};
+  const bootIssue: TFilterValues = {};
+  const testIssue: TFilterValues = {};
+
   const configs: TFilterValues = {};
   const archs: TFilterValues = {};
   const compilers: TFilterValues = {};
@@ -74,6 +78,9 @@ export const createFilter = (
     data.configs.forEach(config => {
       configs[config ?? 'Unknown'] = false;
     });
+    data.builds.issues.forEach(i => (buildIssue[i.id] = false));
+    data.boots.issues.forEach(i => (bootIssue[i.id] = false));
+    data.tests.issues.forEach(i => (testIssue[i.id] = false));
   }
 
   return {
@@ -85,6 +92,9 @@ export const createFilter = (
     testStatus,
     trees,
     treeIndexes,
+    buildIssue,
+    bootIssue,
+    testIssue,
   };
 };
 
@@ -103,6 +113,21 @@ const sectionHardware: ISectionItem[] = [
     title: 'filter.testStatus',
     subtitle: 'filter.statusSubtitle',
     sectionKey: 'testStatus',
+  },
+  {
+    title: 'filter.buildIssue',
+    subtitle: 'filter.issueSubtitle',
+    sectionKey: 'buildIssue',
+  },
+  {
+    title: 'filter.bootIssue',
+    subtitle: 'filter.issueSubtitle',
+    sectionKey: 'bootIssue',
+  },
+  {
+    title: 'filter.testIssue',
+    subtitle: 'filter.issueSubtitle',
+    sectionKey: 'testIssue',
   },
   {
     title: 'global.configs',


### PR DESCRIPTION
- Fixes a bug where the boots and tests issues weren't being shown in the hardwareDetails page
- Adds the issue filter handling in the hardwareDetailsView endpoint
- Adds the issue filter sections in the hardwareDetails page frontend
- Hides checkbox filter sections if they are empty

## How to test
Go to a hardwareDetails page with issues data, such as this [localhost example](http://localhost:5173/hardware/google,tomato-rev2?intervalInDays=1&origin=maestro&limitTimestampInSeconds=1733765557&currentPageTab=global.boots&tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22failed%22%2C%22testsTable%22%3A%22all%22%7D&diffFilter=%7B%7D&treeIndexes=%5B%5D) and try out the issue filter. Also compare it to the [equivalent page in staging](https://staging.dashboard.kernelci.org:9000/hardware/google,tomato-rev2?intervalInDays=1&origin=maestro&limitTimestampInSeconds=1733765557&currentPageTab=global.boots&tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22failed%22%2C%22testsTable%22%3A%22all%22%7D&diffFilter=%7B%7D&treeIndexes=%5B%5D).

Also test the issue filter on treeDetails page to make sure it's still working after the refactors, such as this [localhost example](http://localhost:5173/tree/1331fb6640440f42a709eafd5c802f3496f746b8?tableFilter=%7B%22buildsTable%22%3A%22all%22%2C%22bootsTable%22%3A%22failed%22%2C%22testsTable%22%3A%22all%22%7D&origin=maestro&currentPageTab=global.boots&diffFilter=%7B%7D&treeInfo=%7B%22gitBranch%22%3A%22for-next%22%2C%22gitUrl%22%3A%22https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fbroonie%2Fregmap.git%22%2C%22treeName%22%3A%22broonie-regmap%22%2C%22commitName%22%3A%22v6.13-rc2-7-g1331fb664044%22%2C%22headCommitHash%22%3A%221331fb6640440f42a709eafd5c802f3496f746b8%22%7D&intervalInDays=7)

Check if the filters are being applied correctly, including the "Unknown" filter, and if the filter sheet contains the issue ids and reacts to the selected filters

- Closes #643 