### PR TITLE
feat: Remove default values from URL

### DIFF
--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -17,10 +17,9 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import type {
   TestByCommitHash,
-  TestsTableFilter,
   TTestByCommitHashResponse,
 } from '@/types/tree/TreeDetails';
-import { possibleTestsTableFilter } from '@/types/tree/TreeDetails';
+import { possibleTestsTableFilter } from '@/types/general';
 
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 
@@ -33,7 +32,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 
-import type { TestHistory } from '@/types/general';
+import type { TestHistory, TestsTableFilter } from '@/types/general';
 
 import BaseTable, { TableHead } from '@/components/Table/BaseTable';
 

--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -23,7 +23,7 @@ import { Sheet, SheetTrigger } from '@/components/Sheet';
 
 import { LogSheet } from '@/pages/TreeDetails/Tabs/LogSheet';
 
-import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
+import type { TableFilter, TestsTableFilter } from '@/types/general';
 
 import BuildDetailsTestSection from './BuildDetailsTestSection';
 

--- a/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
@@ -8,9 +8,9 @@ import { Separator } from '@/components/ui/separator';
 
 import { useBuildTests } from '@/api/buildTests';
 
-import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
-
 import { TestsTable } from '@/components/TestsTable/TestsTable';
+
+import type { TableFilter, TestsTableFilter } from '@/types/general';
 
 interface IBuildDetailsTestSection {
   buildId: string;

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -34,11 +34,7 @@ import TableStatusFilter from '@/components/Table/TableStatusFilter';
 import { TableBody, TableCell, TableRow } from '@/components/ui/table';
 import type { IAccordionItems } from '@/pages/TreeDetails/Tabs/Build/BuildAccordionContent';
 import AccordionBuildContent from '@/pages/TreeDetails/Tabs/Build/BuildAccordionContent';
-import type {
-  AccordionItemBuilds,
-  BuildsTableFilter,
-} from '@/types/tree/TreeDetails';
-import { possibleBuildsTableFilter } from '@/types/tree/TreeDetails';
+import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
 
 import { useBuildStatusCount } from '@/api/treeDetails';
 import WrapperTable from '@/pages/TreeDetails/Tabs/WrapperTable';
@@ -47,6 +43,8 @@ import { cn } from '@/lib/utils';
 import { usePaginationState } from '@/hooks/usePaginationState';
 
 import type { TableKeys } from '@/utils/constants/tables';
+import { possibleBuildsTableFilter } from '@/types/general';
+import type { BuildsTableFilter } from '@/types/general';
 
 export interface IBuildsTable {
   tableKey: TableKeys;

--- a/dashboard/src/components/Table/TableStatusFilter.tsx
+++ b/dashboard/src/components/Table/TableStatusFilter.tsx
@@ -2,10 +2,8 @@ import classNames from 'classnames';
 import { useCallback, useMemo } from 'react';
 
 import { Button } from '@/components/ui/button';
-import type {
-  BuildsTableFilter,
-  TestsTableFilter,
-} from '@/types/tree/TreeDetails';
+
+import type { BuildsTableFilter, TestsTableFilter } from '@/types/general';
 
 interface ITableStatusFilter {
   onClickBuild?: (value: BuildsTableFilter) => void;

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -19,10 +19,14 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import type { LinkProps } from '@tanstack/react-router';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
-import { possibleTestsTableFilter } from '@/types/tree/TreeDetails';
+import { possibleTestsTableFilter } from '@/types/general';
 
-import type { TestHistory, TIndividualTest, TPathTests } from '@/types/general';
+import type {
+  TestHistory,
+  TestsTableFilter,
+  TIndividualTest,
+  TPathTests,
+} from '@/types/general';
 
 import { StatusTable } from '@/utils/constants/database';
 

--- a/dashboard/src/components/TreeListingPage/InputTime.tsx
+++ b/dashboard/src/components/TreeListingPage/InputTime.tsx
@@ -12,7 +12,7 @@ import { Controller, useForm } from 'react-hook-form';
 import type { ChangeEvent } from 'react';
 import { useCallback } from 'react';
 
-import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
+import { DEFAULT_TREE_INTERVAL_IN_DAYS } from '@/pages/treeConstants';
 import { toast } from '@/hooks/useToast';
 
 import DebounceInput from '../DebounceInput/DebounceInput';
@@ -37,7 +37,7 @@ export function InputTime(): JSX.Element {
   const { handleSubmit, control } = useForm<z.infer<typeof InputTimeSchema>>({
     resolver: zodResolver(InputTimeSchema),
     defaultValues: {
-      intervalInDays: `${DEFAULT_TIME_SEARCH}`,
+      intervalInDays: `${DEFAULT_TREE_INTERVAL_IN_DAYS}`,
     },
   });
 
@@ -94,7 +94,7 @@ export function InputTime(): JSX.Element {
         min={1}
         className={`${fieldError ? 'border-red' : 'border-gray'} mx-[10px] flex w-[100px] flex-1 rounded-md border`}
         startingValue={
-          interval ? interval.toString() : `${DEFAULT_TIME_SEARCH}`
+          interval ? interval.toString() : `${DEFAULT_TREE_INTERVAL_IN_DAYS}`
         }
         placeholder="7"
         {...rest}

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -23,15 +23,14 @@ import { useSearch } from '@tanstack/react-router';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 
 import type { TreeTableBody } from '@/types/tree/Tree';
-import { zOrigin } from '@/types/general';
-
-import { formattedBreakLineValue } from '@/locales/messages';
-
 import {
   possibleBuildsTableFilter,
   possibleTestsTableFilter,
+  zOrigin,
   zPossibleTabValidator,
-} from '@/types/tree/TreeDetails';
+} from '@/types/general';
+
+import { formattedBreakLineValue } from '@/locales/messages';
 
 import { usePaginationState } from '@/hooks/usePaginationState';
 

--- a/dashboard/src/pages/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetails.tsx
@@ -8,10 +8,10 @@ import {
   useRouterState,
 } from '@tanstack/react-router';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
 
 import { RedirectFrom } from '@/types/general';
+import type { TestsTableFilter } from '@/types/general';
 
 import TreeBuildDetails from '@/pages/TreeBuildDetails';
 import HardwareBuildDetails from '@/pages/HardwareBuildDetails';

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -41,7 +41,7 @@ import { sumStatus } from '@/utils/status';
 
 import { usePaginationState } from '@/hooks/usePaginationState';
 
-import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
+import { zPossibleTabValidator } from '@/types/general';
 
 import type { ListingTableColumnMeta } from '@/types/table';
 

--- a/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
+++ b/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/Breadcrumb/Breadcrumb';
 
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import type { TestsTableFilter } from '@/types/general';
 
 const HardwareBuildDetails = (): JSX.Element => {
   const searchParams = useSearch({ from: '/build/$buildId' });

--- a/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
+++ b/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/Breadcrumb/Breadcrumb';
 
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import type { TestsTableFilter } from '@/types/general';
 
 const TreeBuildDetails = (): JSX.Element => {
   const searchParams = useSearch({ from: '/build/$buildId' });

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -12,7 +12,6 @@ import { Skeleton } from '@/components/Skeleton';
 import { BootsTable } from '@/components/BootsTable/BootsTable';
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
 import {
   DesktopGrid,
   MobileGrid,
@@ -24,7 +23,8 @@ import MemoizedConfigList from '@/components/Tabs/Tests/ConfigsList';
 import MemoizedErrorsSummary from '@/components/Tabs/Tests/ErrorsSummary';
 
 import MemoizedStatusCard from '@/components/Tabs/Tests/StatusCard';
-import type { TFilter } from '@/types/general';
+
+import type { TestsTableFilter, TFilter } from '@/types/general';
 
 import TreeCommitNavigationGraph from '@/pages/TreeDetails/Tabs/TreeCommitNavigationGraph';
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -34,16 +34,16 @@ interface BootsTabProps {
 
 const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
   const { treeId } = useParams({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
   const { tableFilter, diffFilter } = useSearch({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
   const currentPathFilter = diffFilter.bootPath
     ? Object.keys(diffFilter.bootPath)[0]
     : undefined;
 
-  const navigate = useNavigate({ from: '/tree/$treeId/' });
+  const navigate = useNavigate({ from: '/tree/$treeId' });
 
   const updatePathFilter = useCallback(
     (pathFilter: string) => {

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -36,7 +36,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
   });
 
   const { diffFilter } = useSearch({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
 
   const toggleFilterBySection = useCallback(

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -106,9 +106,9 @@ const columns: ColumnDef<AccordionItemBuilds>[] = [
 export function TreeDetailsBuildsTable({
   buildItems,
 }: TTreeDetailsBuildsTable): JSX.Element {
-  const { treeId } = useParams({ from: '/tree/$treeId/' });
-  const { tableFilter } = useSearch({ from: '/tree/$treeId/' });
-  const navigate = useNavigate({ from: '/tree/$treeId/' });
+  const { treeId } = useParams({ from: '/tree/$treeId' });
+  const { tableFilter } = useSearch({ from: '/tree/$treeId' });
+  const navigate = useNavigate({ from: '/tree/$treeId' });
 
   const navigateToBuildDetails = useCallback(
     (buildId: string) => {

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -11,10 +11,8 @@ import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
 import { ItemType } from '@/components/ListingItem/ListingItem';
 import { TableHeader } from '@/components/Table/TableHeader';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
-import type {
-  AccordionItemBuilds,
-  BuildsTableFilter,
-} from '@/types/tree/TreeDetails';
+import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
+import type { BuildsTableFilter } from '@/types/general';
 
 export interface TTreeDetailsBuildsTable {
   buildItems: AccordionItemBuilds[];

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -10,8 +10,6 @@ import { Skeleton } from '@/components/Skeleton';
 import { useTreeDetails } from '@/api/treeDetails';
 import BaseCard from '@/components/Cards/BaseCard';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
-
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
 
@@ -26,7 +24,8 @@ import MemoizedConfigList from '@/components/Tabs/Tests/ConfigsList';
 import MemoizedErrorsSummary from '@/components/Tabs/Tests/ErrorsSummary';
 
 import MemoizedStatusCard from '@/components/Tabs/Tests/StatusCard';
-import type { TFilter } from '@/types/general';
+
+import type { TestsTableFilter, TFilter } from '@/types/general';
 
 import TreeCommitNavigationGraph from '@/pages/TreeDetails/Tabs/TreeCommitNavigationGraph';
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -35,14 +35,14 @@ interface TestsTabProps {
 }
 
 const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
-  const { treeId } = useParams({ from: '/tree/$treeId/' });
+  const { treeId } = useParams({ from: '/tree/$treeId' });
   const { isLoading, data, error } = useTreeDetails({
     treeId: treeId ?? '',
     filter: reqFilter,
   });
 
   const { tableFilter, diffFilter } = useSearch({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
   const currentPathFilter = diffFilter.testPath
     ? Object.keys(diffFilter.testPath)[0]

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
@@ -10,10 +10,10 @@ const TreeCommitNavigationGraph = (): React.ReactNode => {
     currentPageTab,
     diffFilter,
     treeInfo: { gitUrl, gitBranch, headCommitHash },
-  } = useSearch({ from: '/tree/$treeId/' });
+  } = useSearch({ from: '/tree/$treeId' });
 
   const { treeId } = useParams({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
 
   const navigate = useNavigate({

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -35,7 +35,7 @@ const TreeDetailsTab = ({
   countElements,
 }: ITreeDetailsTab): JSX.Element => {
   const { currentPageTab } = useSearch({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
   const navigate = useNavigate({ from: '/tree/$treeId' });
   const treeDetailsTab: ITabItem[] = useMemo(

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -6,11 +6,9 @@ import { useCallback, useMemo } from 'react';
 import type { ITabItem } from '@/components/Tabs/Tabs';
 import Tabs from '@/components/Tabs/Tabs';
 
-import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
-
 import type { ITreeDetails } from '@/pages/TreeDetails/TreeDetails';
 
-import type { TFilter } from '@/types/general';
+import { zPossibleTabValidator, type TFilter } from '@/types/general';
 
 import BuildTab from './Build';
 import BootsTab from './Boots';

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -121,10 +121,10 @@ const TreeHeader = ({
 };
 
 function TreeDetails(): JSX.Element {
-  const { treeId } = useParams({ from: '/tree/$treeId/' });
-  const searchParams = useSearch({ from: '/tree/$treeId/' });
+  const { treeId } = useParams({ from: '/tree/$treeId' });
+  const searchParams = useSearch({ from: '/tree/$treeId' });
   const { diffFilter, treeInfo } = searchParams;
-  const navigate = useNavigate({ from: '/tree/$treeId/' });
+  const navigate = useNavigate({ from: '/tree/$treeId' });
 
   const reqFilter = mapFilterToReq(diffFilter);
 

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -136,7 +136,7 @@ const TreeDetailsFilter = ({
   paramFilter,
   treeUrl,
 }: ITreeDetailsFilter): JSX.Element => {
-  const { treeId } = useParams({ from: '/tree/$treeId/' });
+  const { treeId } = useParams({ from: '/tree/$treeId' });
 
   const { data, isLoading } = useTreeDetails({
     treeId,

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -158,7 +158,7 @@ const HardwareDetailsFilter = ({
   const isLoading = false;
 
   const navigate = useNavigate({
-    from: '/hardware/$hardwareId/',
+    from: '/hardware/$hardwareId',
   });
 
   const filter: TFilterCreate = useMemo(() => {

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -12,8 +12,6 @@ import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
 import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
-
 import {
   DesktopGrid,
   MobileGrid,
@@ -25,6 +23,7 @@ import MemoizedConfigList from '@/components/Tabs/Tests/ConfigsList';
 import MemoizedErrorsSummary from '@/components/Tabs/Tests/ErrorsSummary';
 
 import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph';
+import type { TestsTableFilter } from '@/types/general';
 
 interface TBootsTab {
   boots: THardwareDetails['boots'];

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -33,11 +33,11 @@ interface TBuildTab {
 
 const BuildTab = ({ builds, hardwareId, trees }: TBuildTab): JSX.Element => {
   const navigate = useNavigate({
-    from: '/hardware/$hardwareId/',
+    from: '/hardware/$hardwareId',
   });
 
   const { diffFilter } = useSearch({
-    from: '/hardware/$hardwareId/',
+    from: '/hardware/$hardwareId',
   });
 
   const toggleFilterBySection = useCallback(

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -117,7 +117,7 @@ export function HardwareDetailsBuildsTable({
 }: THardwareDetailsBuildsTable): JSX.Element {
   const { tableFilter } = useSearch({ from: '/hardware/$hardwareId' });
 
-  const navigate = useNavigate({ from: '/hardware/$hardwareId/' });
+  const navigate = useNavigate({ from: '/hardware/$hardwareId' });
 
   const navigateToBuildDetails = useCallback(
     (buildId: string) => {

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -12,10 +12,8 @@ import { ItemType } from '@/components/ListingItem/ListingItem';
 import { TableHeader } from '@/components/Table/TableHeader';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 
-import type {
-  AccordionItemBuilds,
-  BuildsTableFilter,
-} from '@/types/tree/TreeDetails';
+import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
+import type { BuildsTableFilter } from '@/types/general';
 
 export interface THardwareDetailsBuildsTable {
   buildItems: AccordionItemBuilds[];

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
@@ -18,7 +18,7 @@ const HardwareCommitNavigationGraph = ({
       from: '/hardware/$hardwareId',
     });
 
-  const navigate = useNavigate({ from: '/hardware/$hardwareId/' });
+  const navigate = useNavigate({ from: '/hardware/$hardwareId' });
 
   const diffFilterWithHardware = useMemo(
     () => ({ ...diffFilter, hardware: { [hardwareId]: true } }),

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -33,7 +33,7 @@ const HardwareDetailsTabs = ({
   countElements,
 }: IHardwareDetailsTab): JSX.Element => {
   const { currentPageTab } = useSearch({
-    from: '/hardware/$hardwareId/',
+    from: '/hardware/$hardwareId',
   });
 
   const navigate = useNavigate({ from: '/hardware/$hardwareId' });

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -6,9 +6,8 @@ import { useCallback, useMemo } from 'react';
 import type { ITabItem } from '@/components/Tabs/Tabs';
 import Tabs from '@/components/Tabs/Tabs';
 
-import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
-
 import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import { zPossibleTabValidator } from '@/types/general';
 
 import BuildTab from './Build';
 import BootsTab from './Boots';

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -8,8 +8,6 @@ import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
 import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
-
 import {
   DesktopGrid,
   MobileGrid,
@@ -19,7 +17,10 @@ import {
 import MemoizedStatusCard from '@/components/Tabs/Tests/StatusCard';
 import MemoizedConfigList from '@/components/Tabs/Tests/ConfigsList';
 import MemoizedErrorsSummary from '@/components/Tabs/Tests/ErrorsSummary';
+
 import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph';
+
+import type { TestsTableFilter } from '@/types/general';
 
 import HardwareDetailsTestTable from './HardwareDetailsTestsTable';
 

--- a/dashboard/src/pages/treeConstants.ts
+++ b/dashboard/src/pages/treeConstants.ts
@@ -1,1 +1,2 @@
-export const DEFAULT_TIME_SEARCH = 7;
+export const DEFAULT_TREE_INTERVAL_IN_DAYS = 7;
+export const DEFAULT_TREE_SEARCH = '';

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -1,4 +1,8 @@
-import { createRootRoute, Outlet } from '@tanstack/react-router';
+import {
+  createRootRoute,
+  Outlet,
+  stripSearchParams,
+} from '@tanstack/react-router';
 
 import { z } from 'zod';
 
@@ -9,7 +13,11 @@ import { z } from 'zod';
 import SideMenu from '@/components/SideMenu/SideMenu';
 import TopBar from '@/components/TopBar/TopBar';
 
-import { zOrigin } from '@/types/general';
+import { DEFAULT_ORIGIN, zOrigin } from '@/types/general';
+
+const defaultValues = {
+  origin: DEFAULT_ORIGIN,
+};
 
 const RouteSchema = z.object({
   origin: zOrigin,
@@ -17,6 +25,7 @@ const RouteSchema = z.object({
 
 export const Route = createRootRoute({
   validateSearch: RouteSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
   component: () => (
     <>
       <div className="h-full w-full">

--- a/dashboard/src/routes/build/$buildId/route.tsx
+++ b/dashboard/src/routes/build/$buildId/route.tsx
@@ -3,24 +3,33 @@ import { z } from 'zod';
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import {
-  defaultValidadorValues,
+  DEFAULT_DIFF_FILTER,
+  DEFAULT_ORIGIN,
+  DEFAULT_TAB,
   zTableFilterInfoDefault,
   zTableFilterInfoValidator,
-} from '@/types/tree/TreeDetails';
-import { DEFAULT_DIFF_FILTER, DEFAULT_ORIGIN } from '@/types/general';
-import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
+} from '@/types/general';
+
+import {
+  DEFAULT_TREE_INTERVAL_IN_DAYS,
+  DEFAULT_TREE_SEARCH,
+} from '@/pages/treeConstants';
+import {
+  DEFAULT_TREE_COMMITS,
+  DEFAULT_TREE_INDEXES,
+} from '@/types/hardware/hardwareDetails';
+import { DEFAULT_HARDWARE_SEARCH } from '@/utils/constants/hardware';
 
 const defaultValues = {
   origin: DEFAULT_ORIGIN,
   tableFilter: zTableFilterInfoDefault,
   diffFilter: DEFAULT_DIFF_FILTER,
-  currentPageTab: defaultValidadorValues.tab,
-  intervalInDays: DEFAULT_TIME_SEARCH,
-  testPath: '',
-  treeSearch: '',
-  hardwareSearch: '',
-  treeIndexes: [],
-  treeCommits: {},
+  currentPageTab: DEFAULT_TAB,
+  intervalInDays: DEFAULT_TREE_INTERVAL_IN_DAYS,
+  treeSearch: DEFAULT_TREE_SEARCH,
+  hardwareSearch: DEFAULT_HARDWARE_SEARCH,
+  treeIndexes: DEFAULT_TREE_INDEXES,
+  treeCommits: DEFAULT_TREE_COMMITS,
 };
 
 const buildDetailsSearchSchema = z.object({

--- a/dashboard/src/routes/build/$buildId/route.tsx
+++ b/dashboard/src/routes/build/$buildId/route.tsx
@@ -1,8 +1,27 @@
 import { z } from 'zod';
 
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
-import { zTableFilterInfoValidator } from '@/types/tree/TreeDetails';
+import {
+  defaultValidadorValues,
+  zTableFilterInfoDefault,
+  zTableFilterInfoValidator,
+} from '@/types/tree/TreeDetails';
+import { DEFAULT_DIFF_FILTER, DEFAULT_ORIGIN } from '@/types/general';
+import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
+
+const defaultValues = {
+  origin: DEFAULT_ORIGIN,
+  tableFilter: zTableFilterInfoDefault,
+  diffFilter: DEFAULT_DIFF_FILTER,
+  currentPageTab: defaultValidadorValues.tab,
+  intervalInDays: DEFAULT_TIME_SEARCH,
+  testPath: '',
+  treeSearch: '',
+  hardwareSearch: '',
+  treeIndexes: [],
+  treeCommits: {},
+};
 
 const buildDetailsSearchSchema = z.object({
   tableFilter: zTableFilterInfoValidator,
@@ -10,4 +29,5 @@ const buildDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/build/$buildId')({
   validateSearch: buildDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/route.tsx
@@ -1,18 +1,27 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
 import {
+  defaultValidadorValues,
   zPossibleTabValidator,
+  zTableFilterInfoDefault,
   zTableFilterInfoValidator,
 } from '@/types/tree/TreeDetails';
 
 import { zTreeCommits } from '@/types/hardware/hardwareDetails';
-import { zDiffFilter } from '@/types/general';
+import { DEFAULT_DIFF_FILTER, zDiffFilter } from '@/types/general';
 
+const defaultValues = {
+  currentPageTab: defaultValidadorValues.tab,
+  treeIndexes: [],
+  treeCommits: {},
+  tableFilter: zTableFilterInfoDefault,
+  diffFilter: DEFAULT_DIFF_FILTER,
+};
 const hardwareDetailsSearchSchema = z.object({
   currentPageTab: zPossibleTabValidator,
-  treeIndexes: z.array(z.number().int()).optional(),
+  treeIndexes: z.array(z.number().int()).default([]),
   treeCommits: zTreeCommits,
   tableFilter: zTableFilterInfoValidator,
   startTimestampInSeconds: z.number(),
@@ -22,4 +31,5 @@ const hardwareDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/hardware/$hardwareId')({
   validateSearch: hardwareDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/route.tsx
@@ -3,25 +3,31 @@ import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import {
-  defaultValidadorValues,
+  DEFAULT_TREE_COMMITS,
+  DEFAULT_TREE_INDEXES,
+  zTreeCommits,
+  zTreeIndexes,
+} from '@/types/hardware/hardwareDetails';
+
+import {
+  DEFAULT_DIFF_FILTER,
+  DEFAULT_TAB,
+  zDiffFilter,
   zPossibleTabValidator,
   zTableFilterInfoDefault,
   zTableFilterInfoValidator,
-} from '@/types/tree/TreeDetails';
-
-import { zTreeCommits } from '@/types/hardware/hardwareDetails';
-import { DEFAULT_DIFF_FILTER, zDiffFilter } from '@/types/general';
+} from '@/types/general';
 
 const defaultValues = {
-  currentPageTab: defaultValidadorValues.tab,
-  treeIndexes: [],
-  treeCommits: {},
+  currentPageTab: DEFAULT_TAB,
+  treeIndexes: DEFAULT_TREE_INDEXES,
+  treeCommits: DEFAULT_TREE_COMMITS,
   tableFilter: zTableFilterInfoDefault,
   diffFilter: DEFAULT_DIFF_FILTER,
 };
 const hardwareDetailsSearchSchema = z.object({
   currentPageTab: zPossibleTabValidator,
-  treeIndexes: z.array(z.number().int()).default([]),
+  treeIndexes: zTreeIndexes,
   treeCommits: zTreeCommits,
   tableFilter: zTableFilterInfoValidator,
   startTimestampInSeconds: z.number(),

--- a/dashboard/src/routes/hardware/route.tsx
+++ b/dashboard/src/routes/hardware/route.tsx
@@ -2,16 +2,19 @@ import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { makeZIntervalInDays } from '@/types/general';
-import { DEFAULT_HARDWARE_INTERVAL_IN_DAYS } from '@/utils/constants/hardware';
+import {
+  DEFAULT_HARDWARE_INTERVAL_IN_DAYS,
+  DEFAULT_HARDWARE_SEARCH,
+} from '@/utils/constants/hardware';
 
 const defaultValues = {
   intervalInDays: DEFAULT_HARDWARE_INTERVAL_IN_DAYS,
-  hardwareSearch: '',
+  hardwareSearch: DEFAULT_HARDWARE_SEARCH,
 };
 
 const zHardwareSchema = z.object({
   intervalInDays: makeZIntervalInDays(DEFAULT_HARDWARE_INTERVAL_IN_DAYS),
-  hardwareSearch: z.string().catch(''),
+  hardwareSearch: z.string().catch(DEFAULT_HARDWARE_SEARCH),
 });
 
 export const Route = createFileRoute('/hardware')({

--- a/dashboard/src/routes/hardware/route.tsx
+++ b/dashboard/src/routes/hardware/route.tsx
@@ -1,14 +1,20 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { makeZIntervalInDays } from '@/types/general';
 import { DEFAULT_HARDWARE_INTERVAL_IN_DAYS } from '@/utils/constants/hardware';
 
+const defaultValues = {
+  intervalInDays: DEFAULT_HARDWARE_INTERVAL_IN_DAYS,
+  hardwareSearch: '',
+};
+
 const zHardwareSchema = z.object({
   intervalInDays: makeZIntervalInDays(DEFAULT_HARDWARE_INTERVAL_IN_DAYS),
-  hardwareSearch: z.string().optional().catch(undefined),
+  hardwareSearch: z.string().catch(''),
 });
 
 export const Route = createFileRoute('/hardware')({
   validateSearch: zHardwareSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -1,12 +1,15 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { z } from 'zod';
 
-import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
+import {
+  DEFAULT_TREE_INTERVAL_IN_DAYS,
+  DEFAULT_TREE_SEARCH,
+} from '@/pages/treeConstants';
 import { makeZIntervalInDays } from '@/types/general';
 
 export const HomeSearchSchema = z.object({
-  treeSearch: z.string().catch(''),
-  intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+  treeSearch: z.string().catch(DEFAULT_TREE_SEARCH),
+  intervalInDays: makeZIntervalInDays(DEFAULT_TREE_INTERVAL_IN_DAYS),
 });
 
 export const Route = createFileRoute('/')({

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
 import { makeZIntervalInDays } from '@/types/general';
 
 export const HomeSearchSchema = z.object({
-  treeSearch: z.string().optional().catch(undefined),
+  treeSearch: z.string().catch(''),
   intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
 });
 

--- a/dashboard/src/routes/test/$testId/route.tsx
+++ b/dashboard/src/routes/test/$testId/route.tsx
@@ -1,3 +1,39 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
-export const Route = createFileRoute('/test/$testId')();
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
+
+import {
+  DEFAULT_DIFF_FILTER,
+  DEFAULT_ORIGIN,
+  DEFAULT_TAB,
+  zTableFilterInfoDefault,
+} from '@/types/general';
+
+import {
+  DEFAULT_TREE_INTERVAL_IN_DAYS,
+  DEFAULT_TREE_SEARCH,
+} from '@/pages/treeConstants';
+import {
+  DEFAULT_TREE_COMMITS,
+  DEFAULT_TREE_INDEXES,
+} from '@/types/hardware/hardwareDetails';
+import { DEFAULT_HARDWARE_SEARCH } from '@/utils/constants/hardware';
+
+const defaultValues = {
+  origin: DEFAULT_ORIGIN,
+  tableFilter: zTableFilterInfoDefault,
+  diffFilter: DEFAULT_DIFF_FILTER,
+  currentPageTab: DEFAULT_TAB,
+  intervalInDays: DEFAULT_TREE_INTERVAL_IN_DAYS,
+  treeSearch: DEFAULT_TREE_SEARCH,
+  hardwareSearch: DEFAULT_HARDWARE_SEARCH,
+  treeIndexes: DEFAULT_TREE_INDEXES,
+  treeCommits: DEFAULT_TREE_COMMITS,
+};
+
+const testDetailsSearchSchema = z.object({});
+
+export const Route = createFileRoute('/test/$testId')({
+  validateSearch: testDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
+});

--- a/dashboard/src/routes/tree/$treeId/build/$buildId/index.tsx
+++ b/dashboard/src/routes/tree/$treeId/build/$buildId/index.tsx
@@ -2,8 +2,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
-import { zTableFilterInfoValidator } from '@/types/tree/TreeDetails';
-import { RedirectFrom } from '@/types/general';
+import { RedirectFrom, zTableFilterInfoValidator } from '@/types/general';
 
 const buildDetailsSearchSchema = z.object({
   tableFilter: zTableFilterInfoValidator,

--- a/dashboard/src/routes/tree/$treeId/route.tsx
+++ b/dashboard/src/routes/tree/$treeId/route.tsx
@@ -1,18 +1,35 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
-import { zDiffFilter, zOrigin } from '@/types/general';
+import {
+  DEFAULT_DIFF_FILTER,
+  DEFAULT_ORIGIN,
+  zDiffFilter,
+  zOrigin,
+} from '@/types/general';
 
 import {
+  DEFAULT_TREE_INFO,
+  defaultValidadorValues,
   zPossibleTabValidator,
+  zTableFilterInfoDefault,
   zTableFilterInfoValidator,
   zTreeInformation,
 } from '@/types/tree/TreeDetails';
 
+const defaultValues = {
+  diffFilter: DEFAULT_DIFF_FILTER,
+  testPath: '',
+  origin: DEFAULT_ORIGIN,
+  treeInfo: DEFAULT_TREE_INFO,
+  currentPageTab: defaultValidadorValues.tab,
+  tableFilter: zTableFilterInfoDefault,
+};
+
 const treeDetailsSearchSchema = z.object({
   diffFilter: zDiffFilter,
-  testPath: z.string().optional().catch(''),
+  testPath: z.string().catch(''),
   origin: zOrigin,
   treeInfo: zTreeInformation,
   currentPageTab: zPossibleTabValidator,
@@ -21,4 +38,5 @@ const treeDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/tree/$treeId')({
   validateSearch: treeDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/tree/$treeId/route.tsx
+++ b/dashboard/src/routes/tree/$treeId/route.tsx
@@ -5,31 +5,26 @@ import { z } from 'zod';
 import {
   DEFAULT_DIFF_FILTER,
   DEFAULT_ORIGIN,
+  DEFAULT_TAB,
   zDiffFilter,
   zOrigin,
-} from '@/types/general';
-
-import {
-  DEFAULT_TREE_INFO,
-  defaultValidadorValues,
   zPossibleTabValidator,
   zTableFilterInfoDefault,
   zTableFilterInfoValidator,
-  zTreeInformation,
-} from '@/types/tree/TreeDetails';
+} from '@/types/general';
+
+import { DEFAULT_TREE_INFO, zTreeInformation } from '@/types/tree/TreeDetails';
 
 const defaultValues = {
   diffFilter: DEFAULT_DIFF_FILTER,
-  testPath: '',
   origin: DEFAULT_ORIGIN,
   treeInfo: DEFAULT_TREE_INFO,
-  currentPageTab: defaultValidadorValues.tab,
+  currentPageTab: DEFAULT_TAB,
   tableFilter: zTableFilterInfoDefault,
 };
 
 const treeDetailsSearchSchema = z.object({
   diffFilter: zDiffFilter,
-  testPath: z.string().catch(''),
   origin: zOrigin,
   treeInfo: zTreeInformation,
   currentPageTab: zPossibleTabValidator,

--- a/dashboard/src/routes/tree/index.tsx
+++ b/dashboard/src/routes/tree/index.tsx
@@ -3,9 +3,10 @@ import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import Trees from '@/pages/Trees';
+import { DEFAULT_TREE_SEARCH } from '@/pages/treeConstants';
 
 export const TreeSearchSchema = z.object({
-  treeSearch: z.string().catch(''),
+  treeSearch: z.string().catch(DEFAULT_TREE_SEARCH),
 });
 
 export const Route = createFileRoute('/tree/')({

--- a/dashboard/src/routes/tree/index.tsx
+++ b/dashboard/src/routes/tree/index.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import Trees from '@/pages/Trees';
 
 export const TreeSearchSchema = z.object({
-  treeSearch: z.string().optional().catch(undefined),
+  treeSearch: z.string().catch(''),
 });
 
 export const Route = createFileRoute('/tree/')({

--- a/dashboard/src/routes/tree/route.tsx
+++ b/dashboard/src/routes/tree/route.tsx
@@ -1,14 +1,21 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
 import { makeZIntervalInDays } from '@/types/general';
 import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
 
+const defaultValues = {
+  intervalInDays: DEFAULT_TIME_SEARCH,
+  treeSearch: '',
+};
+
 export const RootSearchSchema = z.object({
   intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+  treeSearch: z.string().catch(''),
 });
 
 export const Route = createFileRoute('/tree')({
   validateSearch: RootSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/tree/route.tsx
+++ b/dashboard/src/routes/tree/route.tsx
@@ -3,16 +3,19 @@ import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { makeZIntervalInDays } from '@/types/general';
-import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
+import {
+  DEFAULT_TREE_INTERVAL_IN_DAYS,
+  DEFAULT_TREE_SEARCH,
+} from '@/pages/treeConstants';
 
 const defaultValues = {
-  intervalInDays: DEFAULT_TIME_SEARCH,
-  treeSearch: '',
+  intervalInDays: DEFAULT_TREE_INTERVAL_IN_DAYS,
+  treeSearch: DEFAULT_TREE_SEARCH,
 };
 
 export const RootSearchSchema = z.object({
-  intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
-  treeSearch: z.string().catch(''),
+  intervalInDays: makeZIntervalInDays(DEFAULT_TREE_INTERVAL_IN_DAYS),
+  treeSearch: z.string().catch(DEFAULT_TREE_SEARCH),
 });
 
 export const Route = createFileRoute('/tree')({

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -117,12 +117,14 @@ const origins = [
   'syzbot',
   'tuxsuite',
 ] as const;
-const DEFAULT_ORIGIN = 'maestro';
+export const DEFAULT_ORIGIN = 'maestro';
 
 export type TOrigins = (typeof origins)[number];
 
 export const zOriginEnum = z.enum(origins);
-export const zOrigin = zOriginEnum.catch(DEFAULT_ORIGIN);
+export const zOrigin = zOriginEnum
+  .default(DEFAULT_ORIGIN)
+  .catch(DEFAULT_ORIGIN);
 
 const zFilterBoolValue = z.record(z.boolean()).optional();
 const zFilterNumberValue = z.number().optional();
@@ -156,6 +158,7 @@ export type TFilterKeys =
   | z.infer<typeof zFilterObjectsKeys>
   | z.infer<typeof zFilterNumberKeys>;
 
+export const DEFAULT_DIFF_FILTER = {};
 export const zDiffFilter = z
   .union([
     z.object({
@@ -181,7 +184,8 @@ export const zDiffFilter = z
     } satisfies Record<TFilterKeys, unknown>),
     z.record(z.never()),
   ])
-  .catch({});
+  .default(DEFAULT_DIFF_FILTER)
+  .catch(DEFAULT_DIFF_FILTER);
 
 export type TFilterObjectsKeys = z.infer<typeof zFilterObjectsKeys>;
 export type TFilter = z.infer<typeof zDiffFilter>;

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -158,7 +158,29 @@ export type TFilterKeys =
   | z.infer<typeof zFilterObjectsKeys>
   | z.infer<typeof zFilterNumberKeys>;
 
+const possibleTabs = ['global.builds', 'global.boots', 'global.tests'] as const;
+
+export const possibleBuildsTableFilter = [
+  'invalid',
+  'valid',
+  'all',
+  'null',
+] as const;
+
+export const possibleTestsTableFilter = [
+  'all',
+  'success',
+  'failed',
+  'inconclusive',
+] as const;
+
 export const DEFAULT_DIFF_FILTER = {};
+export const DEFAULT_TAB: (typeof possibleTabs)[number] = 'global.builds';
+const DEFAULT_BUILDS_TABLE_FILTER: (typeof possibleBuildsTableFilter)[number] =
+  'all';
+const DEFAULT_TESTS_TABLE_FILTER: (typeof possibleTestsTableFilter)[number] =
+  'all';
+
 export const zDiffFilter = z
   .union([
     z.object({
@@ -186,6 +208,40 @@ export const zDiffFilter = z
   ])
   .default(DEFAULT_DIFF_FILTER)
   .catch(DEFAULT_DIFF_FILTER);
+
+export const zPossibleTabValidator = z
+  .enum(possibleTabs)
+  .default(DEFAULT_TAB)
+  .catch(DEFAULT_TAB);
+
+export const zBuildsTableFilterValidator = z
+  .enum(possibleBuildsTableFilter)
+  .catch(DEFAULT_BUILDS_TABLE_FILTER);
+
+export const zTestsTableFilterValidator = z
+  .enum(possibleTestsTableFilter)
+  .catch(DEFAULT_TESTS_TABLE_FILTER);
+
+export type BuildsTableFilter = z.infer<typeof zBuildsTableFilterValidator>;
+export type TestsTableFilter = z.infer<typeof zTestsTableFilterValidator>;
+
+export const zTableFilterInfo = z.object({
+  buildsTable: zBuildsTableFilterValidator,
+  bootsTable: zTestsTableFilterValidator,
+  testsTable: zTestsTableFilterValidator,
+});
+
+export const zTableFilterInfoDefault = {
+  buildsTable: zBuildsTableFilterValidator.parse(''),
+  bootsTable: zTestsTableFilterValidator.parse(''),
+  testsTable: zTestsTableFilterValidator.parse(''),
+};
+
+export const zTableFilterInfoValidator = zTableFilterInfo
+  .default(zTableFilterInfoDefault)
+  .catch(zTableFilterInfoDefault);
+
+export type TableFilter = z.infer<typeof zTableFilterInfo>;
 
 export type TFilterObjectsKeys = z.infer<typeof zFilterObjectsKeys>;
 export type TFilter = z.infer<typeof zDiffFilter>;

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -78,5 +78,11 @@ export interface THardwareDetailsFilter
   valid?: string[];
 }
 
-export const zTreeCommits = z.record(z.string()).default({});
+export const DEFAULT_TREE_COMMITS = {};
+export const DEFAULT_TREE_INDEXES = [];
+
+export const zTreeIndexes = z
+  .array(z.number().int())
+  .default(DEFAULT_TREE_INDEXES);
+export const zTreeCommits = z.record(z.string()).default(DEFAULT_TREE_COMMITS);
 export type TTreeCommits = z.infer<typeof zTreeCommits>;

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -78,5 +78,5 @@ export interface THardwareDetailsFilter
   valid?: string[];
 }
 
-export const zTreeCommits = z.record(z.string()).optional();
+export const zTreeCommits = z.record(z.string()).default({});
 export type TTreeCommits = z.infer<typeof zTreeCommits>;

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -1,4 +1,4 @@
-import { object, z } from 'zod';
+import { z } from 'zod';
 
 import type { ReactNode } from 'react';
 
@@ -94,67 +94,8 @@ export type TTreeTestsFullData = {
   treeUrl: string;
 };
 
-const possibleTabs = ['global.builds', 'global.boots', 'global.tests'] as const;
-
-export const possibleBuildsTableFilter = [
-  'invalid',
-  'valid',
-  'all',
-  'null',
-] as const;
-
-export const possibleTestsTableFilter = [
-  'all',
-  'success',
-  'failed',
-  'inconclusive',
-] as const;
-
-export const defaultValidadorValues: {
-  tab: (typeof possibleTabs)[number];
-  buildsTableFilter: (typeof possibleBuildsTableFilter)[number];
-  testsTableFilter: (typeof possibleTestsTableFilter)[number];
-} = {
-  tab: 'global.builds',
-  buildsTableFilter: 'all',
-  testsTableFilter: 'all',
-};
-
-export const zPossibleTabValidator = z
-  .enum(possibleTabs)
-  .default(defaultValidadorValues.tab)
-  .catch(defaultValidadorValues.tab);
-
-export const zBuildsTableFilterValidator = z
-  .enum(possibleBuildsTableFilter)
-  .catch(defaultValidadorValues.buildsTableFilter);
-
-export const zTestsTableFilterValidator = z
-  .enum(possibleTestsTableFilter)
-  .catch(defaultValidadorValues.testsTableFilter);
-
-export type BuildsTableFilter = z.infer<typeof zBuildsTableFilterValidator>;
-export type TestsTableFilter = z.infer<typeof zTestsTableFilterValidator>;
-
-export const zTableFilterInfo = object({
-  buildsTable: zBuildsTableFilterValidator,
-  bootsTable: zTestsTableFilterValidator,
-  testsTable: zTestsTableFilterValidator,
-});
-
-export const zTableFilterInfoDefault = {
-  buildsTable: zBuildsTableFilterValidator.parse(''),
-  bootsTable: zTestsTableFilterValidator.parse(''),
-  testsTable: zTestsTableFilterValidator.parse(''),
-};
-
-export const zTableFilterInfoValidator = zTableFilterInfo
-  .default(zTableFilterInfoDefault)
-  .catch(zTableFilterInfoDefault);
-
-export type TableFilter = z.infer<typeof zTableFilterInfo>;
-
 export const DEFAULT_TREE_INFO = {};
+
 export const zTreeInformation = z
   .object({
     gitBranch: z.string().optional().catch(''),

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -96,10 +96,6 @@ export type TTreeTestsFullData = {
 
 const possibleTabs = ['global.builds', 'global.boots', 'global.tests'] as const;
 
-export const zPossibleTabValidator = z
-  .enum(possibleTabs)
-  .catch('global.builds');
-
 export const possibleBuildsTableFilter = [
   'invalid',
   'valid',
@@ -114,12 +110,28 @@ export const possibleTestsTableFilter = [
   'inconclusive',
 ] as const;
 
+export const defaultValidadorValues: {
+  tab: (typeof possibleTabs)[number];
+  buildsTableFilter: (typeof possibleBuildsTableFilter)[number];
+  testsTableFilter: (typeof possibleTestsTableFilter)[number];
+} = {
+  tab: 'global.builds',
+  buildsTableFilter: 'all',
+  testsTableFilter: 'all',
+};
+
+export const zPossibleTabValidator = z
+  .enum(possibleTabs)
+  .default(defaultValidadorValues.tab)
+  .catch(defaultValidadorValues.tab);
+
 export const zBuildsTableFilterValidator = z
   .enum(possibleBuildsTableFilter)
-  .catch('all');
+  .catch(defaultValidadorValues.buildsTableFilter);
+
 export const zTestsTableFilterValidator = z
   .enum(possibleTestsTableFilter)
-  .catch('all');
+  .catch(defaultValidadorValues.testsTableFilter);
 
 export type BuildsTableFilter = z.infer<typeof zBuildsTableFilterValidator>;
 export type TestsTableFilter = z.infer<typeof zTestsTableFilterValidator>;
@@ -130,14 +142,19 @@ export const zTableFilterInfo = object({
   testsTable: zTestsTableFilterValidator,
 });
 
-export const zTableFilterInfoValidator = zTableFilterInfo.catch({
+export const zTableFilterInfoDefault = {
   buildsTable: zBuildsTableFilterValidator.parse(''),
   bootsTable: zTestsTableFilterValidator.parse(''),
   testsTable: zTestsTableFilterValidator.parse(''),
-});
+};
+
+export const zTableFilterInfoValidator = zTableFilterInfo
+  .default(zTableFilterInfoDefault)
+  .catch(zTableFilterInfoDefault);
 
 export type TableFilter = z.infer<typeof zTableFilterInfo>;
 
+export const DEFAULT_TREE_INFO = {};
 export const zTreeInformation = z
   .object({
     gitBranch: z.string().optional().catch(''),
@@ -146,7 +163,8 @@ export const zTreeInformation = z
     commitName: z.string().optional().catch(''),
     headCommitHash: z.string().optional().catch(undefined),
   })
-  .catch({});
+  .default(DEFAULT_TREE_INFO)
+  .catch(DEFAULT_TREE_INFO);
 
 export type TestByCommitHash = {
   id: string;

--- a/dashboard/src/utils/constants/hardware.ts
+++ b/dashboard/src/utils/constants/hardware.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_HARDWARE_INTERVAL_IN_DAYS = 3;
+export const DEFAULT_HARDWARE_SEARCH = '';


### PR DESCRIPTION
- Added the search middleware `stripSearchParams` to remove search params with default values from the URL
- Changed `from` options to use route instead of index e.g from `/tree/$treeId/` to `/tree/$treeId`
- Added some default clauses to zod types to make the default values of search params be returned when they are stripped from the URL. Without this clause the returned value would be undefined

Closes #656

## How to test
Navigate through the app, verifying that default values aren't being shown in the URL while keeping the same behaviour. Also note that when changing something, the search params goes back to the URL.