### PR TITLE
Feat: hardware listing tab direction

### DIFF
--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -51,6 +51,8 @@ import { BuildStatus, GroupedTestStatus } from '@/components/Status/Status';
 import { TableHeader } from '@/components/Table/TableHeader';
 import { PaginationInfo } from '@/components/Table/PaginationInfo';
 
+import type { ListingTableColumnMeta } from '@/types/table';
+
 import { InputTime } from './InputTime';
 
 const MemoizedInputTime = memo(InputTime);
@@ -77,12 +79,18 @@ const columns: ColumnDef<TreeTableBody>[] = [
         </Tooltip>
       );
     },
+    meta: {
+      tabTarget: 'global.builds',
+    },
   },
   {
     accessorKey: 'branch',
     header: ({ column }): JSX.Element => (
       <TableHeader column={column} intlKey="globalTable.branch" />
     ),
+    meta: {
+      tabTarget: 'global.builds',
+    },
   },
   {
     accessorKey: 'commitName',
@@ -95,6 +103,9 @@ const columns: ColumnDef<TreeTableBody>[] = [
           ? row.getValue('commitName')
           : row.original.commitHash,
       ),
+    meta: {
+      tabTarget: 'global.builds',
+    },
   },
   {
     accessorKey: 'date',
@@ -104,6 +115,9 @@ const columns: ColumnDef<TreeTableBody>[] = [
     cell: ({ row }): JSX.Element => (
       <TooltipDateTime dateTime={row.getValue('date')} lineBreak={true} />
     ),
+    meta: {
+      tabTarget: 'global.builds',
+    },
   },
   {
     accessorKey: 'buildStatus.valid',
@@ -124,6 +138,9 @@ const columns: ColumnDef<TreeTableBody>[] = [
       ) : (
         <FormattedMessage id="global.loading" defaultMessage="Loading..." />
       );
+    },
+    meta: {
+      tabTarget: 'global.builds',
     },
   },
   {
@@ -149,6 +166,9 @@ const columns: ColumnDef<TreeTableBody>[] = [
         <FormattedMessage id="global.loading" defaultMessage="Loading..." />
       );
     },
+    meta: {
+      tabTarget: 'global.boots',
+    },
   },
   {
     accessorKey: 'testStatus.pass',
@@ -173,18 +193,11 @@ const columns: ColumnDef<TreeTableBody>[] = [
         <FormattedMessage id="global.loading" defaultMessage="Loading..." />
       );
     },
+    meta: {
+      tabTarget: 'global.tests',
+    },
   },
 ];
-
-const columnLinkTargets = [
-  'global.builds',
-  'global.builds',
-  'global.builds',
-  'global.builds',
-  'global.builds',
-  'global.boots',
-  'global.tests',
-] as const;
 
 interface ITreeTable {
   treeTableRows: TreeTableBody[];
@@ -199,7 +212,7 @@ export function TreeTable({ treeTableRows }: ITreeTable): JSX.Element {
   const origin = zOrigin.parse(unsafeOrigin);
 
   const getLinkProps = useCallback(
-    (row: Row<TreeTableBody>, target: string): LinkProps => {
+    (row: Row<TreeTableBody>, tabTarget?: string): LinkProps => {
       return {
         to: '/tree/$treeId',
         params: { treeId: row.original.id },
@@ -211,7 +224,7 @@ export function TreeTable({ treeTableRows }: ITreeTable): JSX.Element {
             testsTable: possibleTestsTableFilter[0],
           },
           origin: origin,
-          currentPageTab: zPossibleTabValidator.parse(target),
+          currentPageTab: zPossibleTabValidator.parse(tabTarget),
           diffFilter: {},
           treeInfo: {
             gitUrl: row.original.url,
@@ -268,12 +281,15 @@ export function TreeTable({ treeTableRows }: ITreeTable): JSX.Element {
     return modelRows?.length ? (
       modelRows.map(row => (
         <TableRow key={row.id}>
-          {row.getVisibleCells().map((cell, cellIndex) => {
+          {row.getVisibleCells().map(cell => {
+            const tabTarget = (
+              cell.column.columnDef.meta as ListingTableColumnMeta
+            ).tabTarget;
             return (
               <TableCellWithLink
                 key={cell.id}
                 linkClassName="w-full inline-block h-full"
-                linkProps={getLinkProps(row, columnLinkTargets[cellIndex])}
+                linkProps={getLinkProps(row, tabTarget)}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </TableCellWithLink>

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -41,6 +41,10 @@ import { sumStatus } from '@/utils/status';
 
 import { usePaginationState } from '@/hooks/usePaginationState';
 
+import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
+
+import type { ListingTableColumnMeta } from '@/types/table';
+
 import { InputTime } from './InputTime';
 
 // TODO Extract and reuse the table
@@ -51,6 +55,9 @@ const columns: ColumnDef<HardwareTableItem>[] = [
     header: ({ column }): JSX.Element => (
       <TableHeader column={column} intlKey="global.name" />
     ),
+    meta: {
+      tabTarget: 'global.builds',
+    },
   },
   {
     accessorKey: 'buildCount',
@@ -73,6 +80,9 @@ const columns: ColumnDef<HardwareTableItem>[] = [
       ) : (
         <FormattedMessage id="global.loading" defaultMessage="Loading..." />
       );
+    },
+    meta: {
+      tabTarget: 'global.builds',
     },
   },
   {
@@ -101,6 +111,9 @@ const columns: ColumnDef<HardwareTableItem>[] = [
         <FormattedMessage id="global.loading" defaultMessage="Loading..." />
       );
     },
+    meta: {
+      tabTarget: 'global.boots',
+    },
   },
   {
     accessorKey: 'testStatusCount',
@@ -128,6 +141,9 @@ const columns: ColumnDef<HardwareTableItem>[] = [
         <FormattedMessage id="global.loading" defaultMessage="Loading..." />
       );
     },
+    meta: {
+      tabTarget: 'global.tests',
+    },
   },
 ];
 
@@ -146,13 +162,15 @@ export function HardwareTable({
     usePaginationState('hardwareListing');
 
   const getLinkProps = useCallback(
-    (row: Row<HardwareTableItem>): LinkProps => {
+    (row: Row<HardwareTableItem>, tabTarget?: string): LinkProps => {
       return {
         from: '/hardware',
         to: '/hardware/$hardwareId',
         params: { hardwareId: row.original.hardwareName },
+
         search: previousSearch => ({
           ...previousSearch,
+          currentPageTab: zPossibleTabValidator.parse(tabTarget),
           limitTimestampInSeconds,
         }),
       };
@@ -206,11 +224,14 @@ export function HardwareTable({
       modelRows.map(row => (
         <TableRow key={row.id}>
           {row.getVisibleCells().map(cell => {
+            const tabTarget = (
+              cell.column.columnDef.meta as ListingTableColumnMeta
+            ).tabTarget;
             return (
               <TableCellWithLink
                 key={cell.id}
                 linkClassName="w-full inline-block h-full"
-                linkProps={getLinkProps(row)}
+                linkProps={getLinkProps(row, tabTarget)}
               >
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
               </TableCellWithLink>

--- a/dashboard/src/types/table.ts
+++ b/dashboard/src/types/table.ts
@@ -1,0 +1,3 @@
+export type ListingTableColumnMeta = {
+  tabTarget?: string;
+};


### PR DESCRIPTION
- Adds the correct tab direction to the hardwareListingTable by passing a custom property in the column meta
- Refactors the treeListingTable to use the same logic as the hardwareListingTable for tab direction

The tab direction was made by using the `meta` property for the column definition, which doesn't have explicit typing so I need to typecast it to a custom type. If I extended the `Column` or `ColumnDef` types, they got lost in the abstraction of the cell (I can define `columns` as a `CustomColumn` type, but `cell.column` will still be the original `Column` type, so I can't retrieve the custom property)

Another way to do this, which is told by [the documentation](https://tanstack.com/table/v8/docs/api/core/column-def#meta), is to extend the entire module of tanstack-table to define a global meta type. This works but it will type the meta parameter to all tables, even those who don't need it, so I preferred to use the typecast in the tables I actually need it. The module extension would be something like this:
```typescript
declare module '@tanstack/react-table' {
  interface ColumnMeta<TData extends RowData, TValue> {
    tabTarget?: string;
  }
}
```


## How to test:
Go to the hardwareListing or treeListing page and enter a details page by clicking in different columns, the boot status and test status should direct you to the build tab and tests tab respectively, while the other columns should direct to the build tab

Closes #523 
