### PR TITLE
feat: Remove default values from URL

### DIFF
--- a/dashboard/src/pages/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetails.tsx
@@ -8,7 +8,10 @@ import {
   useRouterState,
 } from '@tanstack/react-router';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import {
+  zTableFilterInfoDefault,
+  type TestsTableFilter,
+} from '@/types/tree/TreeDetails';
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
 
 import { RedirectFrom } from '@/types/general';
@@ -40,8 +43,7 @@ const BuildDetailsPage = (): JSX.Element => {
           return {
             ...previousParams,
             tableFilter: {
-              bootsTable: previousParams.tableFilter.bootsTable,
-              buildsTable: previousParams.tableFilter.buildsTable,
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               testsTable: filter,
             },
           };
@@ -65,7 +67,7 @@ const BuildDetailsPage = (): JSX.Element => {
     <BuildDetails
       buildId={buildId}
       onClickFilter={onClickFilter}
-      tableFilter={searchParams.tableFilter}
+      tableFilter={searchParams.tableFilter ?? zTableFilterInfoDefault}
       getTestTableRowLink={getTestTableRowLink}
     />
   );

--- a/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
+++ b/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
@@ -20,7 +20,10 @@ import {
 } from '@/components/Breadcrumb/Breadcrumb';
 
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import {
+  zTableFilterInfoDefault,
+  type TestsTableFilter,
+} from '@/types/tree/TreeDetails';
 
 const HardwareBuildDetails = (): JSX.Element => {
   const searchParams = useSearch({ from: '/build/$buildId' });
@@ -50,8 +53,7 @@ const HardwareBuildDetails = (): JSX.Element => {
           return {
             ...previousParams,
             tableFilter: {
-              bootsTable: previousParams.tableFilter.bootsTable,
-              buildsTable: previousParams.tableFilter.buildsTable,
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               testsTable: filter,
             },
           };
@@ -92,7 +94,7 @@ const HardwareBuildDetails = (): JSX.Element => {
       buildId={buildId}
       breadcrumb={breadcrumbElement}
       onClickFilter={onClickFilter}
-      tableFilter={searchParams.tableFilter}
+      tableFilter={searchParams.tableFilter ?? zTableFilterInfoDefault}
       getTestTableRowLink={getTestTableRowLink}
     />
   );

--- a/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
+++ b/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
@@ -20,7 +20,10 @@ import {
 } from '@/components/Breadcrumb/Breadcrumb';
 
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import {
+  zTableFilterInfoDefault,
+  type TestsTableFilter,
+} from '@/types/tree/TreeDetails';
 
 const TreeBuildDetails = (): JSX.Element => {
   const searchParams = useSearch({ from: '/build/$buildId' });
@@ -48,8 +51,7 @@ const TreeBuildDetails = (): JSX.Element => {
           return {
             ...previousParams,
             tableFilter: {
-              bootsTable: previousParams.tableFilter.bootsTable,
-              buildsTable: previousParams.tableFilter.buildsTable,
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               testsTable: filter,
             },
           };
@@ -90,7 +92,7 @@ const TreeBuildDetails = (): JSX.Element => {
       buildId={buildId}
       breadcrumb={breadcrumbElement}
       onClickFilter={onClickFilter}
-      tableFilter={searchParams.tableFilter}
+      tableFilter={searchParams.tableFilter ?? zTableFilterInfoDefault}
       getTestTableRowLink={getTestTableRowLink}
     />
   );

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -12,7 +12,10 @@ import { Skeleton } from '@/components/Skeleton';
 import { BootsTable } from '@/components/BootsTable/BootsTable';
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import {
+  zTableFilterInfoDefault,
+  type TestsTableFilter,
+} from '@/types/tree/TreeDetails';
 import {
   DesktopGrid,
   MobileGrid,
@@ -34,16 +37,16 @@ interface BootsTabProps {
 
 const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
   const { treeId } = useParams({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
   const { tableFilter, diffFilter } = useSearch({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
   const currentPathFilter = diffFilter.bootPath
     ? Object.keys(diffFilter.bootPath)[0]
     : undefined;
 
-  const navigate = useNavigate({ from: '/tree/$treeId/' });
+  const navigate = useNavigate({ from: '/tree/$treeId' });
 
   const updatePathFilter = useCallback(
     (pathFilter: string) => {
@@ -67,7 +70,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
           return {
             ...previousParams,
             tableFilter: {
-              ...previousParams.tableFilter,
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               bootsTable: newFilter,
             },
           };

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -36,7 +36,7 @@ const BuildTab = ({ treeDetailsData }: BuildTab): JSX.Element => {
   });
 
   const { diffFilter } = useSearch({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
 
   const toggleFilterBySection = useCallback(

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -11,9 +11,10 @@ import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
 import { ItemType } from '@/components/ListingItem/ListingItem';
 import { TableHeader } from '@/components/Table/TableHeader';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
-import type {
-  AccordionItemBuilds,
-  BuildsTableFilter,
+import {
+  zTableFilterInfoDefault,
+  type AccordionItemBuilds,
+  type BuildsTableFilter,
 } from '@/types/tree/TreeDetails';
 
 export interface TTreeDetailsBuildsTable {
@@ -106,9 +107,9 @@ const columns: ColumnDef<AccordionItemBuilds>[] = [
 export function TreeDetailsBuildsTable({
   buildItems,
 }: TTreeDetailsBuildsTable): JSX.Element {
-  const { treeId } = useParams({ from: '/tree/$treeId/' });
-  const { tableFilter } = useSearch({ from: '/tree/$treeId/' });
-  const navigate = useNavigate({ from: '/tree/$treeId/' });
+  const { treeId } = useParams({ from: '/tree/$treeId' });
+  const { tableFilter } = useSearch({ from: '/tree/$treeId' });
+  const navigate = useNavigate({ from: '/tree/$treeId' });
 
   const navigateToBuildDetails = useCallback(
     (buildId: string) => {
@@ -128,9 +129,8 @@ export function TreeDetailsBuildsTable({
           return {
             ...previousParams,
             tableFilter: {
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               buildsTable: newFilter,
-              bootsTable: previousParams.tableFilter?.bootsTable ?? 'all',
-              testsTable: previousParams.tableFilter?.testsTable ?? 'all',
             },
           };
         },

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -10,7 +10,10 @@ import { Skeleton } from '@/components/Skeleton';
 import { useTreeDetails } from '@/api/treeDetails';
 import BaseCard from '@/components/Cards/BaseCard';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import {
+  zTableFilterInfoDefault,
+  type TestsTableFilter,
+} from '@/types/tree/TreeDetails';
 
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
@@ -35,14 +38,14 @@ interface TestsTabProps {
 }
 
 const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
-  const { treeId } = useParams({ from: '/tree/$treeId/' });
+  const { treeId } = useParams({ from: '/tree/$treeId' });
   const { isLoading, data, error } = useTreeDetails({
     treeId: treeId ?? '',
     filter: reqFilter,
   });
 
   const { tableFilter, diffFilter } = useSearch({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
   const currentPathFilter = diffFilter.testPath
     ? Object.keys(diffFilter.testPath)[0]
@@ -86,8 +89,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
           return {
             ...previousParams,
             tableFilter: {
-              bootsTable: previousParams.tableFilter.bootsTable,
-              buildsTable: previousParams.tableFilter.buildsTable,
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               testsTable: filter,
             },
           };

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
@@ -10,10 +10,10 @@ const TreeCommitNavigationGraph = (): React.ReactNode => {
     currentPageTab,
     diffFilter,
     treeInfo: { gitUrl, gitBranch, headCommitHash },
-  } = useSearch({ from: '/tree/$treeId/' });
+  } = useSearch({ from: '/tree/$treeId' });
 
   const { treeId } = useParams({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
 
   const navigate = useNavigate({

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -35,7 +35,7 @@ const TreeDetailsTab = ({
   countElements,
 }: ITreeDetailsTab): JSX.Element => {
   const { currentPageTab } = useSearch({
-    from: '/tree/$treeId/',
+    from: '/tree/$treeId',
   });
   const navigate = useNavigate({ from: '/tree/$treeId' });
   const treeDetailsTab: ITabItem[] = useMemo(

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -121,10 +121,10 @@ const TreeHeader = ({
 };
 
 function TreeDetails(): JSX.Element {
-  const { treeId } = useParams({ from: '/tree/$treeId/' });
-  const searchParams = useSearch({ from: '/tree/$treeId/' });
+  const { treeId } = useParams({ from: '/tree/$treeId' });
+  const searchParams = useSearch({ from: '/tree/$treeId' });
   const { diffFilter, treeInfo } = searchParams;
-  const navigate = useNavigate({ from: '/tree/$treeId/' });
+  const navigate = useNavigate({ from: '/tree/$treeId' });
 
   const reqFilter = mapFilterToReq(diffFilter);
 

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -136,7 +136,7 @@ const TreeDetailsFilter = ({
   paramFilter,
   treeUrl,
 }: ITreeDetailsFilter): JSX.Element => {
-  const { treeId } = useParams({ from: '/tree/$treeId/' });
+  const { treeId } = useParams({ from: '/tree/$treeId' });
 
   const { data, isLoading } = useTreeDetails({
     treeId,

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -158,7 +158,7 @@ const HardwareDetailsFilter = ({
   const isLoading = false;
 
   const navigate = useNavigate({
-    from: '/hardware/$hardwareId/',
+    from: '/hardware/$hardwareId',
   });
 
   const filter: TFilterCreate = useMemo(() => {

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -12,7 +12,10 @@ import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
 import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import {
+  zTableFilterInfoDefault,
+  type TestsTableFilter,
+} from '@/types/tree/TreeDetails';
 
 import {
   DesktopGrid,
@@ -76,7 +79,7 @@ const BootsTab = ({ boots, hardwareId, trees }: TBootsTab): JSX.Element => {
           return {
             ...previousParams,
             tableFilter: {
-              ...previousParams.tableFilter,
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               bootsTable: newFilter,
             },
           };

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -33,11 +33,11 @@ interface TBuildTab {
 
 const BuildTab = ({ builds, hardwareId, trees }: TBuildTab): JSX.Element => {
   const navigate = useNavigate({
-    from: '/hardware/$hardwareId/',
+    from: '/hardware/$hardwareId',
   });
 
   const { diffFilter } = useSearch({
-    from: '/hardware/$hardwareId/',
+    from: '/hardware/$hardwareId',
   });
 
   const toggleFilterBySection = useCallback(

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -12,9 +12,10 @@ import { ItemType } from '@/components/ListingItem/ListingItem';
 import { TableHeader } from '@/components/Table/TableHeader';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 
-import type {
-  AccordionItemBuilds,
-  BuildsTableFilter,
+import {
+  zTableFilterInfoDefault,
+  type AccordionItemBuilds,
+  type BuildsTableFilter,
 } from '@/types/tree/TreeDetails';
 
 export interface THardwareDetailsBuildsTable {
@@ -117,7 +118,7 @@ export function HardwareDetailsBuildsTable({
 }: THardwareDetailsBuildsTable): JSX.Element {
   const { tableFilter } = useSearch({ from: '/hardware/$hardwareId' });
 
-  const navigate = useNavigate({ from: '/hardware/$hardwareId/' });
+  const navigate = useNavigate({ from: '/hardware/$hardwareId' });
 
   const navigateToBuildDetails = useCallback(
     (buildId: string) => {
@@ -137,9 +138,8 @@ export function HardwareDetailsBuildsTable({
           return {
             ...previousParams,
             tableFilter: {
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               buildsTable: filter,
-              bootsTable: previousParams.tableFilter?.bootsTable ?? 'all',
-              testsTable: previousParams.tableFilter?.testsTable ?? 'all',
             },
           };
         },

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
@@ -18,7 +18,7 @@ const HardwareCommitNavigationGraph = ({
       from: '/hardware/$hardwareId',
     });
 
-  const navigate = useNavigate({ from: '/hardware/$hardwareId/' });
+  const navigate = useNavigate({ from: '/hardware/$hardwareId' });
 
   const diffFilterWithHardware = useMemo(
     () => ({ ...diffFilter, hardware: { [hardwareId]: true } }),

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -33,7 +33,7 @@ const HardwareDetailsTabs = ({
   countElements,
 }: IHardwareDetailsTab): JSX.Element => {
   const { currentPageTab } = useSearch({
-    from: '/hardware/$hardwareId/',
+    from: '/hardware/$hardwareId',
   });
 
   const navigate = useNavigate({ from: '/hardware/$hardwareId' });

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -8,7 +8,10 @@ import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
 import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
+import {
+  zTableFilterInfoDefault,
+  type TestsTableFilter,
+} from '@/types/tree/TreeDetails';
 
 import {
   DesktopGrid,
@@ -61,7 +64,7 @@ const TestsTab = ({ tests, trees, hardwareId }: TTestsTab): JSX.Element => {
           return {
             ...previousParams,
             tableFilter: {
-              ...previousParams.tableFilter,
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
               testsTable: newFilter,
             },
           };

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -1,4 +1,8 @@
-import { createRootRoute, Outlet } from '@tanstack/react-router';
+import {
+  createRootRoute,
+  Outlet,
+  stripSearchParams,
+} from '@tanstack/react-router';
 
 import { z } from 'zod';
 
@@ -9,7 +13,11 @@ import { z } from 'zod';
 import SideMenu from '@/components/SideMenu/SideMenu';
 import TopBar from '@/components/TopBar/TopBar';
 
-import { zOrigin } from '@/types/general';
+import { DEFAULT_ORIGIN, zOrigin } from '@/types/general';
+
+const defaultValues = {
+  origin: DEFAULT_ORIGIN,
+};
 
 const RouteSchema = z.object({
   origin: zOrigin,
@@ -17,6 +25,7 @@ const RouteSchema = z.object({
 
 export const Route = createRootRoute({
   validateSearch: RouteSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
   component: () => (
     <>
       <div className="h-full w-full">

--- a/dashboard/src/routes/build/$buildId/route.tsx
+++ b/dashboard/src/routes/build/$buildId/route.tsx
@@ -1,8 +1,26 @@
 import { z } from 'zod';
 
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
-import { zTableFilterInfoValidator } from '@/types/tree/TreeDetails';
+import {
+  defaultValidadorValues,
+  zTableFilterInfoDefault,
+  zTableFilterInfoValidator,
+} from '@/types/tree/TreeDetails';
+import { DEFAULT_DIFF_FILTER, DEFAULT_ORIGIN } from '@/types/general';
+import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
+
+const defaultValues = {
+  origin: DEFAULT_ORIGIN,
+  tableFilter: zTableFilterInfoDefault,
+  diffFilter: DEFAULT_DIFF_FILTER,
+  currentPageTab: defaultValidadorValues.tab,
+  intervalInDays: DEFAULT_TIME_SEARCH,
+  treeSearch: '',
+  hardwareSearch: '',
+  treeIndexes: [],
+  treeCommits: {},
+};
 
 const buildDetailsSearchSchema = z.object({
   tableFilter: zTableFilterInfoValidator,
@@ -10,4 +28,5 @@ const buildDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/build/$buildId')({
   validateSearch: buildDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/route.tsx
@@ -1,18 +1,27 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
 import {
+  defaultValidadorValues,
   zPossibleTabValidator,
+  zTableFilterInfoDefault,
   zTableFilterInfoValidator,
 } from '@/types/tree/TreeDetails';
 
 import { zTreeCommits } from '@/types/hardware/hardwareDetails';
-import { zDiffFilter } from '@/types/general';
+import { DEFAULT_DIFF_FILTER, zDiffFilter } from '@/types/general';
 
+const defaultValues = {
+  currentPageTab: defaultValidadorValues.tab,
+  treeIndexes: [],
+  treeCommits: {},
+  tableFilter: zTableFilterInfoDefault,
+  diffFilter: DEFAULT_DIFF_FILTER,
+};
 const hardwareDetailsSearchSchema = z.object({
   currentPageTab: zPossibleTabValidator,
-  treeIndexes: z.array(z.number().int()).optional(),
+  treeIndexes: z.array(z.number().int()).default([]),
   treeCommits: zTreeCommits,
   tableFilter: zTableFilterInfoValidator,
   startTimestampInSeconds: z.number(),
@@ -22,4 +31,5 @@ const hardwareDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/hardware/$hardwareId')({
   validateSearch: hardwareDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/hardware/route.tsx
+++ b/dashboard/src/routes/hardware/route.tsx
@@ -1,14 +1,20 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { makeZIntervalInDays } from '@/types/general';
 import { DEFAULT_HARDWARE_INTERVAL_IN_DAYS } from '@/utils/constants/hardware';
 
+const defaultValues = {
+  intervalInDays: DEFAULT_HARDWARE_INTERVAL_IN_DAYS,
+  hardwareSearch: '',
+};
+
 const zHardwareSchema = z.object({
   intervalInDays: makeZIntervalInDays(DEFAULT_HARDWARE_INTERVAL_IN_DAYS),
-  hardwareSearch: z.string().optional().catch(undefined),
+  hardwareSearch: z.string().catch(''),
 });
 
 export const Route = createFileRoute('/hardware')({
   validateSearch: zHardwareSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
 import { makeZIntervalInDays } from '@/types/general';
 
 export const HomeSearchSchema = z.object({
-  treeSearch: z.string().optional().catch(undefined),
+  treeSearch: z.string().catch(''),
   intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
 });
 

--- a/dashboard/src/routes/test/$testId/route.tsx
+++ b/dashboard/src/routes/test/$testId/route.tsx
@@ -1,3 +1,29 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
-export const Route = createFileRoute('/test/$testId')();
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
+
+import {
+  defaultValidadorValues,
+  zTableFilterInfoDefault,
+} from '@/types/tree/TreeDetails';
+import { DEFAULT_DIFF_FILTER, DEFAULT_ORIGIN } from '@/types/general';
+import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
+
+const defaultValues = {
+  origin: DEFAULT_ORIGIN,
+  tableFilter: zTableFilterInfoDefault,
+  diffFilter: DEFAULT_DIFF_FILTER,
+  currentPageTab: defaultValidadorValues.tab,
+  intervalInDays: DEFAULT_TIME_SEARCH,
+  treeSearch: '',
+  hardwareSearch: '',
+  treeIndexes: [],
+  treeCommits: {},
+};
+
+const testDetailsSearchSchema = z.object({});
+
+export const Route = createFileRoute('/test/$testId')({
+  validateSearch: testDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
+});

--- a/dashboard/src/routes/tree/$treeId/build/$buildId/index.tsx
+++ b/dashboard/src/routes/tree/$treeId/build/$buildId/index.tsx
@@ -1,16 +1,8 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 
-import { z } from 'zod';
-
-import { zTableFilterInfoValidator } from '@/types/tree/TreeDetails';
 import { RedirectFrom } from '@/types/general';
 
-const buildDetailsSearchSchema = z.object({
-  tableFilter: zTableFilterInfoValidator,
-});
-
 export const Route = createFileRoute('/tree/$treeId/build/$buildId/')({
-  validateSearch: buildDetailsSearchSchema,
   loaderDeps: ({ search }) => ({ search }),
   loader: async ({ params, deps }) => {
     throw redirect({

--- a/dashboard/src/routes/tree/$treeId/route.tsx
+++ b/dashboard/src/routes/tree/$treeId/route.tsx
@@ -1,18 +1,33 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
-import { zDiffFilter, zOrigin } from '@/types/general';
+import {
+  DEFAULT_DIFF_FILTER,
+  DEFAULT_ORIGIN,
+  zDiffFilter,
+  zOrigin,
+} from '@/types/general';
 
 import {
+  DEFAULT_TREE_INFO,
+  defaultValidadorValues,
   zPossibleTabValidator,
+  zTableFilterInfoDefault,
   zTableFilterInfoValidator,
   zTreeInformation,
 } from '@/types/tree/TreeDetails';
 
+const defaultValues = {
+  diffFilter: DEFAULT_DIFF_FILTER,
+  origin: DEFAULT_ORIGIN,
+  treeInfo: DEFAULT_TREE_INFO,
+  currentPageTab: defaultValidadorValues.tab,
+  tableFilter: zTableFilterInfoDefault,
+};
+
 const treeDetailsSearchSchema = z.object({
   diffFilter: zDiffFilter,
-  testPath: z.string().optional().catch(''),
   origin: zOrigin,
   treeInfo: zTreeInformation,
   currentPageTab: zPossibleTabValidator,
@@ -21,4 +36,5 @@ const treeDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/tree/$treeId')({
   validateSearch: treeDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/routes/tree/index.tsx
+++ b/dashboard/src/routes/tree/index.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import Trees from '@/pages/Trees';
 
 export const TreeSearchSchema = z.object({
-  treeSearch: z.string().optional().catch(undefined),
+  treeSearch: z.string().catch(''),
 });
 
 export const Route = createFileRoute('/tree/')({

--- a/dashboard/src/routes/tree/route.tsx
+++ b/dashboard/src/routes/tree/route.tsx
@@ -1,14 +1,21 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
 import { makeZIntervalInDays } from '@/types/general';
 import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
 
+const defaultValues = {
+  intervalInDays: DEFAULT_TIME_SEARCH,
+  treeSearch: '',
+};
+
 export const RootSearchSchema = z.object({
   intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+  treeSearch: z.string().catch(''),
 });
 
 export const Route = createFileRoute('/tree')({
   validateSearch: RootSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
 });

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -117,12 +117,14 @@ const origins = [
   'syzbot',
   'tuxsuite',
 ] as const;
-const DEFAULT_ORIGIN = 'maestro';
+export const DEFAULT_ORIGIN = 'maestro';
 
 export type TOrigins = (typeof origins)[number];
 
 export const zOriginEnum = z.enum(origins);
-export const zOrigin = zOriginEnum.catch(DEFAULT_ORIGIN);
+export const zOrigin = zOriginEnum
+  .default(DEFAULT_ORIGIN)
+  .catch(DEFAULT_ORIGIN);
 
 const zFilterBoolValue = z.record(z.boolean()).optional();
 const zFilterNumberValue = z.number().optional();
@@ -156,6 +158,7 @@ export type TFilterKeys =
   | z.infer<typeof zFilterObjectsKeys>
   | z.infer<typeof zFilterNumberKeys>;
 
+export const DEFAULT_DIFF_FILTER = {};
 export const zDiffFilter = z
   .union([
     z.object({
@@ -181,7 +184,8 @@ export const zDiffFilter = z
     } satisfies Record<TFilterKeys, unknown>),
     z.record(z.never()),
   ])
-  .catch({});
+  .default(DEFAULT_DIFF_FILTER)
+  .catch(DEFAULT_DIFF_FILTER);
 
 export type TFilterObjectsKeys = z.infer<typeof zFilterObjectsKeys>;
 export type TFilter = z.infer<typeof zDiffFilter>;

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -78,5 +78,5 @@ export interface THardwareDetailsFilter
   valid?: string[];
 }
 
-export const zTreeCommits = z.record(z.string()).optional();
+export const zTreeCommits = z.record(z.string()).default({});
 export type TTreeCommits = z.infer<typeof zTreeCommits>;

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -96,10 +96,6 @@ export type TTreeTestsFullData = {
 
 const possibleTabs = ['global.builds', 'global.boots', 'global.tests'] as const;
 
-export const zPossibleTabValidator = z
-  .enum(possibleTabs)
-  .catch('global.builds');
-
 export const possibleBuildsTableFilter = [
   'invalid',
   'valid',
@@ -114,12 +110,28 @@ export const possibleTestsTableFilter = [
   'inconclusive',
 ] as const;
 
+export const defaultValidadorValues: {
+  tab: (typeof possibleTabs)[number];
+  buildsTableFilter: (typeof possibleBuildsTableFilter)[number];
+  testsTableFilter: (typeof possibleTestsTableFilter)[number];
+} = {
+  tab: 'global.builds',
+  buildsTableFilter: 'all',
+  testsTableFilter: 'all',
+};
+
+export const zPossibleTabValidator = z
+  .enum(possibleTabs)
+  .default(defaultValidadorValues.tab)
+  .catch(defaultValidadorValues.tab);
+
 export const zBuildsTableFilterValidator = z
   .enum(possibleBuildsTableFilter)
-  .catch('all');
+  .catch(defaultValidadorValues.buildsTableFilter);
+
 export const zTestsTableFilterValidator = z
   .enum(possibleTestsTableFilter)
-  .catch('all');
+  .catch(defaultValidadorValues.testsTableFilter);
 
 export type BuildsTableFilter = z.infer<typeof zBuildsTableFilterValidator>;
 export type TestsTableFilter = z.infer<typeof zTestsTableFilterValidator>;
@@ -130,14 +142,19 @@ export const zTableFilterInfo = object({
   testsTable: zTestsTableFilterValidator,
 });
 
-export const zTableFilterInfoValidator = zTableFilterInfo.catch({
+export const zTableFilterInfoDefault = {
   buildsTable: zBuildsTableFilterValidator.parse(''),
   bootsTable: zTestsTableFilterValidator.parse(''),
   testsTable: zTestsTableFilterValidator.parse(''),
-});
+};
+
+export const zTableFilterInfoValidator = zTableFilterInfo
+  .default(zTableFilterInfoDefault)
+  .catch(zTableFilterInfoDefault);
 
 export type TableFilter = z.infer<typeof zTableFilterInfo>;
 
+export const DEFAULT_TREE_INFO = {};
 export const zTreeInformation = z
   .object({
     gitBranch: z.string().optional().catch(''),
@@ -146,7 +163,8 @@ export const zTreeInformation = z
     commitName: z.string().optional().catch(''),
     headCommitHash: z.string().optional().catch(undefined),
   })
-  .catch({});
+  .default(DEFAULT_TREE_INFO)
+  .catch(DEFAULT_TREE_INFO);
 
 export type TestByCommitHash = {
   id: string;


### PR DESCRIPTION
- Added the search middleware `stripSearchParams` to remove search params with default values from the URL
- Changed `from` options to use route instead of index e.g from `/tree/$treeId/` to `/tree/$treeId`
- Added some default clauses to zod types to make the default values of search params be returned when they are stripped from the URL. Without this clause the returned value would be undefined

Closes #656 

Solved the bug that caused the revert where trying to use the table filter inside a build detail would cause a error message. Also solved a bug where trying to change the table filter from 'all' to any other after expanding a row in the tests table would cause the filter to not change.