### PR TITLE
feat: Change query params serialization

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -50,6 +50,7 @@
     "date-fns": "^4.0.0",
     "eslint-import-resolver-typescript": "^3.6.3",
     "lucide-react": "^0.396.0",
+    "query-string": "^9.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.0.13",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test": "vitest",
+    "coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "lint-staged": "eslint --max-warnings=0 --ext .ts,.tsx,.js,.jsx src",
@@ -97,6 +99,7 @@
     "prettier-plugin-tailwindcss": "^0.6.6",
     "storybook": "^8.3.0",
     "tailwindcss": "^3.4.11",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "vitest": "^2.1.8"
   }
 }

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.8(@types/node@20.16.5)(terser@5.32.0)
 
 packages:
 
@@ -2243,20 +2246,49 @@ packages:
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
+  '@vitest/expect@2.1.8':
+    resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
+
+  '@vitest/mocker@2.1.8':
+    resolution: {integrity: sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.0.5':
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
   '@vitest/pretty-format@2.1.1':
     resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
 
+  '@vitest/pretty-format@2.1.8':
+    resolution: {integrity: sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==}
+
+  '@vitest/runner@2.1.8':
+    resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
+
+  '@vitest/snapshot@2.1.8':
+    resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
+
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+
+  '@vitest/spy@2.1.8':
+    resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
   '@vitest/utils@2.1.1':
     resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
+
+  '@vitest/utils@2.1.8':
+    resolution: {integrity: sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==}
 
   '@webassemblyjs/ast@1.12.1':
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
@@ -2505,6 +2537,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
     engines: {node: '>= 0.4'}
@@ -2525,6 +2561,10 @@ packages:
 
   chai@5.1.1:
     resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+    engines: {node: '>=12'}
+
+  chai@5.1.2:
+    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
     engines: {node: '>=12'}
 
   chalk@2.4.2:
@@ -3093,6 +3133,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
+
   express@4.21.0:
     resolution: {integrity: sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==}
     engines: {node: '>= 0.10.0'}
@@ -3638,6 +3682,9 @@ packages:
   loupe@3.1.1:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
 
+  loupe@3.1.2:
+    resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3659,6 +3706,9 @@ packages:
 
   magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -3880,6 +3930,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -4330,6 +4383,9 @@ packages:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4360,9 +4416,15 @@ packages:
     resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
     engines: {node: '>=12'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
   storybook@8.3.0:
     resolution: {integrity: sha512-XKU+nem9OKX/juvJPwka1Q7DTpSbOe0IMp8ZyLQWorhFKpquJdUjryl7Z9GiFZyyTykCqH4ItQ7h8PaOmqVMOw==}
@@ -4506,6 +4568,16 @@ packages:
 
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
@@ -4706,6 +4778,11 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
 
+  vite-node@2.1.8:
+    resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-tsconfig-paths@5.0.1:
     resolution: {integrity: sha512-yqwv+LstU7NwPeNqajZzLEBVpUFU6Dugtb2P84FXuvaoYA+/70l9MHE+GYfYAycVyPSDYZ7mjOFuYBRqlEpTig==}
     peerDependencies:
@@ -4743,6 +4820,31 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vitest@2.1.8:
+    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.8
+      '@vitest/ui': 2.1.8
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   watchpack@2.4.2:
@@ -4784,6 +4886,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -7007,6 +7114,21 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@2.1.8':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.8(vite@5.4.6(@types/node@20.16.5)(terser@5.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.6(@types/node@20.16.5)(terser@5.32.0)
+
   '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
@@ -7015,7 +7137,26 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/pretty-format@2.1.8':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.8':
+    dependencies:
+      '@vitest/utils': 2.1.8
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.8':
+    dependencies:
+      '@vitest/pretty-format': 2.1.8
+      magic-string: 0.30.17
+      pathe: 1.1.2
+
   '@vitest/spy@2.0.5':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/spy@2.1.8':
     dependencies:
       tinyspy: 3.0.2
 
@@ -7030,6 +7171,12 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 2.1.1
       loupe: 3.1.1
+      tinyrainbow: 1.2.0
+
+  '@vitest/utils@2.1.8':
+    dependencies:
+      '@vitest/pretty-format': 2.1.8
+      loupe: 3.1.2
       tinyrainbow: 1.2.0
 
   '@webassemblyjs/ast@1.12.1':
@@ -7351,6 +7498,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind@1.0.7:
     dependencies:
       es-define-property: 1.0.0
@@ -7368,6 +7517,14 @@ snapshots:
   caniuse-lite@1.0.30001660: {}
 
   chai@5.1.1:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.1
+      pathval: 2.0.0
+
+  chai@5.1.2:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -8051,6 +8208,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  expect-type@1.1.0: {}
+
   express@4.21.0:
     dependencies:
       accepts: 1.3.8
@@ -8607,6 +8766,8 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
+  loupe@3.1.2: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -8624,6 +8785,10 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.10:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -8814,6 +8979,8 @@ snapshots:
   path-to-regexp@0.1.10: {}
 
   path-type@4.0.0: {}
+
+  pathe@1.1.2: {}
 
   pathval@2.0.0: {}
 
@@ -9268,6 +9435,8 @@ snapshots:
       get-intrinsic: 1.2.4
       object-inspect: 1.13.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
@@ -9287,7 +9456,11 @@ snapshots:
 
   split-on-first@3.0.0: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.1: {}
+
+  std-env@3.8.0: {}
 
   storybook@8.3.0:
     dependencies:
@@ -9471,6 +9644,12 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tiny-warning@1.0.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.1: {}
+
+  tinypool@1.0.2: {}
 
   tinyrainbow@1.2.0: {}
 
@@ -9671,6 +9850,24 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  vite-node@2.1.8(@types/node@20.16.5)(terser@5.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.7
+      es-module-lexer: 1.5.4
+      pathe: 1.1.2
+      vite: 5.4.6(@types/node@20.16.5)(terser@5.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-tsconfig-paths@5.0.1(typescript@5.6.2)(vite@5.4.6(@types/node@20.16.5)(terser@5.32.0)):
     dependencies:
       debug: 4.3.5
@@ -9691,6 +9888,41 @@ snapshots:
       '@types/node': 20.16.5
       fsevents: 2.3.3
       terser: 5.32.0
+
+  vitest@2.1.8(@types/node@20.16.5)(terser@5.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.8
+      '@vitest/mocker': 2.1.8(vite@5.4.6(@types/node@20.16.5)(terser@5.32.0))
+      '@vitest/pretty-format': 2.1.8
+      '@vitest/runner': 2.1.8
+      '@vitest/snapshot': 2.1.8
+      '@vitest/spy': 2.1.8
+      '@vitest/utils': 2.1.8
+      chai: 5.1.2
+      debug: 4.3.7
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 5.4.6(@types/node@20.16.5)(terser@5.32.0)
+      vite-node: 2.1.8(@types/node@20.16.5)(terser@5.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.16.5
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   watchpack@2.4.2:
     dependencies:
@@ -9773,6 +10005,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       lucide-react:
         specifier: ^0.396.0
         version: 0.396.0(react@18.3.1)
+      query-string:
+        specifier: ^9.1.1
+        version: 9.1.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2733,6 +2736,10 @@ packages:
       supports-color:
         optional: true
 
+  decode-uri-component@0.4.1:
+    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+    engines: {node: '>=14.16'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -3120,6 +3127,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  filter-obj@5.1.0:
+    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
+    engines: {node: '>=14.16'}
 
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
@@ -4044,6 +4055,10 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
+  query-string@9.1.1:
+    resolution: {integrity: sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==}
+    engines: {node: '>=18'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -4340,6 +4355,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  split-on-first@3.0.0:
+    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
+    engines: {node: '>=12'}
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
@@ -7532,6 +7551,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-uri-component@0.4.1: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -7811,7 +7832,7 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.30.0)(webpack@5.92.1(esbuild@0.23.1)))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-bun-module: 1.2.1
@@ -7841,7 +7862,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.30.0)(webpack@5.92.1(esbuild@0.23.1)))(eslint@8.57.0):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7853,7 +7874,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.30.0)(webpack@5.92.1(esbuild@0.23.1)))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7875,7 +7896,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.30.0)(eslint@8.57.0))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.30.0)(webpack@5.92.1(esbuild@0.23.1)))(eslint@8.57.0)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@8.12.2(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -8095,6 +8116,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  filter-obj@5.1.0: {}
 
   finalhandler@1.3.1:
     dependencies:
@@ -8892,6 +8915,12 @@ snapshots:
     dependencies:
       side-channel: 1.0.6
 
+  query-string@9.1.1:
+    dependencies:
+      decode-uri-component: 0.4.1
+      filter-obj: 5.1.0
+      split-on-first: 3.0.0
+
   queue-microtask@1.2.3: {}
 
   randombytes@2.1.0:
@@ -9255,6 +9284,8 @@ snapshots:
   source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  split-on-first@3.0.0: {}
 
   statuses@2.0.1: {}
 

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -21,6 +21,7 @@ import './index.css';
 import { isDev } from './lib/utils/vite';
 import { ToastProvider } from './components/ui/toast';
 import type { RedirectFrom } from './types/general';
+import { parseSearch, stringifySearch } from './utils/search';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -57,7 +58,11 @@ const persister = createSyncStoragePersister({
 
 const currentMessages = messages[LOCALES.EN_US];
 
-const router = createRouter({ routeTree });
+const router = createRouter({
+  routeTree: routeTree,
+  parseSearch: parseSearch,
+  stringifySearch: stringifySearch,
+});
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/dashboard/src/utils/search.test.ts
+++ b/dashboard/src/utils/search.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, assert } from 'vitest';
+
+import { stringifySearchWith } from '@tanstack/react-router';
+
+import {
+  flattenObject,
+  unflattenObject,
+  parseSearch,
+  stringifySearch,
+  isEncodedJSONArrayParam,
+} from './search';
+
+const KEY_FLAT_CHAR = '|';
+
+const simpleObject = {
+  origin: 'maestro',
+  intervalInDays: 7,
+  // eslint-disable-next-line no-magic-numbers
+  treeIndexes: [1, 2, 3],
+};
+
+const simpleObjectStringify =
+  '?origin=maestro&intervalInDays=7&treeIndexes[]=1,2,3';
+
+const nestedObject = {
+  origin: 'maestro',
+  intervalInDays: 7,
+  tableFilter: {
+    bootsTable: 'all',
+    buildsTable: 'failed',
+    testsTable: 'all',
+  },
+  treeInfo: {
+    treeName: 'android',
+    gitCommitHash: 'hash',
+  },
+  diffFilter: {
+    configs: { defconfig: true },
+    archs: { arm: true },
+    testPath: 'amlogic',
+  },
+  treeIndexes: [0, 1, 2],
+};
+
+const flatObject = {
+  origin: 'maestro',
+  intervalInDays: 7,
+  'tableFilter|bootsTable': 'all',
+  'tableFilter|buildsTable': 'failed',
+  'tableFilter|testsTable': 'all',
+  'treeInfo|treeName': 'android',
+  'treeInfo|gitCommitHash': 'hash',
+  'diffFilter|configs|defconfig': true,
+  'diffFilter|archs|arm': true,
+  'diffFilter|testPath': 'amlogic',
+  treeIndexes: [0, 1, 2],
+};
+
+const nestedObjectStringify =
+  '?origin=maestro&intervalInDays=7' +
+  '&tableFilter|bootsTable=all&tableFilter|buildsTable=failed&tableFilter|testsTable=all' +
+  '&treeInfo|treeName=android&treeInfo|gitCommitHash=hash' +
+  '&diffFilter|configs|defconfig=true&diffFilter|archs|arm=true&diffFilter|testPath=amlogic' +
+  '&treeIndexes[]=0,1,2';
+
+describe('isEncodedArrayParam', () => {
+  const emptyJSONArrayStr = 'treeIndexes=[]';
+  const emptyQSArrayStr = 'treeIndexes[]';
+  const filledJSONArrayStr = 'treeIndexes=[1,2,3]';
+  const filledQSArrayStr = 'treeIndexes[]=1,2,3';
+
+  it('JSON empty array', () => {
+    expect(isEncodedJSONArrayParam(emptyJSONArrayStr)).toBe(true);
+  });
+
+  it('JSON empty array - URI encoded', () => {
+    expect(isEncodedJSONArrayParam(encodeURI(emptyJSONArrayStr))).toBe(true);
+  });
+
+  it('query-string empty array', () => {
+    expect(isEncodedJSONArrayParam(emptyQSArrayStr)).toBe(false);
+  });
+
+  it('query-string empty array - URI encoded', () => {
+    expect(isEncodedJSONArrayParam(encodeURI(emptyQSArrayStr))).toBe(false);
+  });
+
+  it('JSON filled array', () => {
+    expect(isEncodedJSONArrayParam(filledJSONArrayStr)).toBe(true);
+  });
+
+  it('JSON filled array - URI encoded', () => {
+    expect(isEncodedJSONArrayParam(encodeURI(filledJSONArrayStr))).toBe(true);
+  });
+
+  it('JSON filled array - partially URI encoded', () => {
+    const customEncodedStr = filledJSONArrayStr.replace(/,/g, '%2C');
+    expect(isEncodedJSONArrayParam(customEncodedStr)).toBe(true);
+  });
+
+  it('query-string filled array', () => {
+    expect(isEncodedJSONArrayParam(filledQSArrayStr)).toBe(false);
+  });
+
+  it('query-string filled array - URI encoded', () => {
+    expect(isEncodedJSONArrayParam(encodeURI(filledQSArrayStr))).toBe(false);
+  });
+});
+
+describe('flattenObject', () => {
+  it('Simple object with filled array', () => {
+    expect(flattenObject(simpleObject, KEY_FLAT_CHAR)).toStrictEqual(
+      simpleObject,
+    );
+  });
+
+  it('Simple object with empty array', () => {
+    const simpleObjectEmptyArray = { ...simpleObject, treeIndexes: [] };
+    expect(flattenObject(simpleObjectEmptyArray, KEY_FLAT_CHAR)).toStrictEqual(
+      simpleObjectEmptyArray,
+    );
+  });
+
+  it('Nested object', () => {
+    expect(flattenObject(nestedObject, KEY_FLAT_CHAR)).toStrictEqual(
+      flatObject,
+    );
+  });
+});
+
+describe('unflattenObject', () => {
+  it('Simple object with filled array', () => {
+    expect(unflattenObject(simpleObject, KEY_FLAT_CHAR)).toStrictEqual(
+      simpleObject,
+    );
+  });
+
+  it('Simple object with empty array', () => {
+    const simpleObjectEmptyArray = { ...simpleObject, treeIndexes: [] };
+    expect(
+      unflattenObject(simpleObjectEmptyArray, KEY_FLAT_CHAR),
+    ).toStrictEqual(simpleObjectEmptyArray);
+  });
+
+  it('Nested object', () => {
+    expect(unflattenObject(flatObject, KEY_FLAT_CHAR)).toStrictEqual(
+      nestedObject,
+    );
+  });
+});
+
+describe('parseSearch', () => {
+  it('Simple object with filled array', () => {
+    expect(parseSearch(simpleObjectStringify)).toStrictEqual(simpleObject);
+  });
+
+  it('Simple object with empty array', () => {
+    const simpleObjectEmptyArray = { ...simpleObject, treeIndexes: [] };
+    const simpleObjectEmptyArrayStringify =
+      '?origin=maestro&intervalInDays=7&treeIndexes[]';
+    expect(parseSearch(simpleObjectEmptyArrayStringify)).toStrictEqual(
+      simpleObjectEmptyArray,
+    );
+  });
+
+  it('Nested object', () => {
+    expect(parseSearch(nestedObjectStringify)).toStrictEqual(nestedObject);
+  });
+
+  it('Simple object with filled array - URI encoded', () => {
+    expect(parseSearch(encodeURI(simpleObjectStringify))).toStrictEqual(
+      simpleObject,
+    );
+  });
+
+  it('Nested object - URI encoded', () => {
+    expect(parseSearch(encodeURI(nestedObjectStringify))).toStrictEqual(
+      nestedObject,
+    );
+  });
+
+  it('JSON stringified simple object with filled array', () => {
+    const JSONSimpleObjectStringify = stringifySearchWith(JSON.stringify)(
+      simpleObject,
+    );
+    expect(parseSearch(JSONSimpleObjectStringify)).toStrictEqual(simpleObject);
+  });
+
+  it('JSON stringified simple object with empty array', () => {
+    const simpleObjectEmptyArray = { ...simpleObject, treeIndexes: [] };
+    const JSONSimpleObjectStringify = stringifySearchWith(JSON.stringify)(
+      simpleObjectEmptyArray,
+    );
+    expect(parseSearch(JSONSimpleObjectStringify)).toStrictEqual(
+      simpleObjectEmptyArray,
+    );
+  });
+
+  it('JSON stringified simple object - not URI encoded', () => {
+    const JSONSimpleObjectStringify = stringifySearchWith(JSON.stringify)(
+      simpleObject,
+    );
+    const decodeStr = JSONSimpleObjectStringify.replace(/%5B/g, '[').replace(
+      /%5D/g,
+      ']',
+    );
+    expect(parseSearch(decodeStr)).toStrictEqual(simpleObject);
+  });
+
+  it('JSON stringified nested object', () => {
+    const JSONNestedObjectStringify = stringifySearchWith(JSON.stringify)(
+      nestedObject,
+    );
+    expect(parseSearch(JSONNestedObjectStringify)).toStrictEqual(nestedObject);
+  });
+});
+
+describe('stringifySearch', () => {
+  const assertSearchParams = (
+    result: string,
+    expected: Record<string, unknown>,
+  ): void => {
+    assert(result.includes('?'));
+    for (const [key, value] of Object.entries(expected)) {
+      if (Array.isArray(value)) {
+        const arrayKeyStr = `${encodeURIComponent(key)}[]`;
+        const arrayValueStr = `${value.length !== 0 ? '=' + value.join(',') : ''}`;
+        assert(result.includes(`${arrayKeyStr}${arrayValueStr}`));
+      } else {
+        const valueStr = `${encodeURIComponent(key)}=${value}`;
+        assert(result.includes(valueStr));
+      }
+    }
+  };
+
+  it('Simple object with filled array', () => {
+    const result = stringifySearch(simpleObject);
+    assertSearchParams(result, simpleObject);
+  });
+
+  it('Simple object with empty array', () => {
+    const simpleObjectEmptyArray = { ...simpleObject, treeIndexes: [] };
+    const result = stringifySearch(simpleObjectEmptyArray);
+    assertSearchParams(result, simpleObjectEmptyArray);
+  });
+
+  it('Nested object', () => {
+    const result = stringifySearch(nestedObject);
+    assertSearchParams(result, flatObject);
+  });
+});

--- a/dashboard/src/utils/search.ts
+++ b/dashboard/src/utils/search.ts
@@ -72,7 +72,7 @@ const isStringRecord = (obj: unknown): obj is Record<string, unknown> => {
   );
 };
 
-const flattenObject = (
+export const flattenObject = (
   obj: Record<string, unknown>,
   keySplitChar: string,
   parent = '',
@@ -97,7 +97,7 @@ const flattenObject = (
   return result;
 };
 
-const unflattenObject = (
+export const unflattenObject = (
   obj: qs.ParsedQuery<string | number | boolean>,
   keySplitChar: string,
 ): Record<string, unknown> => {

--- a/dashboard/src/utils/search.ts
+++ b/dashboard/src/utils/search.ts
@@ -1,0 +1,124 @@
+import qs from 'query-string';
+
+import { type AnySchema, parseSearchWith } from '@tanstack/react-router';
+
+// Must be a character not used in any other query parameters (e.g. '.' or '_' wouldn't work)
+const KEY_FLAT_CHAR = '|';
+const ARRAY_SEPARATOR = ',';
+
+export const isEncodedJSONArrayParam = (str: string): boolean => {
+  // Regex responsible to match URI encoded (or not) array of numbers
+  // in the query parameters when they where JSON stringified and not
+  // query-string stringified.
+  const encodedArrayRegex =
+    /=(%5B|\[)\d+(?:(%2C|,)\d+)*(%5D|\])|=(%5B|\[)(%5D|\])/;
+  return encodedArrayRegex.test(str);
+};
+
+export const parseSearch = (searchStr: string): AnySchema => {
+  const JSONChar = '{';
+  const encodeJSONChar = encodeURI(JSONChar);
+  const encodeKeyFlatChar = encodeURI(KEY_FLAT_CHAR);
+
+  if (
+    ((!searchStr.includes(KEY_FLAT_CHAR) ||
+      !searchStr.includes(encodeKeyFlatChar)) &&
+      (searchStr.includes(JSONChar) || searchStr.includes(encodeJSONChar))) ||
+    isEncodedJSONArrayParam(searchStr)
+  ) {
+    return parseSearchWith(JSON.parse)(searchStr);
+  }
+
+  const flattenedParsedSearch = qs.parse(searchStr, {
+    arrayFormat: 'bracket-separator',
+    arrayFormatSeparator: ARRAY_SEPARATOR,
+    parseBooleans: true,
+    types: {
+      intervalInDays: 'number',
+      diffFilter_buildDurationMax: 'number',
+      diffFilter_buildDurationMin: 'number',
+      diffFilter_bootDurationMin: 'number',
+      diffFilter_bootDurationMax: 'number',
+      diffFilter_testDurationMin: 'number',
+      diffFilter_testDurationMax: 'number',
+      treeIndexes: 'number[]',
+      startTimestampInSeconds: 'number',
+      endTimestampInSeconds: 'number',
+    },
+  });
+
+  Object.setPrototypeOf(flattenedParsedSearch, Object.prototype);
+  const parsedSearch = unflattenObject(flattenedParsedSearch, KEY_FLAT_CHAR);
+  return parsedSearch;
+};
+
+export const stringifySearch = (
+  searchParams: Record<string, unknown>,
+): string => {
+  const flattenedSearchParams = flattenObject(searchParams, KEY_FLAT_CHAR);
+  const stringifiedSearch = qs.stringify(flattenedSearchParams, {
+    arrayFormat: 'bracket-separator',
+    arrayFormatSeparator: ARRAY_SEPARATOR,
+  });
+  return stringifiedSearch && `?${stringifiedSearch}`;
+};
+
+const isStringRecord = (obj: unknown): obj is Record<string, unknown> => {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    !Array.isArray(obj) &&
+    Object.keys(obj).every(key => typeof key === 'string')
+  );
+};
+
+const flattenObject = (
+  obj: Record<string, unknown>,
+  keySplitChar: string,
+  parent = '',
+  result: Record<string, boolean | number | string | number[]> = {},
+): Record<string, boolean | string | number | number[]> => {
+  for (const strKey in obj) {
+    const key = strKey as keyof typeof obj;
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const newKey = parent ? `${parent}${keySplitChar}${key}` : key;
+      if (isStringRecord(obj[key])) {
+        flattenObject(obj[key], keySplitChar, newKey, result);
+      } else if (
+        typeof obj[key] === 'number' ||
+        typeof obj[key] === 'string' ||
+        typeof obj[key] === 'boolean' ||
+        Array.isArray(obj[key])
+      ) {
+        result[newKey] = obj[key];
+      }
+    }
+  }
+  return result;
+};
+
+const unflattenObject = (
+  obj: qs.ParsedQuery<string | number | boolean>,
+  keySplitChar: string,
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      const keys = key.split(keySplitChar);
+      keys.reduce<Record<string, unknown> | number[]>((acc, part, index) => {
+        if (isStringRecord(acc)) {
+          if (index === keys.length - 1) {
+            acc[part] = obj[key];
+          } else {
+            acc[part] = acc[part] || {};
+          }
+          if (isStringRecord(acc[part]) || Array.isArray(acc[part])) {
+            return acc[part];
+          }
+        }
+        return acc;
+      }, result);
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
Uses query-string parse/stringify as the new serialization and deserialization methods ensuring a cleaner URL as stated in the URL proposal document.

Closes #657 

## Discussion
- Currently, I'm using the character '|' to flatten the elements, but it's a character that can be URI encoded, so maybe we should think of another one to avoid making the URL too 'messy'. The same goes for the comma that I'm using to separate array elements in the URL (treeIndexes up to now). 
- Check if the way the data is structured is good. Because of the object 'flattening', the URL has ended up being larger (since it repeats the name 'treeInfo' several times, for example). I decided to start with the 'query-string' library, and that's why this 'flattening' was necessary. Another solution would be to use jsurl2 or create our own stringify solution that follows a different logic and wouldn't need to repeat these names multiple times.


## How to test
Navigate through all the application and interact with the elements that change the query parameters, e.g. change tabs, add or remove filters (try both by clicking in the cards and in the modal), change the table filter. In the hardware details page, change the selected trees.  

### Backward compatibility
To test link backward compatibility just navigate to a page in `staging.dashboard.kernelci.org:9000` and change all of this to `localhost:5173`, keeping all the path and query parameters unchanged. 

### Unit tests
To execute unit tests:
- Install vitest by running `pnpm install`
- Run the tests with `pnpm test`

You can also download the [vitest vscode extension](https://marketplace.visualstudio.com/items?itemName=vitest.explorer) to run the tests from inside the IDE.

This addition of unit tests is part of #375 