### PR TITLE
Feat(hardware): Difference between hardware listing and hardware details tests counts

### DIFF
--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -266,7 +266,7 @@ class HardwareDetails(View):
         return test_filter_pass
 
     def handle_test(self, record, tests):
-        status = record["status"]
+        status = record["status"] or "NULL"
 
         tests["history"].append(get_history(record))
         tests["statusSummary"][status] += 1
@@ -372,8 +372,10 @@ class HardwareDetails(View):
                 processed_builds.add(build_id)
                 continue
 
-            should_process_test = not record["id"] in processed_tests \
-                and self.test_in_filter(test_filter_key, record)
+            should_process_test = (
+                self.test_in_filter(test_filter_key, record)
+                and record["id"] not in processed_tests
+            )
 
             if should_process_test:
                 processed_tests.add(record['id'])

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -333,6 +333,7 @@ class HardwareDetails(View):
 
     def sanitize_records(self, records, trees: List, is_all_selected: bool):
         processed_builds = set()
+        processed_tests = set()
         tests = generate_test_dict()
         boots = generate_test_dict()
         tree_status_summary = defaultdict(generate_tree_status_summary_dict)
@@ -371,9 +372,11 @@ class HardwareDetails(View):
                 processed_builds.add(build_id)
                 continue
 
-            should_process_test = self.test_in_filter(test_filter_key, record)
+            should_process_test = not record["id"] in processed_tests \
+                and self.test_in_filter(test_filter_key, record)
 
             if should_process_test:
+                processed_tests.add(record['id'])
                 self.handle_test(record, boots if is_record_boot else tests)
 
             should_process_build = self.is_build_filtered_in(build, processed_builds)


### PR DESCRIPTION
- [x] Add validation of repeated tests in hardware listing and hardware details
- [x] Treat NULL tests status

**How to test**
-   Compare the counter [hardware google,juniper-sku16](https://staging.dashboard.kernelci.org:9000/hardware?hardwareSearch=google%2Cjuniper-sku) in hardware listing with the counter in hardware details.
-   Test the same hardware counter in [localhost](http://localhost:5173/hardware?hardwareSearch=google%2Cjuniper-sku)

Close of #687