### PR TITLE
feat: consider env_misc.platform as hardware

### DIFF
--- a/backend/kernelCI_app/helpers/misc.py
+++ b/backend/kernelCI_app/helpers/misc.py
@@ -1,0 +1,61 @@
+from typing import Union, TypedDict, Optional
+from kernelCI_app.helpers.filters import UNKNOWN_STRING
+from kernelCI_app.utils import string_to_json
+
+
+class EnvironmentMisc(TypedDict):
+    platform: str
+
+
+class BuildMisc(TypedDict):
+    platform: str
+
+
+def handle_environment_misc(misc: Union[str, dict, None]) -> Optional[EnvironmentMisc]:
+    parsed_misc: EnvironmentMisc = {}
+
+    if isinstance(misc, str):
+        misc = string_to_json(misc)
+        if misc is None:
+            return None
+    elif not isinstance(misc, dict):
+        return None
+
+    parsed_misc["platform"] = misc.get("platform", UNKNOWN_STRING)
+
+    return parsed_misc
+
+
+def handle_build_misc(misc: Union[str, dict, None]) -> Optional[BuildMisc]:
+    parsed_misc: BuildMisc = {}
+
+    if isinstance(misc, str):
+        misc = string_to_json(misc)
+        if misc is None:
+            return None
+    elif not isinstance(misc, dict):
+        return None
+
+    parsed_misc["platform"] = misc.get("platform", UNKNOWN_STRING)
+
+    return parsed_misc
+
+
+def env_misc_value_or_default(misc: Optional[EnvironmentMisc]) -> EnvironmentMisc:
+    default_misc: EnvironmentMisc = {
+        "platform": UNKNOWN_STRING,
+    }
+
+    if misc is not None:
+        return misc
+    return default_misc
+
+
+def build_misc_value_or_default(misc: Optional[BuildMisc]) -> BuildMisc:
+    default_misc: BuildMisc = {
+        "platform": UNKNOWN_STRING,
+    }
+
+    if misc is not None:
+        return misc
+    return default_misc

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -34,20 +34,6 @@ def convert_issues_dict_to_list(issues_dict: Dict[str, Issue]) -> List[Issue]:
     return list(issues_dict.values())
 
 
-def extract_platform(misc_environment: Union[str, dict, None]):
-    parsedEnvMisc = None
-    if isinstance(misc_environment, dict):
-        parsedEnvMisc = misc_environment
-    elif misc_environment is None:
-        return "unknown"
-    else:
-        parsedEnvMisc = json.loads(misc_environment)
-    platform = parsedEnvMisc.get("platform")
-    if platform:
-        return platform
-    return "unknown"
-
-
 # TODO misc is not stable and should be used as a POC only
 def extract_error_message(misc: Union[str, dict, None]):
     parsedEnv = None
@@ -79,3 +65,4 @@ def string_to_json(string: str) -> Optional[dict]:
             return json.loads(string)
         except json.JSONDecodeError as e:
             log_message(e.msg)
+            return None

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import type { LinkProps } from '@tanstack/react-router';
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useTreeDetails } from '@/api/treeDetails';
 import BaseCard from '@/components/Cards/BaseCard';
@@ -97,6 +97,13 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
     [treeId],
   );
 
+  const hardwareData = useMemo(() => {
+    return {
+      ...data?.bootEnvironmentCompatible,
+      ...data?.bootEnvironmentMisc,
+    };
+  }, [data?.bootEnvironmentCompatible, data?.bootEnvironmentMisc]);
+
   if (error || !treeId) {
     return (
       <div>
@@ -157,7 +164,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
           <TreeCommitNavigationGraph />
           <MemoizedHardwareTested
             title={<FormattedMessage id="bootsTab.hardwareTested" />}
-            environmentCompatible={data.bootEnvironmentCompatible}
+            environmentCompatible={hardwareData}
             diffFilter={diffFilter}
           />
         </div>
@@ -191,7 +198,7 @@ const BootsTab = ({ reqFilter }: BootsTabProps): JSX.Element => {
           <div>
             <MemoizedHardwareTested
               title={<FormattedMessage id="bootsTab.hardwareTested" />}
-              environmentCompatible={data.bootEnvironmentCompatible}
+              environmentCompatible={hardwareData}
               diffFilter={diffFilter}
             />
           </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import type { LinkProps } from '@tanstack/react-router';
 import { useParams, useNavigate, useSearch } from '@tanstack/react-router';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { Skeleton } from '@/components/Skeleton';
 
@@ -99,6 +99,13 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
     [navigate],
   );
 
+  const hardwareData = useMemo(() => {
+    return {
+      ...data?.testEnvironmentCompatible,
+      ...data?.testEnvironmentMisc,
+    };
+  }, [data?.testEnvironmentCompatible, data?.testEnvironmentMisc]);
+
   if (error || !treeId) {
     return (
       <div>
@@ -159,7 +166,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
           <TreeCommitNavigationGraph />
           <MemoizedHardwareTested
             title={<FormattedMessage id="testsTab.hardwareTested" />}
-            environmentCompatible={data.testEnvironmentCompatible}
+            environmentCompatible={hardwareData}
             diffFilter={diffFilter}
           />
         </div>
@@ -193,7 +200,7 @@ const TestsTab = ({ reqFilter }: TestsTabProps): JSX.Element => {
           <div>
             <MemoizedHardwareTested
               title={<FormattedMessage id="testsTab.hardwareTested" />}
-              environmentCompatible={data.testEnvironmentCompatible}
+              environmentCompatible={hardwareData}
               diffFilter={diffFilter}
             />
           </div>

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -80,6 +80,8 @@ export type TTreeTestsFullData = {
   testIssues: TIssue[];
   testEnvironmentCompatible: PropertyStatusCounts;
   bootEnvironmentCompatible: PropertyStatusCounts;
+  testEnvironmentMisc: PropertyStatusCounts;
+  bootEnvironmentMisc: PropertyStatusCounts;
   hardwareUsed: string[];
   failedTestsWithUnknownIssues: number;
   failedBootsWithUnknownIssues: number;


### PR DESCRIPTION
Add a new logic to the backend where `environment_misc.platform` will work as a fallback case for when the `environment_compatabile` field is null in the database. When `environment_misc.plaftorm` is null, we'll use `build.misc.platform`, but the logic of the Hardware filter will be kept the same, meaning that the builds returned will be first the build associated with the tests that have that hardware. This means that even if `build.misc.platform` is null but the build is associated with a test that have `environment_compatible` or `environment_misc.platform` not null, it will also be added when filtering for that hardware

This drastically lowers the number of Unknown hardware but they can still occur if both `environment_compatible` and `environment_misc.platform` and `build.misc.platform` are null.

Closes #692 

## How to test
- Add hardware filters from the Hardware Used card, Hardware Tested card and Filter modal and verify that they are correctly being added by comparing with staging. Verify that the commit graph is also working properly, showing the correct graph and changing the commit correctly
- Add a platform filter (these are hardwares that do not appear in staging, e.g. `acer-R721T-grunt`) from the Hardware Used card, Hardware Tested card and Filter modal and make the same verifications as above, if the status are showing correctly (comparing the values in the Hardware Tested card and the value shown in the pie chart) and if the commit graph is working.
- Test in other origins to verify that the behaviour is consistent between them