### PR TITLE
Fix: Navigation in Hardware Details by Commit History Chart

### DIFF
--- a/dashboard/src/api/commitHistory.ts
+++ b/dashboard/src/api/commitHistory.ts
@@ -18,6 +18,8 @@ const fetchCommitHistory = async (
   gitUrl: string,
   gitBranch: string,
   filters: TTreeDetailsFilter,
+  startTimestampInSeconds: number | undefined,
+  endTimestampInSeconds: number | undefined,
 ): Promise<TTreeCommitHistoryResponse> => {
   const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
 
@@ -25,6 +27,8 @@ const fetchCommitHistory = async (
     origin,
     git_url: gitUrl,
     git_branch: gitBranch,
+    startTimestampInSeconds,
+    endTimestampInSeconds,
     ...filtersFormatted,
   };
 
@@ -44,12 +48,16 @@ export const useCommitHistory = (
     gitUrl,
     gitBranch,
     filter,
+    endTimestampInSeconds,
+    startTimestampInSeconds,
   }: {
     commitHash: string;
     origin: string;
     gitUrl: string;
     gitBranch: string;
     filter: TTreeDetailsFilter | TFilter;
+    startTimestampInSeconds?: number;
+    endTimestampInSeconds?: number;
   },
   { enabled = true },
 ): UseQueryResult<TTreeCommitHistoryResponse> => {
@@ -69,9 +77,19 @@ export const useCommitHistory = (
       gitUrl,
       gitBranch,
       filters,
+      startTimestampInSeconds,
+      endTimestampInSeconds,
     ],
     enabled,
     queryFn: () =>
-      fetchCommitHistory(commitHash, origin, gitUrl, gitBranch, filters),
+      fetchCommitHistory(
+        commitHash,
+        origin,
+        gitUrl,
+        gitBranch,
+        filters,
+        startTimestampInSeconds,
+        endTimestampInSeconds,
+      ),
   });
 };

--- a/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
+++ b/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
@@ -25,6 +25,8 @@ interface ICommitNavigationGraph {
   gitBranch?: string;
   headCommitHash?: string;
   treeId?: string;
+  startTimestampInSeconds?: number;
+  endTimestampInSeconds?: number;
   onMarkClick: (commitHash: string, commitName?: string) => void;
 }
 const CommitNavigationGraph = ({
@@ -36,6 +38,8 @@ const CommitNavigationGraph = ({
   headCommitHash,
   treeId,
   onMarkClick,
+  endTimestampInSeconds,
+  startTimestampInSeconds,
 }: ICommitNavigationGraph): JSX.Element => {
   const { formatMessage } = useIntl();
 
@@ -48,6 +52,8 @@ const CommitNavigationGraph = ({
       commitHash: headCommitHash ?? '',
       origin: origin,
       filter: reqFilter,
+      endTimestampInSeconds,
+      startTimestampInSeconds,
     },
     {
       enabled: !!gitBranch && !!gitUrl,

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
@@ -13,10 +13,17 @@ const HardwareCommitNavigationGraph = ({
   trees,
   hardwareId,
 }: ICommitNavigationGraph): React.ReactNode => {
-  const { diffFilter, treeIndexes, origin, currentPageTab, treeCommits } =
-    useSearch({
-      from: '/hardware/$hardwareId',
-    });
+  const {
+    diffFilter,
+    treeIndexes,
+    origin,
+    currentPageTab,
+    treeCommits,
+    startTimestampInSeconds,
+    endTimestampInSeconds,
+  } = useSearch({
+    from: '/hardware/$hardwareId',
+  });
 
   const navigate = useNavigate({ from: '/hardware/$hardwareId' });
 
@@ -57,6 +64,8 @@ const HardwareCommitNavigationGraph = ({
       onMarkClick={markClickHandle}
       diffFilter={diffFilterWithHardware}
       currentPageTab={currentPageTab}
+      endTimestampInSeconds={endTimestampInSeconds}
+      startTimestampInSeconds={startTimestampInSeconds}
     />
   );
 };


### PR DESCRIPTION
Add startTimestamp and endTimestamp in commit history charts.
Close #688 

**How to Test**
- Select any Hardware and fix one tree to see the commits history. Try to select another commit in chart.
  - e.g. [hardware: google,juniper-sku16  tree: arbd/for-kernelci](http://localhost:5173/hardware/google%2Cjuniper-sku16?endTimestampInSeconds=1734714000&startTimestampInSeconds=1734454800&treeIndexes[]=0) 
- Select any Tree and see the same behavior as in staging