### PR TITLE
Feat: IssueDetails test and build info

### DIFF
--- a/backend/kernelCI_app/typeModels/issueDetails.py
+++ b/backend/kernelCI_app/typeModels/issueDetails.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class IssueDetailsPathParameters(BaseModel):
+    issue_id: str
+    version: int

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -74,4 +74,7 @@ urlpatterns = [
     path("issue/<str:issue_id>/version/<str:version>",
          viewCache(views.IssueDetails),
          name="issueDetails"),
+    path("issue/<str:issue_id>/version/<str:version>/tests",
+         viewCache(views.IssueDetailsTests),
+         name="issueDetailsTests"),
 ]

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -77,4 +77,7 @@ urlpatterns = [
     path("issue/<str:issue_id>/version/<str:version>/tests",
          viewCache(views.IssueDetailsTests),
          name="issueDetailsTests"),
+    path("issue/<str:issue_id>/version/<str:version>/builds",
+         viewCache(views.IssueDetailsBuilds),
+         name="issueDetailsBuilds"),
 ]

--- a/backend/kernelCI_app/views/issueDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/issueDetailsBuildsView.py
@@ -1,0 +1,61 @@
+from http import HTTPStatus
+from typing import Dict, Optional
+from django.http import JsonResponse
+from django.views import View
+from kernelCI_app.helpers.errorHandling import create_error_response
+from kernelCI_app.models import Incidents
+from kernelCI_app.typeModels.issueDetails import IssueDetailsPathParameters
+from pydantic import ValidationError
+
+
+class IssueDetailsBuilds(View):
+    def _fetch_incidents(self, *, issue_id: str, version: int) -> Optional[Dict]:
+        fields = [
+            "build__id",
+            "build__architecture",
+            "build__config_name",
+            "build__valid",
+            "build__start_time",
+            "build__duration",
+            "build__compiler",
+            "build__log_url",
+        ]
+
+        builds = Incidents.objects.filter(
+            issue_id=issue_id, issue_version=version
+        ).values(*fields)
+
+        return [
+            {
+                "id": build["build__id"],
+                "architecture": build["build__architecture"],
+                "config_name": build["build__config_name"],
+                "valid": build["build__valid"],
+                "start_time": build["build__start_time"],
+                "duration": build["build__duration"],
+                "compiler": build["build__compiler"],
+                "log_url": build["build__log_url"],
+            }
+            for build in builds
+        ]
+
+    def get(
+        self, _request, issue_id: Optional[str], version: Optional[str]
+    ) -> JsonResponse:
+        try:
+            parsed_params = IssueDetailsPathParameters(
+                issue_id=issue_id, version=version
+            )
+        except ValidationError as e:
+            return create_error_response(e.json())
+
+        builds_data = self._fetch_incidents(
+            issue_id=parsed_params.issue_id, version=parsed_params.version
+        )
+
+        if builds_data is None:
+            return create_error_response(
+                error_message="Builds not found", status_code=HTTPStatus.NOT_FOUND
+            )
+
+        return JsonResponse(builds_data, safe=False)

--- a/backend/kernelCI_app/views/issueDetailsTestsView.py
+++ b/backend/kernelCI_app/views/issueDetailsTestsView.py
@@ -1,0 +1,57 @@
+from http import HTTPStatus
+from typing import Dict, Optional
+from django.http import JsonResponse
+from django.views import View
+from kernelCI_app.helpers.errorHandling import create_error_response
+from kernelCI_app.models import Incidents
+from kernelCI_app.typeModels.issueDetails import IssueDetailsPathParameters
+from pydantic import ValidationError
+
+
+class IssueDetailsTests(View):
+    def _fetch_incidents(self, *, issue_id: str, version: int) -> Optional[Dict]:
+        fields = [
+            "test__id",
+            "test__duration",
+            "test__status",
+            "test__path",
+            "test__start_time",
+            "test__environment_compatible",
+        ]
+
+        tests = Incidents.objects.filter(
+            issue_id=issue_id, issue_version=version
+        ).values(*fields)
+
+        return [
+            {
+                "id": test["test__id"],
+                "duration": test["test__duration"],
+                "status": test["test__status"],
+                "path": test["test__path"],
+                "startTime": test["test__start_time"],
+                "hardware": test["test__environment_compatible"],
+            }
+            for test in tests
+        ]
+
+    def get(
+        self, _request, issue_id: Optional[str], version: Optional[str]
+    ) -> JsonResponse:
+        try:
+            parsed_params = IssueDetailsPathParameters(
+                issue_id=issue_id, version=version
+            )
+        except ValidationError as e:
+            return create_error_response(e.json())
+
+        tests_data = self._fetch_incidents(
+            issue_id=parsed_params.issue_id, version=parsed_params.version
+        )
+
+        if tests_data is None:
+            return create_error_response(
+                error_message="Tests not found", status_code=HTTPStatus.NOT_FOUND
+            )
+
+        return JsonResponse(tests_data, safe=False)

--- a/backend/kernelCI_app/views/issueDetailsView.py
+++ b/backend/kernelCI_app/views/issueDetailsView.py
@@ -1,8 +1,11 @@
+from http import HTTPStatus
 from typing import Dict, Optional
-from django.http import HttpResponseBadRequest, HttpResponseNotFound, JsonResponse
+from django.http import JsonResponse
 from django.views import View
+from kernelCI_app.helpers.errorHandling import create_error_response
 from kernelCI_app.models import Issues
-from kernelCI_app.utils import getErrorResponseBody
+from kernelCI_app.typeModels.issueDetails import IssueDetailsPathParameters
+from pydantic import ValidationError
 
 
 class IssueDetails(View):
@@ -31,27 +34,21 @@ class IssueDetails(View):
 
         return query
 
-    def get(self, _request, issue_id: Optional[str], version: Optional[str]):
-        missing_params = []
-        if issue_id is None:
-            missing_params.append("issue_id")
-        if version is None:
-            missing_params.append("version")
-        if len(missing_params) != 0:
-            return HttpResponseBadRequest(
-                getErrorResponseBody("Missing parameters: ", missing_params)
-            )
-
+    def get(self, _request, issue_id: Optional[str], version: Optional[str]) -> JsonResponse:
         try:
-            parsed_version = int(version)
-        except ValueError:
-            return HttpResponseBadRequest(
-                getErrorResponseBody("Invalid version parameter, must be an integer")
+            parsed_params = IssueDetailsPathParameters(
+                issue_id=issue_id, version=version
             )
+        except ValidationError as e:
+            return create_error_response(e.json())
 
-        issue_data = self._fetch_issue(issue_id=issue_id, version=parsed_version)
+        issue_data = self._fetch_issue(
+            issue_id=parsed_params.issue_id, version=parsed_params.version
+        )
 
         if issue_data is None:
-            return HttpResponseNotFound(getErrorResponseBody("Issue not found"))
+            return create_error_response(
+                error_message="Issue not found", status_code=HTTPStatus.NOT_FOUND
+            )
 
         return JsonResponse(issue_data)

--- a/backend/requests/issue-details-builds-get.sh
+++ b/backend/requests/issue-details-builds-get.sh
@@ -1,0 +1,53 @@
+http http://localhost:8000/api/issue/maestro:f61865c29254c199ba015e5f48acfc070aff0eb0/version/0/builds
+
+# HTTP/1.1 200 OK
+# Cache-Control: max-age=0
+# Content-Length: 872
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Mon, 23 Dec 2024 19:25:24 GMT
+# Expires: Mon, 23 Dec 2024 19:25:24 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# [
+#     {
+#         "architecture": "arm",
+#         "compiler": "clang-17",
+#         "config_name": "imx_v6_v7_defconfig+allmodconfig",
+#         "duration": null,
+#         "id": "maestro:673fcc50923416c0c98dfea6",
+#         "start_time": "2024-11-22T00:12:00.124Z",
+#         "valid": false
+#     },
+#     {
+#         "architecture": "arm",
+#         "compiler": "clang-17",
+#         "config_name": "imx_v6_v7_defconfig+allmodconfig",
+#         "duration": null,
+#         "id": "maestro:67406b8c923416c0c98f75ad",
+#         "start_time": "2024-11-22T11:31:24.629Z",
+#         "valid": false
+#     },
+#     {
+#         "architecture": "arm",
+#         "compiler": "clang-17",
+#         "config_name": "imx_v6_v7_defconfig+allmodconfig",
+#         "duration": null,
+#         "id": "maestro:67409557923416c0c98fa534",
+#         "start_time": "2024-11-22T14:29:43.011Z",
+#         "valid": false
+#     },
+#     {
+#         "architecture": "arm",
+#         "compiler": "clang-17",
+#         "config_name": "imx_v6_v7_defconfig+allmodconfig",
+#         "duration": null,
+#         "id": "maestro:674079b4923416c0c98f79ba",
+#         "start_time": "2024-11-22T12:31:48.309Z",
+#         "valid": false
+#     }
+# ]

--- a/backend/requests/issue-details-tests-get.sh
+++ b/backend/requests/issue-details-tests-get.sh
@@ -1,0 +1,65 @@
+http 'http://localhost:8000/api/issue/maestro:0820fe153b255bf52750bbf1fecb198d8772f5a9/version/0/tests'
+
+# HTTP/1.1 200 OK
+# Cache-Control: max-age=0
+# Content-Length: 904
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Mon, 23 Dec 2024 16:38:59 GMT
+# Expires: Mon, 23 Dec 2024 16:38:59 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# [
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "google,tomato-rev2",
+#             "google,tomato",
+#             "mediatek,mt8195"
+#         ],
+#         "id": "maestro:674ef566063ce49a02bf7b6d",
+#         "path": "boot.nfs",
+#         "start_time": "2024-12-03T12:11:18.636Z",
+#         "status": "FAIL"
+#     },
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "google,tomato-rev2",
+#             "google,tomato",
+#             "mediatek,mt8195"
+#         ],
+#         "id": "maestro:674fddf9089e99b3f2b506f7",
+#         "path": "boot.nfs",
+#         "start_time": "2024-12-04T04:43:37.701Z",
+#         "status": "FAIL"
+#     },
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "google,tomato-rev2",
+#             "google,tomato",
+#             "mediatek,mt8195"
+#         ],
+#         "id": "maestro:674fd928089e99b3f2b4b523",
+#         "path": "boot",
+#         "start_time": "2024-12-04T04:23:04.822Z",
+#         "status": "FAIL"
+#     },
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "google,tomato-rev2",
+#             "google,tomato",
+#             "mediatek,mt8195"
+#         ],
+#         "id": "maestro:6750002f089e99b3f2b7e106",
+#         "path": "boot",
+#         "start_time": "2024-12-04T07:09:35.087Z",
+#         "status": "FAIL"
+#     }
+# ]

--- a/dashboard/src/api/issueDetails.ts
+++ b/dashboard/src/api/issueDetails.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import type { TIssueDetails } from '@/types/issueDetails';
 
-import type { TestHistory } from '@/types/general';
+import type { BuildsTableBuild, TestHistory } from '@/types/general';
 
 import http from './api';
 
@@ -46,5 +46,26 @@ export const useIssueDetailsTests = (
   return useQuery({
     queryKey: ['issueTestsData', issueId, versionNumber],
     queryFn: () => fetchIssueDetailsTests(issueId, versionNumber),
+  });
+};
+
+const fetchIssueDetailsBuilds = async (
+  issueId: string,
+  versionNumber: string,
+): Promise<BuildsTableBuild[]> => {
+  const res = await http.get(
+    `/api/issue/${issueId}/version/${versionNumber}/builds`,
+  );
+
+  return res.data;
+};
+
+export const useIssueDetailsBuilds = (
+  issueId: string,
+  versionNumber: string,
+): UseQueryResult<BuildsTableBuild[]> => {
+  return useQuery({
+    queryKey: ['issueBuildsData', issueId, versionNumber],
+    queryFn: () => fetchIssueDetailsBuilds(issueId, versionNumber),
   });
 };

--- a/dashboard/src/api/issueDetails.ts
+++ b/dashboard/src/api/issueDetails.ts
@@ -3,6 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 
 import type { TIssueDetails } from '@/types/issueDetails';
 
+import type { TestHistory } from '@/types/general';
+
 import http from './api';
 
 const fetchIssueDetailsData = async (
@@ -23,5 +25,26 @@ export const useIssueDetails = (
   return useQuery({
     queryKey: ['issueData', issueId, versionNumber],
     queryFn: () => fetchIssueDetailsData(issueId, versionNumber),
+  });
+};
+
+const fetchIssueDetailsTests = async (
+  issueId: string,
+  versionNumber: string,
+): Promise<TestHistory[]> => {
+  const res = await http.get(
+    `/api/issue/${issueId}/version/${versionNumber}/tests`,
+  );
+
+  return res.data;
+};
+
+export const useIssueDetailsTests = (
+  issueId: string,
+  versionNumber: string,
+): UseQueryResult<TestHistory[]> => {
+  return useQuery({
+    queryKey: ['issueTestsData', issueId, versionNumber],
+    queryFn: () => fetchIssueDetailsTests(issueId, versionNumber),
   });
 };

--- a/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
@@ -1,6 +1,4 @@
-import { FormattedMessage, useIntl } from 'react-intl';
-
-import { RiProhibited2Line } from 'react-icons/ri';
+import { useIntl } from 'react-intl';
 
 import type { HistoryState, LinkProps } from '@tanstack/react-router';
 
@@ -12,6 +10,8 @@ import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
 
 import { TestsTable } from '@/components/TestsTable/TestsTable';
 
+import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+
 interface IBuildDetailsTestSection {
   buildId: string;
   onClickFilter: (filter: TestsTableFilter) => void;
@@ -19,15 +19,6 @@ interface IBuildDetailsTestSection {
   getRowLink: (testId: string) => LinkProps;
   historyState?: HistoryState;
 }
-
-const NoTestFound = (): JSX.Element => (
-  <div className="flex flex-col items-center py-6 text-weakGray">
-    <RiProhibited2Line className="h-14 w-14" />
-    <h1 className="text-2xl font-semibold">
-      <FormattedMessage id={'buildDetails.noTestResults'} />
-    </h1>
-  </div>
-);
 
 const BuildDetailsTestSection = ({
   buildId,
@@ -37,9 +28,9 @@ const BuildDetailsTestSection = ({
   historyState,
 }: IBuildDetailsTestSection): JSX.Element => {
   const intl = useIntl();
-  const { data, error } = useBuildTests(buildId);
+  const { data, error, isLoading } = useBuildTests(buildId);
 
-  const hasTest = data && data.length > 0 && !error;
+  const hasTest = data && data.length > 0;
   return (
     <>
       <span className="text-2xl font-bold">
@@ -58,7 +49,12 @@ const BuildDetailsTestSection = ({
           />
         </div>
       ) : (
-        <NoTestFound />
+        <MemoizedSectionError
+          isLoading={isLoading}
+          errorMessage={error?.message}
+          isEmpty={data?.length === 0}
+          emptyLabel={'buildDetails.noTestResults'}
+        />
       )}
     </>
   );

--- a/dashboard/src/components/DetailsPages/SectionError.tsx
+++ b/dashboard/src/components/DetailsPages/SectionError.tsx
@@ -1,0 +1,40 @@
+import { memo, useMemo } from 'react';
+import { RiProhibited2Line } from 'react-icons/ri';
+import type { MessageDescriptor } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
+
+interface ISectionError {
+  errorMessage?: string;
+  isLoading: boolean;
+  isEmpty?: boolean;
+  emptyLabel?: MessageDescriptor['id'];
+}
+
+const SectionError = ({
+  errorMessage,
+  isLoading,
+  isEmpty,
+  emptyLabel = 'global.noResults',
+}: ISectionError): JSX.Element => {
+  const message = useMemo((): MessageDescriptor['id'] => {
+    if (isLoading) {
+      return 'global.loading';
+    } else if (isEmpty) {
+      return emptyLabel;
+    } else if (errorMessage) {
+      return 'global.error';
+    }
+    return 'global.error';
+  }, [emptyLabel, errorMessage, isEmpty, isLoading]);
+
+  return (
+    <div className="flex flex-col items-center py-6 text-weakGray">
+      {!isLoading && <RiProhibited2Line className="h-14 w-14" />}
+      <p className="text-2xl font-semibold">
+        <FormattedMessage id={message} />
+      </p>
+      {errorMessage && <p>Error: {errorMessage}</p>}
+    </div>
+  );
+};
+export const MemoizedSectionError = memo(SectionError);

--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -2,6 +2,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useMemo } from 'react';
 
+import type { LinkProps } from '@tanstack/react-router';
+
 import SectionGroup from '@/components/Section/SectionGroup';
 import type { ISection } from '@/components/Section/Section';
 import UnexpectedError from '@/components/UnexpectedError/UnexpectedError';
@@ -14,16 +16,28 @@ import { getMiscSection } from '@/components/Section/MiscSection';
 
 import { useIssueDetails } from '@/api/issueDetails';
 
+import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
+
+import { IssueDetailsTestSection } from './IssueDetailsTestSection';
+
 interface IIssueDetails {
   issueId: string;
   versionNumber: string;
+  tableFilter: TableFilter;
+  onClickTestFilter: (filter: TestsTableFilter) => void;
+  getTestTableRowLink: (testId: string) => LinkProps;
 }
 
 export const IssueDetails = ({
   issueId,
   versionNumber,
+  tableFilter,
+  onClickTestFilter,
+  getTestTableRowLink,
 }: IIssueDetails): JSX.Element => {
   const { data, error, isLoading } = useIssueDetails(issueId, versionNumber);
+
+  const hasTest = data && data.test_status !== null;
 
   const { formatMessage } = useIntl();
 
@@ -136,6 +150,15 @@ export const IssueDetails = ({
   return (
     <ErrorBoundary FallbackComponent={UnexpectedError}>
       <SectionGroup sections={sectionsData} />
+      {hasTest && (
+        <IssueDetailsTestSection
+          issueId={issueId}
+          versionNumber={versionNumber}
+          testTableFilter={tableFilter.testsTable}
+          getTableRowLink={getTestTableRowLink}
+          onClickFilter={onClickTestFilter}
+        />
+      )}
     </ErrorBoundary>
   );
 };

--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -16,9 +16,14 @@ import { getMiscSection } from '@/components/Section/MiscSection';
 
 import { useIssueDetails } from '@/api/issueDetails';
 
-import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
+import type {
+  BuildsTableFilter,
+  TableFilter,
+  TestsTableFilter,
+} from '@/types/tree/TreeDetails';
 
 import { IssueDetailsTestSection } from './IssueDetailsTestSection';
+import { IssueDetailsBuildSection } from './IssueDetailsBuildSection';
 
 interface IIssueDetails {
   issueId: string;
@@ -26,6 +31,8 @@ interface IIssueDetails {
   tableFilter: TableFilter;
   onClickTestFilter: (filter: TestsTableFilter) => void;
   getTestTableRowLink: (testId: string) => LinkProps;
+  onClickBuildFilter: (filter: BuildsTableFilter) => void;
+  getBuildTableRowLink: (testId: string) => LinkProps;
 }
 
 export const IssueDetails = ({
@@ -34,10 +41,13 @@ export const IssueDetails = ({
   tableFilter,
   onClickTestFilter,
   getTestTableRowLink,
+  onClickBuildFilter,
+  getBuildTableRowLink,
 }: IIssueDetails): JSX.Element => {
   const { data, error, isLoading } = useIssueDetails(issueId, versionNumber);
 
   const hasTest = data && data.test_status !== null;
+  const hasBuild = data && data.build_valid !== null;
 
   const { formatMessage } = useIntl();
 
@@ -157,6 +167,15 @@ export const IssueDetails = ({
           testTableFilter={tableFilter.testsTable}
           getTableRowLink={getTestTableRowLink}
           onClickFilter={onClickTestFilter}
+        />
+      )}
+      {hasBuild && (
+        <IssueDetailsBuildSection
+          issueId={issueId}
+          versionNumber={versionNumber}
+          buildTableFilter={tableFilter.buildsTable}
+          getTableRowLink={getBuildTableRowLink}
+          onClickFilter={onClickBuildFilter}
         />
       )}
     </ErrorBoundary>

--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -15,18 +15,15 @@ import { getMiscSection } from '@/components/Section/MiscSection';
 import { useIssueDetails } from '@/api/issueDetails';
 
 interface IIssueDetails {
-  issueId?: string;
-  versionNumber?: string;
+  issueId: string;
+  versionNumber: string;
 }
 
 export const IssueDetails = ({
   issueId,
   versionNumber,
 }: IIssueDetails): JSX.Element => {
-  const { data, error, isLoading } = useIssueDetails(
-    issueId ?? '',
-    versionNumber ?? '',
-  );
+  const { data, error, isLoading } = useIssueDetails(issueId, versionNumber);
 
   const { formatMessage } = useIntl();
 

--- a/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
@@ -1,0 +1,73 @@
+import type { LinkProps } from '@tanstack/react-router';
+
+import { useIntl } from 'react-intl';
+
+import { useMemo } from 'react';
+
+import { Separator } from '@/components/ui/separator';
+import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+import type {
+  AccordionItemBuilds,
+  BuildsTableFilter,
+  TableFilter,
+} from '@/types/tree/TreeDetails';
+
+import { useIssueDetailsBuilds } from '@/api/issueDetails';
+
+import { BuildsTable } from '@/components/BuildsTable/BuildsTable';
+import { sanitizeBuildTable } from '@/utils/utils';
+
+interface IIssueDetailsBuildSection {
+  issueId: string;
+  versionNumber: string;
+  buildTableFilter: TableFilter['buildsTable'];
+  onClickFilter: (filter: BuildsTableFilter) => void;
+  getTableRowLink: (testId: string) => LinkProps;
+}
+
+export const IssueDetailsBuildSection = ({
+  issueId,
+  versionNumber,
+  buildTableFilter,
+  onClickFilter,
+  getTableRowLink,
+}: IIssueDetailsBuildSection): JSX.Element => {
+  const { data, error, isLoading } = useIssueDetailsBuilds(
+    issueId,
+    versionNumber,
+  );
+
+  const { formatMessage } = useIntl();
+
+  const buildData = useMemo((): AccordionItemBuilds[] => {
+    if (!data) {
+      return [];
+    }
+    return sanitizeBuildTable(data);
+  }, [data]);
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">
+        {formatMessage({ id: 'global.builds' })}
+      </h2>
+      <Separator className="my-6 bg-darkGray" />
+      {data ? (
+        <div className="flex flex-col gap-6">
+          <BuildsTable
+            tableKey="issueDetailsBuilds"
+            buildItems={buildData}
+            filter={buildTableFilter}
+            getRowLink={getTableRowLink}
+            onClickFilter={onClickFilter}
+          />
+        </div>
+      ) : (
+        <MemoizedSectionError
+          isLoading={isLoading}
+          errorMessage={error?.message}
+        />
+      )}
+    </>
+  );
+};

--- a/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
@@ -1,0 +1,57 @@
+import type { LinkProps } from '@tanstack/react-router';
+
+import { useIntl } from 'react-intl';
+
+import { useIssueDetailsTests } from '@/api/issueDetails';
+
+import { TestsTable } from '@/components/TestsTable/TestsTable';
+import { Separator } from '@/components/ui/separator';
+import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
+
+interface IIssueDetailsTestSection {
+  issueId: string;
+  versionNumber: string;
+  testTableFilter: TableFilter['testsTable'];
+  onClickFilter: (filter: TestsTableFilter) => void;
+  getTableRowLink: (testId: string) => LinkProps;
+}
+
+export const IssueDetailsTestSection = ({
+  issueId,
+  versionNumber,
+  testTableFilter,
+  onClickFilter,
+  getTableRowLink,
+}: IIssueDetailsTestSection): JSX.Element => {
+  const { data, error, isLoading } = useIssueDetailsTests(
+    issueId,
+    versionNumber,
+  );
+  const { formatMessage } = useIntl();
+
+  return (
+    <>
+      <h2 className="text-2xl font-bold">
+        {formatMessage({ id: 'global.tests' })}
+      </h2>
+      <Separator className="my-6 bg-darkGray" />
+      {data ? (
+        <div className="flex flex-col gap-6">
+          <TestsTable
+            tableKey="issueDetailsTests"
+            testHistory={data}
+            onClickFilter={onClickFilter}
+            filter={testTableFilter}
+            getRowLink={getTableRowLink}
+          />
+        </div>
+      ) : (
+        <MemoizedSectionError
+          isLoading={isLoading}
+          errorMessage={error?.message}
+        />
+      )}
+    </>
+  );
+};

--- a/dashboard/src/pages/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/pages/IssueDetails/IssueDetails.tsx
@@ -4,10 +4,11 @@ import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import { useCallback } from 'react';
 
 import { IssueDetails } from '@/components/IssueDetails/IssueDetails';
-import {
-  zTableFilterInfoDefault,
-  type TestsTableFilter,
+import type {
+  BuildsTableFilter,
+  TestsTableFilter,
 } from '@/types/tree/TreeDetails';
+import { zTableFilterInfoDefault } from '@/types/tree/TreeDetails';
 
 const CURRENT_ROUTE = '/issue/$issueId/version/$versionNumber';
 
@@ -44,6 +45,34 @@ const IssueDetailsPage = (): JSX.Element => {
     [navigate],
   );
 
+  const getBuildTableRowLink = useCallback(
+    (buildId: string): LinkProps => ({
+      to: '/build/$buildId',
+      params: {
+        buildId: buildId,
+      },
+      search: s => s,
+    }),
+    [],
+  );
+
+  const onClickBuildFilter = useCallback(
+    (filter: BuildsTableFilter): void => {
+      navigate({
+        search: previousParams => {
+          return {
+            ...previousParams,
+            tableFilter: {
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
+              buildsTable: filter,
+            },
+          };
+        },
+      });
+    },
+    [navigate],
+  );
+
   return (
     <IssueDetails
       issueId={issueId}
@@ -51,6 +80,8 @@ const IssueDetailsPage = (): JSX.Element => {
       tableFilter={searchParams.tableFilter ?? zTableFilterInfoDefault}
       onClickTestFilter={onClickTestFilter}
       getTestTableRowLink={getTestTableRowLink}
+      onClickBuildFilter={onClickBuildFilter}
+      getBuildTableRowLink={getBuildTableRowLink}
     />
   );
 };

--- a/dashboard/src/pages/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/pages/IssueDetails/IssueDetails.tsx
@@ -1,13 +1,58 @@
-import { useParams } from '@tanstack/react-router';
+import type { LinkProps } from '@tanstack/react-router';
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+
+import { useCallback } from 'react';
 
 import { IssueDetails } from '@/components/IssueDetails/IssueDetails';
+import {
+  zTableFilterInfoDefault,
+  type TestsTableFilter,
+} from '@/types/tree/TreeDetails';
+
+const CURRENT_ROUTE = '/issue/$issueId/version/$versionNumber';
 
 const IssueDetailsPage = (): JSX.Element => {
-  const { issueId, versionNumber } = useParams({
-    from: '/issue/$issueId/version/$versionNumber',
-  });
+  const searchParams = useSearch({ from: CURRENT_ROUTE });
+  const { issueId, versionNumber } = useParams({ from: CURRENT_ROUTE });
+  const navigate = useNavigate({ from: CURRENT_ROUTE });
 
-  return <IssueDetails issueId={issueId} versionNumber={versionNumber} />;
+  const getTestTableRowLink = useCallback(
+    (testId: string): LinkProps => ({
+      to: '/test/$testId',
+      params: {
+        testId: testId,
+      },
+      search: s => s,
+    }),
+    [],
+  );
+
+  const onClickTestFilter = useCallback(
+    (filter: TestsTableFilter): void => {
+      navigate({
+        search: previousParams => {
+          return {
+            ...previousParams,
+            tableFilter: {
+              ...(previousParams.tableFilter ?? zTableFilterInfoDefault),
+              testsTable: filter,
+            },
+          };
+        },
+      });
+    },
+    [navigate],
+  );
+
+  return (
+    <IssueDetails
+      issueId={issueId}
+      versionNumber={versionNumber}
+      tableFilter={searchParams.tableFilter ?? zTableFilterInfoDefault}
+      onClickTestFilter={onClickTestFilter}
+      getTestTableRowLink={getTestTableRowLink}
+    />
+  );
 };
 
 export default IssueDetailsPage;

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -66,6 +66,18 @@ export type BuildsTabBuild = {
   tree_index?: number;
 };
 
+export type BuildsTableBuild = Pick<
+  BuildsTabBuild,
+  | 'id'
+  | 'architecture'
+  | 'config_name'
+  | 'valid'
+  | 'start_time'
+  | 'duration'
+  | 'compiler'
+  | 'log_url'
+>;
+
 export type BuildStatus = {
   valid: number;
   invalid: number;

--- a/dashboard/src/utils/constants/tables.ts
+++ b/dashboard/src/utils/constants/tables.ts
@@ -8,4 +8,5 @@ export type TableKeys =
   | 'hardwareDetailsBoots'
   | 'hardwareDetailsTests'
   | 'hardwareDetailsTrees'
-  | 'buildDetailsTests';
+  | 'buildDetailsTests'
+  | 'issueDetailsTests';

--- a/dashboard/src/utils/constants/tables.ts
+++ b/dashboard/src/utils/constants/tables.ts
@@ -9,4 +9,5 @@ export type TableKeys =
   | 'hardwareDetailsTests'
   | 'hardwareDetailsTrees'
   | 'buildDetailsTests'
-  | 'issueDetailsTests';
+  | 'issueDetailsTests'
+  | 'issueDetailsBuilds';

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -8,6 +8,7 @@ import type {
 import type {
   Architecture,
   BuildsTabBuild,
+  BuildsTableBuild,
   BuildStatus,
   StatusCount,
 } from '@/types/general';
@@ -113,8 +114,14 @@ export const sanitizePlatforms = (
   }
 };
 
-const isBuildError = (build: BuildsTabBuild): number => {
-  return build.valid || build.valid === null ? 0 : 1;
+const isBuildError = (build_valid: boolean | null): number => {
+  return build_valid || build_valid === null ? 0 : 1;
+};
+
+const getBuildStatus = (
+  build_valid: boolean | null,
+): AccordionItemBuilds['status'] => {
+  return build_valid === null ? 'null' : build_valid ? 'valid' : 'invalid';
 };
 
 export const sanitizeBuilds = (
@@ -131,8 +138,8 @@ export const sanitizeBuilds = (
     date: build.start_time,
     buildTime: build.duration,
     compiler: build.compiler === UNKNOWN_STRING ? undefined : build.compiler,
-    buildErrors: isBuildError(build),
-    status: build.valid === null ? 'null' : build.valid ? 'valid' : 'invalid',
+    buildErrors: isBuildError(build.valid),
+    status: getBuildStatus(build.valid),
     buildLogs: build.log_url,
     kernelConfig: build.config_url,
     kernelImage: build.misc ? build.misc['kernel_type'] : undefined,
@@ -140,6 +147,22 @@ export const sanitizeBuilds = (
     systemMap: build.misc ? build.misc['system_map'] : undefined,
     modules: build.misc ? build.misc['modules'] : undefined,
     treeBranch: `${sanitizeTableValue(build.tree_name)} / ${sanitizeTableValue(build.git_repository_branch)}`,
+  }));
+};
+
+export const sanitizeBuildTable = (
+  builds: BuildsTableBuild[],
+): AccordionItemBuilds[] => {
+  return builds.map(build => ({
+    id: build.id,
+    config: build.config_name,
+    architecture: build.architecture,
+    date: build.start_time,
+    buildTime: build.duration,
+    compiler: build.compiler,
+    buildErrors: isBuildError(build.valid),
+    status: getBuildStatus(build.valid),
+    buildLogs: build.log_url,
   }));
 };
 


### PR DESCRIPTION
Adds /issues/<issue_id>/version/<version>/tests endpoint to get all tests related to an issue
Adds /issues/<issue_id>/version/<version>/builds endpoint to get all builds related to an issue
Adds request for these endpoints from the frontend
Adds a SectionError component for when a table in a details page can't load and refactors its use in BuildDetailsTestSection
Adds a TestsTable to the IssueDetails page when the current issue is related to a test
Adds a BuildsTable to the IssueDetails page when the current issue is related to a test

The relation with tests and builds are intuitively mutually exclusive, but - since the database allows for both `test_status` and `build_valid` to be not null in a single issue - it is technically possible for an issue to be associated with tests and builds at the same time. There are no issues related to both tests and builds currently.

It's also possible for an issue to not be related with either tests or builds, but there are no occurrences of that for the maestro origin, only for redhat.

## How to test
Go to an IssueDetails page with an issue related to tests and see the test table, such as this example:
http://localhost:5173/issue/maestro%3Af627e08f767a688209f3f9a2d41c6b4c260897b0/version/0

Go to an IssueDetails page with an issue related to builds and see the builds table, such as this example:
http://localhost:5173/issue/maestro:a8ba4fd7ab9f996d9e569f77d5cf91354e7a783b/version/0

An issue with no relation to either tests or builds for example: http://localhost:5173/issue/redhat:issue_2089/version/1727692707

Closes #705