### PR TITLE
fix: show 'NULL' instead of nothing in status col

### DIFF
--- a/backend/kernelCI_app/typeModels/databases.py
+++ b/backend/kernelCI_app/typeModels/databases.py
@@ -1,0 +1,4 @@
+from typing import Literal
+
+# "NULL" must be added manually because the database return None
+type StatusValues = Literal["FAIL", "PASS", "SKIP", "ERROR", "MISS", "NULL"]

--- a/backend/kernelCI_app/typeModels/hardwareDetails.py
+++ b/backend/kernelCI_app/typeModels/hardwareDetails.py
@@ -1,6 +1,18 @@
-from pydantic import BaseModel, Field
-from typing import Dict, Optional, Union, List
 from datetime import datetime
+from typing import Annotated, Any, Dict, List, Optional, Union
+
+from kernelCI_app.typeModels.databases import StatusValues
+from pydantic import BaseModel, BeforeValidator, Field
+
+
+def process_status(value: Any) -> Any:
+    if value is None:
+        return "NULL"
+    return value
+
+
+class DefaultRecordValues(BaseModel):
+    status: Annotated[StatusValues, BeforeValidator(process_status)]
 
 
 class PostBody(BaseModel):

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -20,7 +20,7 @@ from kernelCI_app.helpers.misc import (
     handle_environment_misc,
     env_misc_value_or_default
 )
-from kernelCI_app.typeModels.hardwareDetails import PostBody
+from kernelCI_app.typeModels.hardwareDetails import PostBody, DefaultRecordValues
 from pydantic import ValidationError
 
 DEFAULT_DAYS_INTERVAL = 3
@@ -268,7 +268,7 @@ class HardwareDetails(View):
         return test_filter_pass
 
     def handle_test(self, record, tests):
-        status = record["status"] or "NULL"
+        status = record["status"]
 
         tests["history"].append(get_history(record))
         tests["statusSummary"][status] += 1
@@ -343,6 +343,11 @@ class HardwareDetails(View):
         builds = {"items": [], "issues": {}, "failedWithUnknownIssues": 0}
 
         for record in records:
+            try:
+                validatedRecord = DefaultRecordValues(**record)
+                record["status"] = validatedRecord.status
+            except ValidationError:
+                continue
             current_tree = get_record_tree(record, trees)
             if not current_tree:
                 log_message(f"Tree not found for record: {record}")


### PR DESCRIPTION
After further research, apparently the problem only existed in the boots table in hardware details. The can be seem in this page [Tests table showing 'NULL' status correctly](https://staging.dashboard.kernelci.org:9000/tree/0d7aea765c41401c36c9d0a1d039a2cf30df430e?currentPageTab=global.tests&treeInfo%7CcommitName=v6.13-rc3-4-g0d7aea765c41&treeInfo%7CgitBranch=for-kernelci&treeInfo%7CgitUrl=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fardb%2Flinux.git&treeInfo%7CheadCommitHash=0d7aea765c41401c36c9d0a1d039a2cf30df430e&treeInfo%7CtreeName=ardb), this page [Boots table showing 'NULL' status correctly](https://staging.dashboard.kernelci.org:9000/tree/e43857dccff0b7f2e13a9edf394f1283c116a4df?currentPageTab=global.boots&tableFilter%7CbootsTable=inconclusive&tableFilter%7CbuildsTable=all&tableFilter%7CtestsTable=all&treeInfo%7CcommitName=v6.13-rc1-52-ge43857dccff0&treeInfo%7CgitBranch=for-next&treeInfo%7CgitUrl=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fqcom%2Flinux.git&treeInfo%7CheadCommitHash=e43857dccff0b7f2e13a9edf394f1283c116a4df&treeInfo%7CtreeName=qcom) in the build table code in `src/components/BuildsTable/DefaultBuildsColumn.tsx` (since I couldn't find a tree or hardware that had Build with null status)

```js
    cell: ({ row }): string => {
      return row.getValue('status')
        ? row.getValue('status')!.toString().toUpperCase()
        : 'NULL';
    },
```

Here an example of the bug happening in the boots table for hardware details
- [Boots table in staging showing nothing](https://staging.dashboard.kernelci.org:9000/hardware/amlogic%2Ca311d?currentPageTab=global.boots&endTimestampInSeconds=1734982200&startTimestampInSeconds=1734550200&tableFilter%7CbootsTable=inconclusive&tableFilter%7CbuildsTable=all&tableFilter%7CtestsTable=all)
- [Boots table in localhost showing NULL](http://localhost:5173/hardware/amlogic%2Ca311d?currentPageTab=global.boots&endTimestampInSeconds=1734978600&startTimestampInSeconds=1734546600&tableFilter%7CbootsTable=inconclusive&tableFilter%7CbuildsTable=all&tableFilter%7CtestsTable=all)

This happens because in the TreeDetailsView there's already a process ensuring that `record["test_status"] = "NULL"` if status is null/None in the database, and HardwareDetailsView does not have the same processing being done.

Closes #714 

## Visual reference
Before
![image](https://github.com/user-attachments/assets/da7c516e-8fb3-4596-b732-adb8efe1bb80)

After
![image](https://github.com/user-attachments/assets/cfa28151-7835-4dc2-847a-0eae6f9ab718)
