### PR TITLE
Add latest tree data in route /<tree_name>/<branch>

### DIFF
--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class TreeLatestPathParameters(BaseModel):
+    tree_name: str
+    branch: str

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -36,6 +36,10 @@ urlpatterns = [
          viewCache(views.TreeCommitsHistory),
          name="treeCommits"
          ),
+    path("tree/<str:tree_name>/<str:branch>",
+         viewCache(views.TreeLatest),
+         name="treeLatest"
+         ),
     path("build/<str:build_id>",
          viewCache(views.BuildDetails),
          name="buildDetails"

--- a/backend/kernelCI_app/views/treeLatest.py
+++ b/backend/kernelCI_app/views/treeLatest.py
@@ -1,0 +1,83 @@
+from http import HTTPStatus
+from typing import Dict, Optional
+from urllib.parse import urlencode
+
+from django.http import JsonResponse
+from django.urls import reverse
+from django.views import View
+from pydantic import ValidationError
+
+from kernelCI_app.constants.general import DEFAULT_ORIGIN
+from kernelCI_app.helpers.errorHandling import create_error_response
+from kernelCI_app.models import Checkouts
+from kernelCI_app.typeModels.treeDetails import TreeLatestPathParameters
+
+
+class TreeLatest(View):
+    def _fetch_latest_tree(
+        self, tree_name: str, branch: str, origin: str
+    ) -> Optional[Dict]:
+        tree_fields = [
+            "git_commit_hash",
+            "git_commit_name",
+            "git_repository_url",
+        ]
+
+        query = (
+            Checkouts.objects.values(*tree_fields)
+            .filter(
+                origin=origin,
+                tree_name=tree_name,
+                git_repository_branch=branch,
+                git_commit_hash__isnull=False,
+            )
+            .order_by("-field_timestamp")
+            .first()
+        )
+
+        return query
+
+    def get(self, request, tree_name: str, branch: str) -> JsonResponse:
+        try:
+            parsed_params = TreeLatestPathParameters(tree_name=tree_name, branch=branch)
+        except ValidationError as e:
+            return create_error_response(e.json())
+
+        tree_not_found_error_message = "Tree not found."
+        origin = request.GET.get("origin")
+        if origin is None:
+            origin = DEFAULT_ORIGIN
+            tree_not_found_error_message += (
+                f" No origin was provided so it was defaulted to {DEFAULT_ORIGIN}"
+            )
+
+        tree_data = self._fetch_latest_tree(
+            tree_name=parsed_params.tree_name,
+            branch=parsed_params.branch,
+            origin=origin,
+        )
+
+        if tree_data is None:
+            return create_error_response(
+                error_message=tree_not_found_error_message,
+                status_code=HTTPStatus.NOT_FOUND,
+            )
+
+        base_url = reverse(
+            "treeDetailsView",
+            kwargs={"commit_hash": tree_data["git_commit_hash"]},
+        )
+
+        # TODO: Newer versions of django added (or will add) a parameter to `reverse`
+        # to pass the query parameters directly to it.
+        # You can see more here: https://github.com/django/django/pull/18848
+        # and here: https://code.djangoproject.com/ticket/25582#no1
+        query_params = {
+            "origin": origin,
+            "git_url": tree_data["git_repository_url"],
+            "git_branch": branch,
+        }
+        query_string = f"?{urlencode(query_params)}"
+
+        response_data = {**tree_data, "api_url": f"{base_url}{query_string}"}
+        return JsonResponse(response_data)

--- a/backend/requests/tree-latest-get.sh
+++ b/backend/requests/tree-latest-get.sh
@@ -1,0 +1,21 @@
+http 'http://localhost:8000/api/tree/android/android-mainline'
+
+# HTTP/1.1 200 OK
+# Cache-Control: max-age=0
+# Content-Length: 377
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Tue, 07 Jan 2025 16:42:56 GMT
+# Expires: Tue, 07 Jan 2025 16:42:56 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "api_url": "/api/tree/544ae1decdc3aede3d021ef1310d586f6383c30b/full?origin=maestro&git_url=https%3A%2F%2Fandroid.googlesource.com%2Fkernel%2Fcommon&git_branch=android-mainline",
+#     "git_commit_hash": "544ae1decdc3aede3d021ef1310d586f6383c30b",
+#     "git_commit_name": "ASB-2024-12-05_mainline-227-g544ae1decdc3",
+#     "git_repository_url": "https://android.googlesource.com/kernel/common"
+# }

--- a/dashboard/src/api/tree.ts
+++ b/dashboard/src/api/tree.ts
@@ -3,7 +3,12 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useSearch } from '@tanstack/react-router';
 
-import type { Tree, TreeFastPathResponse } from '@/types/tree/Tree';
+import type {
+  Tree,
+  TreeFastPathResponse,
+  TreeLatestResponse,
+} from '@/types/tree/Tree';
+import { DEFAULT_ORIGIN, type TOrigins } from '@/types/general';
 
 import http from './api';
 
@@ -51,5 +56,27 @@ export const useTreeTableFast = (): UseQueryResult<TreeFastPathResponse> => {
   return useQuery({
     queryKey,
     queryFn: () => fetchTreeFastCheckoutData(origin, intervalInDays),
+  });
+};
+
+const fetchTreeLatest = async (
+  treeName: string,
+  branch: string,
+  origin?: TOrigins,
+): Promise<TreeLatestResponse> => {
+  const res = await http.get(`/api/tree/${treeName}/${branch}`, {
+    params: { origin: origin || DEFAULT_ORIGIN },
+  });
+  return res.data;
+};
+
+export const useTreeLatest = (
+  treeName: string,
+  branch: string,
+  origin?: TOrigins,
+): UseQueryResult<TreeLatestResponse> => {
+  return useQuery({
+    queryKey: ['treeLatest', treeName, branch, origin],
+    queryFn: () => fetchTreeLatest(treeName, branch, origin),
   });
 };

--- a/dashboard/src/pages/TreeLatest.tsx
+++ b/dashboard/src/pages/TreeLatest.tsx
@@ -1,0 +1,59 @@
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+
+import { FormattedMessage } from 'react-intl';
+
+import { useTreeLatest } from '@/api/tree';
+
+import {
+  defaultValidadorValues,
+  zTableFilterInfoDefault,
+} from '@/types/tree/TreeDetails';
+
+import { DEFAULT_DIFF_FILTER } from '@/types/general';
+
+import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+import { Skeleton } from '@/components/Skeleton';
+
+export const TreeLatest = (): JSX.Element | void => {
+  const searchParams = useSearch({ from: '/tree/$treeName/$branch/' });
+  const navigate = useNavigate();
+  const { treeName, branch } = useParams({ from: '/tree/$treeName/$branch/' });
+  const { isLoading, data, error } = useTreeLatest(
+    treeName,
+    branch,
+    searchParams.origin,
+  );
+
+  if (data) {
+    navigate({
+      to: '/tree/$treeId',
+      params: { treeId: data.git_commit_hash },
+      search: {
+        ...searchParams,
+        currentPageTab: defaultValidadorValues.tab,
+        diffFilter: DEFAULT_DIFF_FILTER,
+        tableFilter: zTableFilterInfoDefault,
+        treeInfo: {
+          gitBranch: branch,
+          gitUrl: data.git_repository_url || undefined,
+          treeName: treeName,
+          commitName: data.git_commit_name || undefined,
+          headCommitHash: data.git_commit_hash,
+        },
+      },
+    });
+  } else if (isLoading) {
+    return (
+      <Skeleton>
+        <FormattedMessage id="global.loading" />
+      </Skeleton>
+    );
+  } else {
+    return (
+      <MemoizedSectionError
+        isLoading={isLoading}
+        errorMessage={error?.message}
+      />
+    );
+  }
+};

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as HardwareRouteImport } from './routes/hardware/route'
 import { Route as IndexImport } from './routes/index'
 import { Route as TreeIndexImport } from './routes/tree/index'
 import { Route as HardwareIndexImport } from './routes/hardware/index'
+import { Route as TreeTreeNameRouteImport } from './routes/tree/$treeName/route'
 import { Route as TreeTreeIdRouteImport } from './routes/tree/$treeId/route'
 import { Route as TestTestIdRouteImport } from './routes/test/$testId/route'
 import { Route as HardwareHardwareIdRouteImport } from './routes/hardware/$hardwareId/route'
@@ -27,6 +28,7 @@ import { Route as BuildBuildIdIndexImport } from './routes/build/$buildId/index'
 import { Route as HardwareHardwareIdTestRouteImport } from './routes/hardware/$hardwareId/test/route'
 import { Route as HardwareHardwareIdBuildRouteImport } from './routes/hardware/$hardwareId/build/route'
 import { Route as HardwareHardwareIdBootRouteImport } from './routes/hardware/$hardwareId/boot/route'
+import { Route as TreeTreeNameBranchIndexImport } from './routes/tree/$treeName/$branch/index'
 import { Route as HardwareHardwareIdTestIndexImport } from './routes/hardware/$hardwareId/test/index'
 import { Route as HardwareHardwareIdBuildIndexImport } from './routes/hardware/$hardwareId/build/index'
 import { Route as HardwareHardwareIdBootIndexImport } from './routes/hardware/$hardwareId/boot/index'
@@ -64,6 +66,11 @@ const TreeIndexRoute = TreeIndexImport.update({
 const HardwareIndexRoute = HardwareIndexImport.update({
   path: '/',
   getParentRoute: () => HardwareRouteRoute,
+} as any)
+
+const TreeTreeNameRouteRoute = TreeTreeNameRouteImport.update({
+  path: '/$treeName',
+  getParentRoute: () => TreeRouteRoute,
 } as any)
 
 const TreeTreeIdRouteRoute = TreeTreeIdRouteImport.update({
@@ -123,6 +130,11 @@ const HardwareHardwareIdBootRouteRoute =
     path: '/boot',
     getParentRoute: () => HardwareHardwareIdRouteRoute,
   } as any)
+
+const TreeTreeNameBranchIndexRoute = TreeTreeNameBranchIndexImport.update({
+  path: '/$branch/',
+  getParentRoute: () => TreeTreeNameRouteRoute,
+} as any)
 
 const HardwareHardwareIdTestIndexRoute =
   HardwareHardwareIdTestIndexImport.update({
@@ -241,6 +253,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TreeTreeIdRouteImport
       parentRoute: typeof TreeRouteImport
     }
+    '/tree/$treeName': {
+      id: '/tree/$treeName'
+      path: '/$treeName'
+      fullPath: '/tree/$treeName'
+      preLoaderRoute: typeof TreeTreeNameRouteImport
+      parentRoute: typeof TreeRouteImport
+    }
     '/hardware/': {
       id: '/hardware/'
       path: '/'
@@ -339,6 +358,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof HardwareHardwareIdTestIndexImport
       parentRoute: typeof HardwareHardwareIdTestRouteImport
     }
+    '/tree/$treeName/$branch/': {
+      id: '/tree/$treeName/$branch/'
+      path: '/$branch'
+      fullPath: '/tree/$treeName/$branch'
+      preLoaderRoute: typeof TreeTreeNameBranchIndexImport
+      parentRoute: typeof TreeTreeNameRouteImport
+    }
     '/hardware/$hardwareId/boot/$bootId/': {
       id: '/hardware/$hardwareId/boot/$bootId/'
       path: '/$bootId'
@@ -418,6 +444,9 @@ export const routeTree = rootRoute.addChildren({
         }),
       TreeTreeIdBuildBuildIdIndexRoute,
     }),
+    TreeTreeNameRouteRoute: TreeTreeNameRouteRoute.addChildren({
+      TreeTreeNameBranchIndexRoute,
+    }),
     TreeIndexRoute,
   }),
   BuildBuildIdRouteRoute: BuildBuildIdRouteRoute.addChildren({
@@ -462,6 +491,7 @@ export const routeTree = rootRoute.addChildren({
       "filePath": "tree/route.tsx",
       "children": [
         "/tree/$treeId",
+        "/tree/$treeName",
         "/tree/"
       ]
     },
@@ -494,6 +524,13 @@ export const routeTree = rootRoute.addChildren({
         "/tree/$treeId/",
         "/tree/$treeId/test/$testId",
         "/tree/$treeId/build/$buildId/"
+      ]
+    },
+    "/tree/$treeName": {
+      "filePath": "tree/$treeName/route.tsx",
+      "parent": "/tree",
+      "children": [
+        "/tree/$treeName/$branch/"
       ]
     },
     "/hardware/": {
@@ -568,6 +605,10 @@ export const routeTree = rootRoute.addChildren({
     "/hardware/$hardwareId/test/": {
       "filePath": "hardware/$hardwareId/test/index.tsx",
       "parent": "/hardware/$hardwareId/test"
+    },
+    "/tree/$treeName/$branch/": {
+      "filePath": "tree/$treeName/$branch/index.tsx",
+      "parent": "/tree/$treeName"
     },
     "/hardware/$hardwareId/boot/$bootId/": {
       "filePath": "hardware/$hardwareId/boot/$bootId/index.tsx",

--- a/dashboard/src/routes/tree/$treeName/$branch/index.tsx
+++ b/dashboard/src/routes/tree/$treeName/$branch/index.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { TreeLatest } from '@/pages/TreeLatest';
+
+export const Route = createFileRoute('/tree/$treeName/$branch/')({
+  component: TreeLatest,
+});

--- a/dashboard/src/routes/tree/$treeName/route.tsx
+++ b/dashboard/src/routes/tree/$treeName/route.tsx
@@ -1,0 +1,3 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/tree/$treeName')();

--- a/dashboard/src/types/tree/Tree.tsx
+++ b/dashboard/src/types/tree/Tree.tsx
@@ -72,3 +72,10 @@ export type Tree = {
     miss: number;
   };
 };
+
+export type TreeLatestResponse = {
+  api_url: string;
+  git_commit_hash: string;
+  git_repository_url: string | null;
+  git_commit_name: string | null;
+};


### PR DESCRIPTION
Add a new route `/<tree-name>/<branch>` that redirects to the TreeDetails for the latest checkout of the tree.

Closes #675 

## How to test
- To go `localhost:5173/<tree-name>/<branch>` for a valid `<tree-name>` and `<branch>` and see if it correctly redirects to the TreeDetails page. For example: http://localhost:5173/tree/android/android-mainline
- To go `localhost:5173/<tree-name>/<branch>` for an invalid `<tree-name>` and/or `<branch>` and see if it correctly shows an error message. For example: http://localhost:5173/tree/android/invalid-branch