### PR TITLE
fix: sticky not working on top bar

### DIFF
--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -32,7 +32,7 @@ export const Route = createRootRoute({
         <div className="flex w-full flex-row justify-between">
           <SideMenu />
           <TopBar />
-          <div className="w-full overflow-x-auto bg-lightGray px-16 pt-24">
+          <div className="w-full bg-lightGray px-16 pt-24">
             <Outlet />
           </div>
         </div>


### PR DESCRIPTION
overflow-x-auto was being used to create a blocking formatting context
to contain everything inside the div as much as possible
but as unintended side effects it broke our position sticky

we have a ticket to properly create a mobile layout in #324, let's remove the
hack here and leave the ticket for that

Closes #726
