### PR TITLE
feat: minify URL query parameters

### DIFF
--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -1,10 +1,10 @@
+import { z } from 'zod';
+
 import {
   createRootRoute,
   Outlet,
   stripSearchParams,
 } from '@tanstack/react-router';
-
-import { z } from 'zod';
 
 // Uncomment for TanStack Router  devtools
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import SideMenu from '@/components/SideMenu/SideMenu';
 import TopBar from '@/components/TopBar/TopBar';
 
-import { DEFAULT_ORIGIN, zOrigin } from '@/types/general';
+import { DEFAULT_ORIGIN, type SearchSchema, zOrigin } from '@/types/general';
 
 const defaultValues = {
   origin: DEFAULT_ORIGIN,
@@ -21,7 +21,7 @@ const defaultValues = {
 
 const RouteSchema = z.object({
   origin: zOrigin,
-});
+} satisfies SearchSchema);
 
 export const Route = createRootRoute({
   validateSearch: RouteSchema,

--- a/dashboard/src/routes/build/$buildId/route.tsx
+++ b/dashboard/src/routes/build/$buildId/route.tsx
@@ -7,7 +7,11 @@ import {
   zTableFilterInfoDefault,
   zTableFilterInfoValidator,
 } from '@/types/tree/TreeDetails';
-import { DEFAULT_DIFF_FILTER, DEFAULT_ORIGIN } from '@/types/general';
+import {
+  DEFAULT_DIFF_FILTER,
+  DEFAULT_ORIGIN,
+  type SearchSchema,
+} from '@/types/general';
 import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
 
 const defaultValues = {
@@ -24,7 +28,7 @@ const defaultValues = {
 
 const buildDetailsSearchSchema = z.object({
   tableFilter: zTableFilterInfoValidator,
-});
+} satisfies SearchSchema);
 
 export const Route = createFileRoute('/build/$buildId')({
   validateSearch: buildDetailsSearchSchema,

--- a/dashboard/src/routes/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/hardware/$hardwareId/route.tsx
@@ -10,7 +10,11 @@ import {
 } from '@/types/tree/TreeDetails';
 
 import { zTreeCommits } from '@/types/hardware/hardwareDetails';
-import { DEFAULT_DIFF_FILTER, zDiffFilter } from '@/types/general';
+import {
+  DEFAULT_DIFF_FILTER,
+  type SearchSchema,
+  zDiffFilter,
+} from '@/types/general';
 
 const defaultValues = {
   currentPageTab: defaultValidadorValues.tab,
@@ -27,7 +31,7 @@ const hardwareDetailsSearchSchema = z.object({
   startTimestampInSeconds: z.number(),
   endTimestampInSeconds: z.number(),
   diffFilter: zDiffFilter,
-});
+} satisfies SearchSchema);
 
 export const Route = createFileRoute('/hardware/$hardwareId')({
   validateSearch: hardwareDetailsSearchSchema,

--- a/dashboard/src/routes/hardware/route.tsx
+++ b/dashboard/src/routes/hardware/route.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 import { z } from 'zod';
 
-import { makeZIntervalInDays } from '@/types/general';
+import { makeZIntervalInDays, type SearchSchema } from '@/types/general';
 import { DEFAULT_HARDWARE_INTERVAL_IN_DAYS } from '@/utils/constants/hardware';
 
 const defaultValues = {
@@ -12,7 +12,7 @@ const defaultValues = {
 const zHardwareSchema = z.object({
   intervalInDays: makeZIntervalInDays(DEFAULT_HARDWARE_INTERVAL_IN_DAYS),
   hardwareSearch: z.string().catch(''),
-});
+} satisfies SearchSchema);
 
 export const Route = createFileRoute('/hardware')({
   validateSearch: zHardwareSchema,

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -2,12 +2,12 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
-import { makeZIntervalInDays } from '@/types/general';
+import { makeZIntervalInDays, type SearchSchema } from '@/types/general';
 
 export const HomeSearchSchema = z.object({
   treeSearch: z.string().catch(''),
   intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
-});
+} satisfies SearchSchema);
 
 export const Route = createFileRoute('/')({
   validateSearch: HomeSearchSchema,

--- a/dashboard/src/routes/issue/$issueId/version/$versionNumber/route.tsx
+++ b/dashboard/src/routes/issue/$issueId/version/$versionNumber/route.tsx
@@ -7,7 +7,11 @@ import {
   zTableFilterInfoDefault,
   zTableFilterInfoValidator,
 } from '@/types/tree/TreeDetails';
-import { DEFAULT_DIFF_FILTER, DEFAULT_ORIGIN } from '@/types/general';
+import {
+  DEFAULT_DIFF_FILTER,
+  DEFAULT_ORIGIN,
+  type SearchSchema,
+} from '@/types/general';
 import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
 
 const defaultValues = {
@@ -24,7 +28,7 @@ const defaultValues = {
 
 const issueDetailsSearchSchema = z.object({
   tableFilter: zTableFilterInfoValidator,
-});
+} satisfies SearchSchema);
 
 export const Route = createFileRoute('/issue/$issueId/version/$versionNumber')({
   validateSearch: issueDetailsSearchSchema,

--- a/dashboard/src/routes/test/$testId/route.tsx
+++ b/dashboard/src/routes/test/$testId/route.tsx
@@ -6,7 +6,11 @@ import {
   defaultValidadorValues,
   zTableFilterInfoDefault,
 } from '@/types/tree/TreeDetails';
-import { DEFAULT_DIFF_FILTER, DEFAULT_ORIGIN } from '@/types/general';
+import {
+  DEFAULT_DIFF_FILTER,
+  DEFAULT_ORIGIN,
+  type SearchSchema,
+} from '@/types/general';
 import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
 
 const defaultValues = {
@@ -21,7 +25,7 @@ const defaultValues = {
   treeCommits: {},
 };
 
-const testDetailsSearchSchema = z.object({});
+const testDetailsSearchSchema = z.object({} satisfies SearchSchema);
 
 export const Route = createFileRoute('/test/$testId')({
   validateSearch: testDetailsSearchSchema,

--- a/dashboard/src/routes/tree/$treeId/route.tsx
+++ b/dashboard/src/routes/tree/$treeId/route.tsx
@@ -1,10 +1,11 @@
-import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
-
 import { z } from 'zod';
+
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import {
   DEFAULT_DIFF_FILTER,
   DEFAULT_ORIGIN,
+  type SearchSchema,
   zDiffFilter,
   zOrigin,
 } from '@/types/general';
@@ -32,7 +33,7 @@ const treeDetailsSearchSchema = z.object({
   treeInfo: zTreeInformation,
   currentPageTab: zPossibleTabValidator,
   tableFilter: zTableFilterInfoValidator,
-});
+} satisfies SearchSchema);
 
 export const Route = createFileRoute('/tree/$treeId')({
   validateSearch: treeDetailsSearchSchema,

--- a/dashboard/src/routes/tree/route.tsx
+++ b/dashboard/src/routes/tree/route.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
-import { makeZIntervalInDays } from '@/types/general';
+import { makeZIntervalInDays, type SearchSchema } from '@/types/general';
 import { DEFAULT_TIME_SEARCH } from '@/pages/treeConstants';
 
 const defaultValues = {
@@ -13,7 +13,7 @@ const defaultValues = {
 export const RootSearchSchema = z.object({
   intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
   treeSearch: z.string().catch(''),
-});
+} satisfies SearchSchema);
 
 export const Route = createFileRoute('/tree')({
   validateSearch: RootSearchSchema,

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -217,6 +217,20 @@ export const isTFilterNumberKeys = (key: string): key is TFilterNumberKeys => {
   return zFilterNumberKeys.safeParse(key).success;
 };
 
+export type SearchParamsKeys =
+  | 'origin'
+  | 'intervalInDays'
+  | 'currentPageTab'
+  | 'tableFilter'
+  | 'diffFilter'
+  | 'treeSearch'
+  | 'hardwareSearch'
+  | 'treeInfo'
+  | 'treeIndexes'
+  | 'treeCommits'
+  | 'startTimestampInSeconds'
+  | 'endTimestampInSeconds';
+
 const requestFilters = {
   hardwareDetails: [
     'hardwareDetails.trees',

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z, type ZodTypeAny } from 'zod';
 
 import type { Status } from './database';
 import type { TTreeDetailsFilter } from './tree/TreeDetails';
@@ -230,6 +230,7 @@ export type SearchParamsKeys =
   | 'treeCommits'
   | 'startTimestampInSeconds'
   | 'endTimestampInSeconds';
+export type SearchSchema = Partial<Record<SearchParamsKeys, ZodTypeAny>>;
 
 const requestFilters = {
   hardwareDetails: [

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -157,14 +157,14 @@ export const zTableFilterInfoValidator = zTableFilterInfo
 export type TableFilter = z.infer<typeof zTableFilterInfo>;
 
 export const DEFAULT_TREE_INFO = {};
-export const zTreeInformation = z
-  .object({
-    gitBranch: z.string().optional().catch(''),
-    gitUrl: z.string().optional().catch(''),
-    treeName: z.string().optional().catch(''),
-    commitName: z.string().optional().catch(''),
-    headCommitHash: z.string().optional().catch(undefined),
-  })
+export const zTreeInformationObject = z.object({
+  gitBranch: z.string().optional().catch(''),
+  gitUrl: z.string().optional().catch(''),
+  treeName: z.string().optional().catch(''),
+  commitName: z.string().optional().catch(''),
+  headCommitHash: z.string().optional().catch(undefined),
+});
+export const zTreeInformation = zTreeInformationObject
   .default(DEFAULT_TREE_INFO)
   .catch(DEFAULT_TREE_INFO);
 

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -96,7 +96,11 @@ export type TTreeTestsFullData = {
   treeUrl: string;
 };
 
-const possibleTabs = ['global.builds', 'global.boots', 'global.tests'] as const;
+export const possibleTabs = [
+  'global.builds',
+  'global.boots',
+  'global.tests',
+] as const;
 
 export const possibleBuildsTableFilter = [
   'invalid',
@@ -167,6 +171,8 @@ export const zTreeInformationObject = z.object({
 export const zTreeInformation = zTreeInformationObject
   .default(DEFAULT_TREE_INFO)
   .catch(DEFAULT_TREE_INFO);
+
+export type TTreeInformation = z.infer<typeof zTreeInformation>;
 
 export type TestByCommitHash = {
   id: string;


### PR DESCRIPTION
- Added the object `minifiedParams` to map all the params to their minified forms.
- Added the function `minifyParmas` that return a object with the params minified based on the object `minifiedParams`
- Added the object `groupedMinifiedParams` that divide the minified params in five groups based on the depth of the nested objects in searchParams: general, df (for DiffFilter nested object), ti (for TreeInfo nested object), tf (for TableFilter nested object) and value (for minified values instead of keys). This was required to identify different attributes that were minified to the same value (e.g. 't' for treeInfo.treeName, TableFilter.testsTable and diffFilter.trees)
- Added the function `unminifyParams` that return a object with the original param names based on the object `groupedMinfiedParams`.
- Added `minifyParams` to `stringifySearch` so the processing steps are minify -> flatten -> stringify
- Added `unminifyParams` to `parseSearch` so the processing steps are parse -> unflatten -> unminify
- Added tests for the new functions and changed tests for the old functions

Minifying values instead of just keys might be a sensitive action that should be closely observed.

Closes https://github.com/kernelci/dashboard/issues/725

## How to test
- Run `pnpm test` to guarantee all the unit tests are passed.
- Navigate through the application, changing values that are stored in the query parameters (e.g. origin, interval in days and filters).
- Try to enter links directly instead of navigating to the pages to guarantee they are working.