### PR TITLE
Fix: builds and tests details related to unexistent build/checkout

### DIFF
--- a/backend/kernelCI_app/views/testDetailsView.py
+++ b/backend/kernelCI_app/views/testDetailsView.py
@@ -46,9 +46,9 @@ class TestDetails(View):
                 checkouts.git_repository_branch,
                 checkouts.git_repository_url
             FROM tests
-            INNER JOIN builds
+            LEFT JOIN builds
                 ON tests.build_id = builds.id
-            INNER JOIN checkouts
+            LEFT JOIN checkouts
                 ON builds.checkout_id = checkouts.id
             WHERE tests.id = %s
             """

--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -17,7 +17,7 @@ import { formatDate } from '@/utils/utils';
 
 import IssueSection from '@/components/Issue/IssueSection';
 
-import { valueOrEmpty } from '@/lib/string';
+import { shouldTruncate, valueOrEmpty } from '@/lib/string';
 
 import { Sheet, SheetTrigger } from '@/components/Sheet';
 
@@ -97,22 +97,30 @@ const BuildDetails = ({
               {
                 title: 'global.tree',
                 linkText: valueOrEmpty(data.tree_name),
-                icon: <ImTree className="text-blue" />,
+                icon: data.tree_name ? (
+                  <ImTree className="text-blue" />
+                ) : undefined,
               },
               {
                 title: 'buildDetails.gitUrl',
-                linkText: (
+                linkText: shouldTruncate(
+                  valueOrEmpty(data.git_repository_url),
+                ) ? (
                   <TruncatedValueTooltip
                     value={data.git_repository_url}
                     isUrl={true}
                   />
+                ) : (
+                  <span>{valueOrEmpty(data.git_repository_url)}</span>
                 ),
                 link: data.git_repository_url,
               },
               {
                 title: 'buildDetails.gitBranch',
                 linkText: valueOrEmpty(data.git_repository_branch),
-                icon: <ImTree className="text-blue" />,
+                icon: data.git_repository_branch ? (
+                  <ImTree className="text-blue" />
+                ) : undefined,
               },
               {
                 title: 'buildDetails.gitCommit',

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -85,7 +85,9 @@ const TestDetailsSections = ({ test }: { test: TTestDetails }): JSX.Element => {
             {
               title: 'global.arch',
               linkText: valueOrEmpty(test.architecture),
-              icon: <PiComputerTowerThin className="text-blue" />,
+              icon: test.architecture ? (
+                <PiComputerTowerThin className="text-blue" />
+              ) : undefined,
             },
             {
               title: 'global.compiler',
@@ -109,13 +111,15 @@ const TestDetailsSections = ({ test }: { test: TTestDetails }): JSX.Element => {
             },
             {
               title: 'testDetails.gitRepositoryUrl',
-              linkText: shouldTruncate(test.git_repository_url) ? (
+              linkText: shouldTruncate(
+                valueOrEmpty(test.git_repository_url),
+              ) ? (
                 <TruncatedValueTooltip
                   value={test.git_repository_url}
                   isUrl={true}
                 />
               ) : (
-                test.git_repository_url
+                valueOrEmpty(test.git_repository_url)
               ),
               link: test.git_repository_url,
             },


### PR DESCRIPTION
Fixes test details pages that are related to unexistent builds using left joins and default values
Simple refactors to the build details page to make it tidier

The bug for the buildDetails page was fixed at https://github.com/kernelci/dashboard/pull/730/commits/95700d306f38499c7534620c3b9f9d2dd11d251f by the use of the left join - that build is related to an unexistent checkout

## How to test
Go to http://localhost:5173/build/maestro%3A673f7646923416c0c98d2796 (build with unexistent checkout) and see that it still works, compare to https://dashboard.kernelci.org/build/maestro%3A673f7646923416c0c98d2796
Go to http://localhost:5173/test/maestro%3A674a3a4c069b6571df5af400 (test with unexistent build) and see that it still works, compare to https://staging.dashboard.kernelci.org:9000/test/maestro%3A674a3a4c069b6571df5af400

Closes #736 