### PR TITLE
Feat: get independent issues incidents

### DIFF
--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -50,6 +50,7 @@ export const IssueDetails = ({
 
   const hasTest = data && data.test_status !== null;
   const hasBuild = data && data.build_valid !== null;
+  const hasNothingIdentified = !hasTest && !hasBuild;
 
   const { formatMessage } = useIntl();
 
@@ -163,7 +164,7 @@ export const IssueDetails = ({
     <ErrorBoundary FallbackComponent={UnexpectedError}>
       {breadcrumb}
       <SectionGroup sections={sectionsData} />
-      {hasTest && (
+      {(hasTest || hasNothingIdentified) && (
         <IssueDetailsTestSection
           issueId={issueId}
           versionNumber={versionNumber}
@@ -172,7 +173,7 @@ export const IssueDetails = ({
           onClickFilter={onClickTestFilter}
         />
       )}
-      {hasBuild && (
+      {(hasBuild || hasNothingIdentified) && (
         <IssueDetailsBuildSection
           issueId={issueId}
           versionNumber={versionNumber}

--- a/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
@@ -46,6 +46,10 @@ export const IssueDetailsBuildSection = ({
     return sanitizeBuildTable(data);
   }, [data]);
 
+  if (!isLoading && data?.length === 0) {
+    return <></>;
+  }
+
   return (
     <>
       <h2 className="text-2xl font-bold">

--- a/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
@@ -30,6 +30,10 @@ export const IssueDetailsTestSection = ({
   );
   const { formatMessage } = useIntl();
 
+  if (!isLoading && data?.length === 0) {
+    return <></>;
+  }
+
   return (
     <>
       <h2 className="text-2xl font-bold">


### PR DESCRIPTION
Whenever an issue has its `build_valid` and `test_status` as null (I'm calling it an independent issue, but that's not an official name) it still may have incidents. So this PR makes it so that if an issue is independent it tries to get both tests and builds data (since it's not possible to tell to which one it is related to without another query anyway)

## How to test:
Example of an independent issue with build incidents: http://localhost:5173/issue/redhat%3Aissue_3332/version/1733923991
Example of an independent issue with test incidents: http://localhost:5173/issue/redhat%3Aissue_3137/version/1727863073
Example of an independent issue with no incidents: http://localhost:5173/issue/redhat:issue_2770/version/1725465507
Example of a tree with a build that has an incident of an independent issue: http://localhost:5173/tree/b5cf67a8f716afbd7f8416edfe898c2df460811a?o=redhat&ti%7Cc=v6.13-rc5-199-gb5cf67a8f716&ti%7Cch=b5cf67a8f716afbd7f8416edfe898c2df460811a&ti%7Cgb=main&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fnetfilter%2Fnf.git&ti%7Ct=upstream-nf

Closes #733