### PR TITLE
Fix: issue card count

### DIFF
--- a/backend/kernelCI_app/typeModels/issueDetails.py
+++ b/backend/kernelCI_app/typeModels/issueDetails.py
@@ -1,6 +1,11 @@
+from typing import Dict, Tuple
+from kernelCI_app.utils import Issue
 from pydantic import BaseModel
 
 
 class IssueDetailsPathParameters(BaseModel):
     issue_id: str
     version: int
+
+
+type IssueDict = Dict[Tuple[str, str], Issue]

--- a/backend/kernelCI_app/unitTests/treeDetails.test.py
+++ b/backend/kernelCI_app/unitTests/treeDetails.test.py
@@ -1,0 +1,32 @@
+import unittest
+from kernelCI_app.helpers.filters import should_filter_test_issue, UNKNOWN_STRING
+
+
+# TODO: replace with pytest
+class TestShouldFilterTestIssue(unittest.TestCase):
+
+    def test_no_issue_filters(self):
+        self.assertFalse(
+            should_filter_test_issue(set(), UNKNOWN_STRING, "incident_test_1", "FAIL")
+        )
+
+    def test_unknown_filter_with_exclusively_build_issue(self):
+        self.assertTrue(
+            should_filter_test_issue(
+                {UNKNOWN_STRING}, "issue1", "incident_test_1", "PASS"
+            )
+        )
+
+    def test_unknown_issue_but_not_from_test(self):
+        self.assertFalse(
+            should_filter_test_issue(
+                {UNKNOWN_STRING},
+                "maestro:72697a4efbbd0eff7080781839b405bbf0902f79",
+                None,
+                "FAIL",
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -19,7 +19,7 @@ from kernelCI_app.utils import getErrorResponseBody
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 # TODO Move this endpoint to a function so it doesn't
@@ -106,10 +106,14 @@ class TreeCommitsHistory(APIView):
         build_valid: bool,
         duration: int,
         commit_hash: str,
-        issue_id: str
+        issue_id: str,
+        incident_test_id: Optional[str],
     ) -> None:
         is_filtered_out = self.filterParams.is_build_filtered_out(
-            duration=duration, valid=build_valid, issue_id=issue_id
+            duration=duration,
+            valid=build_valid,
+            issue_id=issue_id,
+            incident_test_id=incident_test_id,
         )
         if is_filtered_out:
             return
@@ -262,7 +266,8 @@ class TreeCommitsHistory(APIView):
                 build_valid=row["build_valid"],
                 duration=row["build_duration"],
                 commit_hash=commit_hash,
-                issue_id=row['issue_id']
+                issue_id=row['issue_id'],
+                incident_test_id=row['incidents_test_id']
             )
 
     def _is_record_in_time_period(self, start_time: datetime) -> bool:

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import List
 from django.http import JsonResponse
 from http import HTTPStatus
 from django.views import View
@@ -32,7 +32,7 @@ from collections import defaultdict
 
 from kernelCI_app.viewCommon import create_details_build_summary
 
-type IssueDict = Dict[Tuple[str, str], Issue]
+from kernelCI_app.typeModels.issueDetails import IssueDict
 
 
 class TreeDetails(View):


### PR DESCRIPTION
- Fixes a behavior where some build issues were listed in the issues card of the tests tab and vice-versa.
- Makes testDetails and buildDetails show different entries for issues with different versions. This also fixes some issues that were being counted from the versions but which weren't present in the tests/builds
- Adds unit tests for the `should_filter_test_issue`


There were tests which were related to a build that had an issue, and since the test failed, there were the right conditions to think that the issue should be incremented in the test issue list. Failed or inconclusive builds with a test that had an issue were also considering that issue as if they were build issues.

## How to test
For the tests tab, go to this [localhost example](http://localhost:5173/tree/3ea7cd6069be582be5569600fd5b9f540df63471?currentPageTab=global.tests&diffFilter|testIssue|maestro%3A72697a4efbbd0eff7080781839b405bbf0902f79=true&treeInfo|commitName=v5.19-10992-g3ea7cd6069be&treeInfo|gitBranch=linus-next&treeInfo|gitUrl=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fsashal%2Flinus-next.git&treeInfo|headCommitHash=3ea7cd6069be582be5569600fd5b9f540df63471&treeInfo|treeName=sashal-next) and compare with [staging](https://staging.dashboard.kernelci.org:9000/tree/3ea7cd6069be582be5569600fd5b9f540df63471?currentPageTab=global.tests&diffFilter%7CtestIssue%7Cmaestro%3A72697a4efbbd0eff7080781839b405bbf0902f79=true&treeInfo%7CcommitName=v5.19-10992-g3ea7cd6069be&treeInfo%7CgitBranch=linus-next&treeInfo%7CgitUrl=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fsashal%2Flinus-next.git&treeInfo%7CheadCommitHash=3ea7cd6069be582be5569600fd5b9f540df63471&treeInfo%7CtreeName=sashal-next)
(in this tree you can also see the fix of when an issue is listed because of its issue_id but without considering the issue_verion in the tests tab, which you can also compare with staging)

For the builds tab, go to this [localhost example](http://localhost:5173/tree/424f7e5260bb76ab91d8f6ec4ff4a0b83e5e4b1d?diffFilter|buildIssue|redhat%3Aissue_3132=true&origin=redhat&tableFilter|bootsTable=all&tableFilter|buildsTable=invalid&tableFilter|testsTable=all&treeInfo|commitName=kernel-6.12.0-0.rc1.e32cde8d2bd7.18&treeInfo|gitBranch=ark-latest&treeInfo|gitUrl=https%3A%2F%2Fgitlab.com%2Fcki-project%2Fkernel-ark.git&treeInfo|headCommitHash=424f7e5260bb76ab91d8f6ec4ff4a0b83e5e4b1d&treeInfo|treeName=c10s) and compare with [staging](https://staging.dashboard.kernelci.org:9000/tree/424f7e5260bb76ab91d8f6ec4ff4a0b83e5e4b1d?diffFilter%7CbuildIssue%7Credhat%3Aissue_3132=true&origin=redhat&tableFilter%7CbootsTable=all&tableFilter%7CbuildsTable=invalid&tableFilter%7CtestsTable=all&treeInfo%7CcommitName=kernel-6.12.0-0.rc1.e32cde8d2bd7.18&treeInfo%7CgitBranch=ark-latest&treeInfo%7CgitUrl=https%3A%2F%2Fgitlab.com%2Fcki-project%2Fkernel-ark.git&treeInfo%7CheadCommitHash=424f7e5260bb76ab91d8f6ec4ff4a0b83e5e4b1d&treeInfo%7CtreeName=c10s)

Closes #728