### PR TITLE
Fix: Inconclusive test counts

### DIFF
--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -16,6 +16,7 @@ from kernelCI_app.helpers.misc import (
     env_misc_value_or_default,
 )
 from kernelCI_app.cache import getQueryCache, setQueryCache
+from kernelCI_app.utils import is_boot
 from django.db import connection
 
 
@@ -231,9 +232,7 @@ def get_hardware_filter(row_data: dict) -> Any:
 
 def is_test_boots_test(row_data: dict) -> bool:
     test_path = row_data["test_path"]
-    if test_path.startswith("boot"):
-        return True
-    return False
+    return is_boot(test_path)
 
 
 def get_build(row_data: dict) -> dict:

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -72,3 +72,7 @@ def string_to_json(string: str) -> Optional[dict]:
         except json.JSONDecodeError as e:
             log_message(e.msg)
             return None
+
+
+def is_boot(path: str | None) -> bool:
+    return path is not None and (path == "boot" or path.startswith("boot."))

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -15,7 +15,7 @@ from kernelCI_app.helpers.misc import (
     build_misc_value_or_default,
     env_misc_value_or_default,
 )
-from kernelCI_app.utils import getErrorResponseBody
+from kernelCI_app.utils import getErrorResponseBody, is_boot
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
@@ -225,10 +225,6 @@ class TreeCommitsHistory(APIView):
         incident_test_id = row["incidents_test_id"]
         build_valid = row["build_valid"]
 
-        is_boot = test_path is not None and test_path.startswith(
-            "boot"
-        )
-
         commit_hash = row["git_commit_hash"]
 
         if issue_id is None and (
@@ -237,7 +233,10 @@ class TreeCommitsHistory(APIView):
         ):
             issue_id = UNKNOWN_STRING
 
-        if is_boot:
+        if test_id is None:
+            return
+
+        if is_boot(test_path):
             self._process_boots_count(
                 test_id=test_id,
                 test_status=test_status,

--- a/dashboard/src/components/TestsTable/DefaultTestsColumns.tsx
+++ b/dashboard/src/components/TestsTable/DefaultTestsColumns.tsx
@@ -44,6 +44,7 @@ export const defaultColumns: ColumnDef<TPathTests>[] = [
           fail={row.original.fail_tests}
           skip={row.original.skip_tests}
           error={row.original.error_tests}
+          nullStatus={row.original.null_tests}
         />
       );
     },

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -124,7 +124,7 @@ export function TestsTable({
           groups[group].skip_tests++;
           break;
         default:
-          if (!e.status) groups[group].null_tests++;
+          groups[group].null_tests++;
       }
     });
     return Object.values(groups);


### PR DESCRIPTION
Some parts of code are ignoring tests with `null` path, while other parts are ignoring this tests.
To make consistent, the follow approach is implemented:

- treat `null` path as nonboot tests
- ignoring test id null

Close #741 