### PR TITLE
Feat: Add invisible fiels in tree details tests

### DIFF
--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -200,6 +200,13 @@ def get_current_row_data(current_row: dict) -> dict:
         "path": current_row_data["test_path"],
         "startTime": current_row_data["test_start_time"],
         "hardware": current_row[tmp_test_env_comp_key],
+        "config": current_row_data["build_config_name"],
+        "log_url": current_row_data["test_log_url"],
+        "architecture": current_row_data["build_architecture"],
+        "compiler": current_row_data["build_compiler"],
+        "misc": {
+            "platform": current_row_data["test_platform"]
+        }
     }
 
     return current_row_data

--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -106,6 +106,10 @@ class SummaryResponse(BaseModel):
     git_commit_tags: Optional[List]
 
 
+class Misc(BaseModel):
+    platform: str
+
+
 class TestHistory(BaseModel):
     id: str
     status: Optional[str]
@@ -113,6 +117,11 @@ class TestHistory(BaseModel):
     path: Optional[str]
     startTime: Optional[Union[datetime, str]]
     hardware: Optional[Union[str, List[str]]]
+    config: Optional[str]
+    log_url: Optional[str]
+    architecture: Optional[str]
+    compiler: Optional[str]
+    misc: Optional[Misc]
 
 
 class BootResponse(BaseModel):


### PR DESCRIPTION
- add config, log_url, arch, compiler and misc platform in tests of Tree Details

Close #771 
Part of #770 