### PR TITLE
fix(get-tree-details-data): fix return position

### DIFF
--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -115,7 +115,7 @@ def get_tree_details_data(request, commit_hash):
             rows = cursor.fetchall()
             setQueryCache(cache_key, params, rows)
 
-        return rows
+    return rows
 
 
 def get_current_row_data(current_row: dict) -> dict:


### PR DESCRIPTION
Closes #785

## How to test
- Test with no cache (default behavior in development environment)
- Test with cache by changing the `settings.py` file to: 
```python
if DEBUG:
    CORS_ALLOWED_ORIGIN_REGEXES = [
        r"^http://localhost",  # dashboard dev server
    ]
    SESSION_COOKIE_SECURE = False
    CSRF_COOKIE_SECURE = False
    SECURE_SSL_REDIRECT = False
    SECURE_HSTS_SECONDS = 3600
    # CACHE_TIMEOUT = 0
    CACHE_TIMEOUT = 3600
```