### PR TITLE
feat(api): add hardware details builds endpoint

### DIFF
--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -574,6 +574,11 @@ def handle_test_summary(
     process_issue(record=record, task_issues_dict=processed_issues, issue_from="test")
 
 
+def handle_build_history(*, record: Dict, tree_idx: int, builds: List[HardwareBuildHistoryItem]) -> None:
+    build = get_build_typed(record=record, tree_idx=tree_idx)
+    builds.append(build)
+
+
 def handle_build_summary(
     *,
     record: Dict,

--- a/backend/kernelCI_app/typeModels/hardwareDetails.py
+++ b/backend/kernelCI_app/typeModels/hardwareDetails.py
@@ -72,8 +72,14 @@ class HardwareSummary(Summary):
     compatibles: List[str]
 
 
+class HardwareBuildHistoryItem(BuildHistoryItem):
+    tree_name: Optional[str]
+    issue_id: Optional[str]
+    issue_version: Optional[str]
+
+
 class HardwareDetailsFullResponse(BaseModel):
-    builds: List[BuildHistoryItem]
+    builds: List[HardwareBuildHistoryItem]
     boots: List[TestHistoryItem]
     tests: List[TestHistoryItem]
     summary: HardwareSummary
@@ -83,10 +89,8 @@ class HardwareDetailsSummaryResponse(BaseModel):
     summary: HardwareSummary
 
 
+class HardwareDetailsBuildsResponse(BaseModel):
+    builds: List[HardwareBuildHistoryItem]
+
+
 PossibleTestType = Literal["test", "boot"]
-
-
-class HardwareBuildHistoryItem(BuildHistoryItem):
-    tree_name: Optional[str]
-    issue_id: Optional[str]
-    issue_version: Optional[str]

--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -1,8 +1,8 @@
 from typing import List, Optional
 
 from kernelCI_app.typeModels.commonDetails import (
-    Summary,
     BuildHistoryItem,
+    Summary,
 )
 from pydantic import BaseModel
 
@@ -41,7 +41,7 @@ class SummaryResponse(BaseModel):
     filters: TreeFilters
 
 
-class BuildsResponse(BaseModel):
+class TreeDetailsBuildsResponse(BaseModel):
     builds: List[BuildHistoryItem]
 
 

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -77,6 +77,10 @@ urlpatterns = [
          viewCache(views.HardwareDetails),
          name="hardwareDetails"
          ),
+    path("hardware/<str:hardware_id>/builds",
+         viewCache(views.HardwareDetailsBuilds),
+         name="hardwareDetailsBuilds"
+         ),
     path("hardware/<str:hardware_id>/commit-history",
          viewCache(views.HardwareDetailsCommitHistoryView),
          name="hardwareDetailsCommitHistory"

--- a/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
@@ -1,0 +1,156 @@
+import json
+from datetime import datetime
+from http import HTTPStatus
+from typing import Dict, List, Set
+
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.helpers.filters import FilterParams
+from kernelCI_app.helpers.hardwareDetails import (
+    assign_default_record_values,
+    decide_if_is_build_in_filter,
+    decide_if_is_full_record_filtered_out,
+    get_build,
+    get_hardware_details_data,
+    get_hardware_trees_data,
+    get_trees_with_selected_commit,
+    get_validated_current_tree,
+    handle_build_history,
+    unstable_parse_post_body,
+)
+from kernelCI_app.typeModels.hardwareDetails import (
+    HardwareBuildHistoryItem,
+    HardwareDetailsBuildsResponse,
+    HardwareDetailsPostBody,
+    Tree,
+)
+
+
+# disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/
+# that protection is recommended for ‘unsafe’ methods (POST, PUT, and DELETE)
+# but we are using POST here just to follow the convention to use the request body
+# also the csrf protection require the usage of cookies which is not currently
+# supported in this project
+@method_decorator(csrf_exempt, name="dispatch")
+class HardwareDetailsBuilds(APIView):
+    def __init__(self):
+        self.origin: str = None
+        self.start_datetime: datetime = None
+        self.end_datetime: datetime = None
+        self.selected_commits: Dict[str, str] = None
+
+        self.filters: FilterParams = None
+
+        self.processed_builds: Set[str] = set()
+        self.builds: List[HardwareBuildHistoryItem] = []
+
+    def _process_build(self, record: Dict, tree_index: int) -> None:
+        build = get_build(record, tree_index)
+        build_id = build["id"]
+
+        should_process_build = decide_if_is_build_in_filter(
+            instance=self,
+            build=build,
+            processed_builds=self.processed_builds,
+            incident_test_id=record["incidents__test_id"],
+        )
+
+        self.processed_builds.add(build_id)
+        if should_process_build:
+            handle_build_history(record=record, tree_idx=tree_index, builds=self.builds)
+
+    def _sanitize_records(
+        self, records, trees: List[Tree], is_all_selected: bool
+    ) -> None:
+        for record in records:
+            current_tree = get_validated_current_tree(
+                record=record, selected_trees=trees
+            )
+            if current_tree is None:
+                continue
+
+            assign_default_record_values(record)
+
+            tree_index = current_tree.index
+
+            is_record_filtered_out = decide_if_is_full_record_filtered_out(
+                instance=self,
+                record=record,
+                current_tree=current_tree,
+                is_all_selected=is_all_selected,
+            )
+
+            if is_record_filtered_out:
+                continue
+
+            self._process_build(record, tree_index)
+
+    @extend_schema(
+        request=HardwareDetailsPostBody,
+        methods=["POST"],
+        responses=HardwareDetailsBuildsResponse,
+    )
+    def post(self, request, hardware_id):
+        try:
+            unstable_parse_post_body(instance=self, request=request)
+        except ValidationError as e:
+            return Response(data={"error": e.json()}, status=HTTPStatus.BAD_REQUEST)
+        except json.JSONDecodeError:
+            return Response(
+                data={
+                    "error": "Invalid body, request body must be a valid json string"
+                },
+                status=HTTPStatus.BAD_REQUEST,
+            )
+        except (ValueError, TypeError):
+            return Response(
+                data={
+                    "error": "startTimeStamp and endTimeStamp must be a Unix Timestamp"
+                },
+                status=HTTPStatus.BAD_REQUEST,
+            )
+
+        trees = get_hardware_trees_data(
+            hardware_id=hardware_id,
+            origin=self.origin,
+            selected_commits=self.selected_commits,
+            start_datetime=self.start_datetime,
+            end_datetime=self.end_datetime,
+        )
+
+        trees_with_selected_commits = get_trees_with_selected_commit(
+            trees=trees, selected_commits=self.selected_commits
+        )
+
+        records = get_hardware_details_data(
+            hardware_id=hardware_id,
+            origin=self.origin,
+            trees_with_selected_commits=trees_with_selected_commits,
+            start_datetime=self.start_datetime,
+            end_datetime=self.end_datetime,
+        )
+
+        if len(records) == 0:
+            return Response(
+                data={"error": "No builds found for this hardware"}, status=HTTPStatus.OK
+            )
+
+        is_all_selected = len(self.selected_commits) == 0
+
+        try:
+            self._sanitize_records(
+                records, trees_with_selected_commits, is_all_selected
+            )
+
+            valid_response = HardwareDetailsBuildsResponse(
+                builds=self.builds,
+            )
+        except ValidationError as e:
+            return Response(data={"error": e.errors()}, status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        return Response(data=valid_response.model_dump(), status=HTTPStatus.OK)

--- a/backend/requests/hardware-details-builds-post.sh
+++ b/backend/requests/hardware-details-builds-post.sh
@@ -1,0 +1,71 @@
+http POST http://localhost:8000/api/hardware/fsl,imx6q-sabrelite/builds \
+Content-Type:application/json \
+<<< '{
+    "origin": "maestro",
+    "startTimestampInSeconds": 1733846400,
+    "endTimestampInSeconds": 1734105600,
+    "selectedCommits": {},
+    "filter": {}
+}'
+
+# HTTP/1.1 200 OK
+# Allow: POST, OPTIONS
+# Content-Length: 32644
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Fri, 24 Jan 2025 14:10:11 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "builds": [
+#         {
+#             "architecture": "arm",
+#             "compiler": "gcc-12",
+#             "config_name": "multi_v7_defconfig",
+#             "config_url": "https://kciapistagingstorage1.file.core.windows.net/production/kbuild-gcc-12-arm-675ae176ca49c97d2997f691/.config?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D",
+#             "duration": null,
+#             "git_repository_branch": "linux-4.4.y-cip-rt",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git",
+#             "id": "maestro:675ae176ca49c97d2997f691",
+#             "issue_id": null,
+#             "issue_version": null,
+#             "log_url": "https://kciapistagingstorage1.file.core.windows.net/production/kbuild-gcc-12-arm-675ae176ca49c97d2997f691/build.log.gz?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D",
+#             "misc": {
+#                 "job_context": "gke_android-kernelci-external_us-east4-c_kci-big-us-east4",
+#                 "job_id": "kci-675ae176ca49c97d2997f691-kbuild-gcc-12-arm-kogmcp67",
+#                 "kernel_type": "zimage",
+#                 "platform": "kubernetes",
+#                 "runtime": "k8s-all"
+#             },
+#             "start_time": "2024-12-12T13:13:26.615000Z",
+#             "tree_name": "cip",
+#             "valid": true
+#         },
+#         {
+#             "architecture": "arm",
+#             "compiler": "gcc-12",
+#             "config_name": "multi_v7_defconfig",
+#             "config_url": "https://kciapistagingstorage1.file.core.windows.net/production/kbuild-gcc-12-arm-675c0fcfca49c97d299e1d37/.config?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D",
+#             "duration": null,
+#             "git_repository_branch": "master",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git",
+#             "id": "maestro:675c0fcfca49c97d299e1d37",
+#             "issue_id": null,
+#             "issue_version": null,
+#             "log_url": "https://kciapistagingstorage1.file.core.windows.net/production/kbuild-gcc-12-arm-675c0fcfca49c97d299e1d37/build.log.gz?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D",
+#             "misc": {
+#                 "job_context": "gke_android-kernelci-external_us-east4-c_kci-big-us-east4",
+#                 "job_id": "kci-675c0fcfca49c97d299e1d37-kbuild-gcc-12-arm-sht7a32w",
+#                 "kernel_type": "zimage",
+#                 "platform": "kubernetes",
+#                 "runtime": "k8s-all"
+#             },
+#             "start_time": "2024-12-13T10:43:27.295000Z",
+#             "tree_name": "renesas",
+#             "valid": true
+#         },
+#         ...

--- a/backend/requests/tree-details-builds-get.sh
+++ b/backend/requests/tree-details-builds-get.sh
@@ -1,1 +1,49 @@
 http 'http://localhost:8000/api/tree/b7bfaa761d760e72a969d116517eaa12e404c262/builds' git_branch==for-kernelci git_url==https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git origin==maestro
+
+# HTTP/1.1 200 OK
+# Allow: GET, HEAD, OPTIONS
+# Content-Length: 8706
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Fri, 24 Jan 2025 14:11:20 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "builds": [
+#         {
+#             "architecture": "arm64",
+#             "compiler": "gcc-12",
+#             "config_name": "defconfig",
+#             "config_url": "https://kciapistagingstorage1.file.core.windows.net/early-access/kbuild-gcc-12-arm64-chromebook-6686b975f686ead9f9232f23/.config?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2024-10-17T19:19:12Z&st=2023-10-17T11:19:12Z&spr=https&sig=sLmFlvZHXRrZsSGubsDUIvTiv%2BtzgDq6vALfkrtWnv8%3D",
+#             "duration": null,
+#             "git_repository_branch": "for-kernelci",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git",
+#             "id": "maestro:6686b975f686ead9f9232f23",
+#             "log_url": "https://kciapistagingstorage1.file.core.windows.net/early-access/kbuild-gcc-12-arm64-chromebook-6686b975f686ead9f9232f23/build.log.gz?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2024-10-17T19:19:12Z&st=2023-10-17T11:19:12Z&spr=https&sig=sLmFlvZHXRrZsSGubsDUIvTiv%2BtzgDq6vALfkrtWnv8%3D",
+#             "misc": {
+#                 "platform": "kubernetes"
+#             },
+#             "start_time": "2024-07-04T15:02:13.615000Z",
+#             "valid": true
+#         },
+#         {
+#             "architecture": "Unknown",
+#             "compiler": "Unknown",
+#             "config_name": "Unknown",
+#             "config_url": null,
+#             "duration": null,
+#             "git_repository_branch": "for-kernelci",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git",
+#             "id": "maestro:6686b976f686ead9f9232f28",
+#             "log_url": null,
+#             "misc": {
+#                 "platform": "kubernetes"
+#             },
+#             "start_time": "2024-07-04T15:02:14.562000Z",
+#             "valid": false
+#         },
+#         ...

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -60,6 +60,40 @@ paths:
               schema:
                 $ref: '#/components/schemas/CommonDetailsBootsResponse'
           description: ''
+  /api/hardware/{hardware_id}/builds:
+    post:
+      operationId: hardware_builds_create
+      parameters:
+      - in: path
+        name: hardware_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - hardware
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+        required: true
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HardwareDetailsBuildsResponse'
+          description: ''
   /api/hardware/{hardware_id}/summary:
     post:
       operationId: hardware_summary_create
@@ -382,7 +416,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BuildsResponse'
+                $ref: '#/components/schemas/TreeDetailsBuildsResponse'
           description: ''
   /api/tree/{commit_hash}/commits:
     get:
@@ -626,17 +660,6 @@ components:
       - unknown_issues
       title: BuildSummary
       type: object
-    BuildsResponse:
-      properties:
-        builds:
-          items:
-            $ref: '#/components/schemas/BuildHistoryItem'
-          title: Builds
-          type: array
-      required:
-      - builds
-      title: BuildsResponse
-      type: object
     CommonDetailsBootsResponse:
       properties:
         boots:
@@ -659,11 +682,118 @@ components:
       - tests
       title: CommonDetailsTestsResponse
       type: object
+    HardwareBuildHistoryItem:
+      properties:
+        id:
+          title: Id
+          type: string
+        architecture:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Architecture
+        config_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Config Name
+        misc:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Misc
+        config_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Config Url
+        compiler:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Compiler
+        valid:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Valid
+        duration:
+          anyOf:
+          - type: integer
+          - type: number
+          - type: 'null'
+          title: Duration
+        log_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Log Url
+        start_time:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: string
+          - type: 'null'
+          title: Start Time
+        git_repository_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Git Repository Url
+        git_repository_branch:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Git Repository Branch
+        tree_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tree Name
+        issue_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Issue Id
+        issue_version:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Issue Version
+      required:
+      - id
+      - architecture
+      - config_name
+      - misc
+      - config_url
+      - compiler
+      - valid
+      - duration
+      - log_url
+      - start_time
+      - git_repository_url
+      - git_repository_branch
+      - tree_name
+      - issue_id
+      - issue_version
+      title: HardwareBuildHistoryItem
+      type: object
+    HardwareDetailsBuildsResponse:
+      properties:
+        builds:
+          items:
+            $ref: '#/components/schemas/HardwareBuildHistoryItem'
+          title: Builds
+          type: array
+      required:
+      - builds
+      title: HardwareDetailsBuildsResponse
+      type: object
     HardwareDetailsFullResponse:
       properties:
         builds:
           items:
-            $ref: '#/components/schemas/BuildHistoryItem'
+            $ref: '#/components/schemas/HardwareBuildHistoryItem'
           title: Builds
           type: array
         boots:
@@ -1121,6 +1251,17 @@ components:
       - tree_url
       - git_commit_tags
       title: TreeCommon
+      type: object
+    TreeDetailsBuildsResponse:
+      properties:
+        builds:
+          items:
+            $ref: '#/components/schemas/BuildHistoryItem'
+          title: Builds
+          type: array
+      required:
+      - builds
+      title: TreeDetailsBuildsResponse
       type: object
     TreeFilters:
       properties:


### PR DESCRIPTION
- Added HardwareDetailsBuilds view
- Added '/api/hardware/<str:hardware_id>/builds/'
- Added the necessary types and changed the location of some types
- Changed the imports and names of some types for TreeDetailsBuilds

Closes #760

## How to test
- Run the appropriate script in requests (since it's not implemented in the frontend yet) or try sending a request using `httpie`. The corresponding script for this endpoint is in `backend/requests/hardware-details-builds-post.sh`. Make sure to run it with bash or zsh (even though the file format is sh)

```sh
bash backend/requests/hardware-details-builds-post.sh
```