### PR TITLE
Fix: tree details broonie

### DIFF
--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -28,6 +28,8 @@ from collections import defaultdict
 from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 from kernelCI_app.viewCommon import create_details_build_summary
+from kernelCI_app.helpers.errorHandling import create_error_response
+from http import HTTPStatus
 
 
 class TreeDetailsSummary(APIView):
@@ -145,6 +147,11 @@ class TreeDetailsSummary(APIView):
     )
     def get(self, request, commit_hash: str | None):
         rows = get_tree_details_data(request, commit_hash)
+
+        if len(rows) == 0:
+            return create_error_response(
+                error_message="Tree not found", status_code=HTTPStatus.NOT_FOUND
+            )
 
         self.filters = FilterParams(request)
 

--- a/dashboard/src/api/commitHistory.ts
+++ b/dashboard/src/api/commitHistory.ts
@@ -41,26 +41,23 @@ const fetchCommitHistory = async (
   return res.data;
 };
 
-export const useCommitHistory = (
-  {
-    commitHash,
-    origin,
-    gitUrl,
-    gitBranch,
-    filter,
-    endTimestampInSeconds,
-    startTimestampInSeconds,
-  }: {
-    commitHash: string;
-    origin: string;
-    gitUrl: string;
-    gitBranch: string;
-    filter: TTreeDetailsFilter | TFilter;
-    startTimestampInSeconds?: number;
-    endTimestampInSeconds?: number;
-  },
-  { enabled = true },
-): UseQueryResult<TTreeCommitHistoryResponse> => {
+export const useCommitHistory = ({
+  commitHash,
+  origin,
+  gitUrl,
+  gitBranch,
+  filter,
+  endTimestampInSeconds,
+  startTimestampInSeconds,
+}: {
+  commitHash: string;
+  origin: string;
+  gitUrl: string;
+  gitBranch: string;
+  filter: TTreeDetailsFilter | TFilter;
+  startTimestampInSeconds?: number;
+  endTimestampInSeconds?: number;
+}): UseQueryResult<TTreeCommitHistoryResponse> => {
   const testFilter = getTargetFilter(filter, 'test');
   const treeDetailsFilter = getTargetFilter(filter, 'treeDetails');
 
@@ -80,7 +77,6 @@ export const useCommitHistory = (
       startTimestampInSeconds,
       endTimestampInSeconds,
     ],
-    enabled,
     queryFn: () =>
       fetchCommitHistory(
         commitHash,

--- a/dashboard/src/api/treeDetails.ts
+++ b/dashboard/src/api/treeDetails.ts
@@ -31,28 +31,11 @@ const useTreeSearchParameters = (): TreeSearchParameters => {
   return { origin, gitUrl, gitBranch };
 };
 
-function assertTreeSearchParameters(
-  treeSearchParameters: TreeSearchParameters,
-  locationMessage: string,
-): asserts treeSearchParameters is Required<TreeSearchParameters> {
-  if (!treeSearchParameters.gitUrl) {
-    throw new Error(`Git URL is required in ${locationMessage}`);
-  }
-  if (!treeSearchParameters.gitBranch) {
-    throw new Error(`Git Branch is required in ${locationMessage}`);
-  }
-}
-
 const fetchTreeDetails = async (
   treeId: string,
   treeSearchParameters: TreeSearchParameters,
   filter: TTreeDetailsFilter = {},
 ): Promise<TTreeTestsFullData> => {
-  assertTreeSearchParameters(
-    treeSearchParameters,
-    'fetchTreeDetails - useSearchTab',
-  );
-
   const backendCompatibleFilters = mapFiltersKeysToBackendCompatible(filter);
 
   const params = {

--- a/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
+++ b/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
@@ -47,20 +47,15 @@ const CommitNavigationGraph = ({
 
   const reqFilter = mapFilterToReq(diffFilter);
 
-  const { data, status, error, isLoading } = useCommitHistory(
-    {
-      gitBranch: gitBranch ?? '',
-      gitUrl: gitUrl ?? '',
-      commitHash: headCommitHash ?? '',
-      origin: origin,
-      filter: reqFilter,
-      endTimestampInSeconds,
-      startTimestampInSeconds,
-    },
-    {
-      enabled: !!gitBranch && !!gitUrl,
-    },
-  );
+  const { data, status, error, isLoading } = useCommitHistory({
+    gitBranch: gitBranch ?? '',
+    gitUrl: gitUrl ?? '',
+    commitHash: headCommitHash ?? '',
+    origin: origin,
+    filter: reqFilter,
+    endTimestampInSeconds,
+    startTimestampInSeconds,
+  });
 
   const displayableData = data ? data : null;
 


### PR DESCRIPTION
A tree in broonie origin have no git url/branch (null field).
In this PR, I remove de validation on frontend to allow the user send a empty git url and git branch to the tree details endpoint, that now returns a error if no data was found.
In the backend, add a logic to search this trees when this fields are null.

**How to test**
- go to any tree and check if the behavior is the same of the staging
- go to broonie origin and search for [mainline master tree](http://localhost:5173/tree?o=broonie&ts=mainline)

Close #729 