### PR TITLE
feat: add hardwareDetailsBoots endpoint

### DIFF
--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -92,3 +92,7 @@ class Summary(BaseModel):
 
 class CommonDetailsTestsResponse(BaseModel):
     tests: List[TestHistoryItem]
+
+
+class CommonDetailsBootsResponse(BaseModel):
+    boots: List[TestHistoryItem]

--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 from kernelCI_app.typeModels.commonDetails import (
     Summary,
     BuildHistoryItem,
-    TestHistoryItem,
 )
 from pydantic import BaseModel
 
@@ -40,10 +39,6 @@ class SummaryResponse(BaseModel):
     common: TreeCommon
     summary: Summary
     filters: TreeFilters
-
-
-class BootResponse(BaseModel):
-    bootHistory: List[TestHistoryItem]
 
 
 class BuildsResponse(BaseModel):

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -81,6 +81,10 @@ urlpatterns = [
          viewCache(views.HardwareDetailsCommitHistoryView),
          name="hardwareDetailsCommitHistory"
          ),
+    path("hardware/<str:hardware_id>/boots",
+         views.HardwareDetailsBoots.as_view(),
+         name="hardwareDetailsBoots"
+         ),
     path("hardware/<str:hardware_id>/summary",
          views.HardwareDetailsSummary.as_view(),
          name="hardwareDetailsSummary"

--- a/backend/kernelCI_app/views/hardwareDetailsBootsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBootsView.py
@@ -1,0 +1,156 @@
+from datetime import datetime
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from drf_spectacular.utils import extend_schema
+from http import HTTPStatus
+import json
+from kernelCI_app.helpers.hardwareDetails import (
+    assign_default_record_values,
+    decide_if_is_full_record_filtered_out,
+    decide_if_is_test_in_filter,
+    get_hardware_details_data,
+    get_hardware_trees_data,
+    get_trees_with_selected_commit,
+    get_validated_current_tree,
+    handle_test_history,
+    unstable_parse_post_body,
+)
+from kernelCI_app.typeModels.commonDetails import (
+    CommonDetailsBootsResponse,
+    TestHistoryItem,
+)
+from kernelCI_app.typeModels.hardwareDetails import (
+    HardwareDetailsPostBody,
+    Tree,
+)
+from kernelCI_app.utils import is_boot
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from typing import Dict, List
+
+
+# disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/
+# that protection is recommended for ‘unsafe’ methods (POST, PUT, and DELETE)
+# but we are using POST here just to follow the convention to use the request body
+# also the csrf protection require the usage of cookies which is not currently
+# supported in this project
+@method_decorator(csrf_exempt, name="dispatch")
+class HardwareDetailsBoots(APIView):
+    required_params_get = ["origin"]
+
+    def __init__(self):
+        self.origin: str = None
+        self.start_datetime: datetime = None
+        self.end_datetime: datetime = None
+        self.selected_commits: Dict[str, str] = None
+
+        self.processed_tests = set()
+
+        self.boots: List[TestHistoryItem] = []
+
+    def _process_test(self, record: Dict) -> None:
+        is_record_boot = is_boot(record["path"])
+        if not is_record_boot:
+            return
+
+        should_process_test = decide_if_is_test_in_filter(
+            instance=self,
+            test_type="boot",
+            record=record,
+            processed_tests=self.processed_tests,
+        )
+
+        self.processed_tests.add(record["id"])
+        if should_process_test:
+            handle_test_history(
+                record=record,
+                task=self.boots,
+            )
+
+    def _sanitize_records(
+        self, records, trees: List[Tree], is_all_selected: bool
+    ) -> None:
+        for record in records:
+            current_tree = get_validated_current_tree(
+                record=record, selected_trees=trees
+            )
+            if current_tree is None:
+                continue
+
+            assign_default_record_values(record)
+
+            is_record_filtered_out = decide_if_is_full_record_filtered_out(
+                instance=self,
+                record=record,
+                current_tree=current_tree,
+                is_all_selected=is_all_selected,
+            )
+            if is_record_filtered_out:
+                continue
+
+            self._process_test(record=record)
+
+    # Using post to receive a body request
+    @extend_schema(
+        responses=CommonDetailsBootsResponse,
+        request=HardwareDetailsPostBody,
+        methods=["POST"],
+    )
+    def post(self, request, hardware_id) -> Response:
+        try:
+            unstable_parse_post_body(instance=self, request=request)
+        except ValidationError as e:
+            return Response(data={"error": e.json()}, status=HTTPStatus.BAD_REQUEST)
+        except json.JSONDecodeError:
+            return Response(
+                data={
+                    "error": "Invalid body, request body must be a valid json string"
+                },
+                status=HTTPStatus.BAD_REQUEST,
+            )
+        except (ValueError, TypeError):
+            return Response(
+                data={
+                    "error": "startTimeStamp and endTimeStamp must be a Unix Timestamp"
+                },
+                status=HTTPStatus.BAD_REQUEST,
+            )
+
+        trees = get_hardware_trees_data(
+            hardware_id=hardware_id,
+            origin=self.origin,
+            selected_commits=self.selected_commits,
+            start_datetime=self.start_datetime,
+            end_datetime=self.end_datetime,
+        )
+
+        trees_with_selected_commits = get_trees_with_selected_commit(
+            trees=trees, selected_commits=self.selected_commits
+        )
+
+        records = get_hardware_details_data(
+            hardware_id=hardware_id,
+            origin=self.origin,
+            trees_with_selected_commits=trees_with_selected_commits,
+            start_datetime=self.start_datetime,
+            end_datetime=self.end_datetime,
+        )
+
+        if len(records) == 0:
+            return Response(
+                data={"error": "No boots found for this hardware"}, status=HTTPStatus.OK
+            )
+
+        is_all_selected = len(self.selected_commits) == 0
+
+        self._sanitize_records(records, trees_with_selected_commits, is_all_selected)
+
+        try:
+            valid_response = CommonDetailsBootsResponse(
+                boots=self.boots,
+            )
+        except ValidationError as e:
+            return Response(data=e.errors(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        return Response(data=valid_response.model_dump(), status=HTTPStatus.OK)

--- a/backend/kernelCI_app/views/treeDetailsBootsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBootsView.py
@@ -18,10 +18,10 @@ from kernelCI_app.helpers.treeDetails import (
     is_test_boots_test,
 )
 from kernelCI_app.typeModels.treeDetails import (
-    BootResponse,
     TreeQueryParameters,
 )
 from kernelCI_app.typeModels.commonDetails import (
+    CommonDetailsBootsResponse,
     TestHistoryItem
 )
 
@@ -65,7 +65,8 @@ class TreeDetailsBoots(APIView):
 
     @extend_schema(
         parameters=[TreeQueryParameters],
-        responses=BootResponse,
+        methods=["GET"],
+        responses=CommonDetailsBootsResponse,
     )
     def get(self, request, commit_hash: str | None):
         rows = get_tree_details_data(request, commit_hash)
@@ -79,11 +80,11 @@ class TreeDetailsBoots(APIView):
 
         try:
             self._sanitize_rows(rows)
-        except ValidationError as e:
-            return Response(data=e.errors(), status=HTTPStatus.BAD_REQUEST)
 
-        return Response(
-            {
-                "boots": self.bootHistory,
-            }
-        )
+            valid_response = CommonDetailsBootsResponse(
+                boots=self.bootHistory,
+            )
+        except ValidationError as e:
+            return Response(data=e.errors(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        return Response(data=valid_response.model_dump(), status=HTTPStatus.OK)

--- a/backend/requests/hardware-details-boots-post.sh
+++ b/backend/requests/hardware-details-boots-post.sh
@@ -1,0 +1,61 @@
+http POST http://localhost:8000/api/hardware/brcm,bcm2711/boots \
+Content-Type:application/json \
+<<< '{
+    "origin":"maestro",
+    "startTimestampInSeconds":1737487800,
+    "endTimestampInSeconds":1737574200,
+    "selectedCommits":{},
+    "filter":{}
+}'
+
+# HTTP/1.1 200 OK
+# Allow: POST, OPTIONS
+# Content-Length: 125078
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Thu, 23 Jan 2025 16:59:39 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "boots": [
+#         {
+#             "architecture": "arm64",
+#             "compiler": "gcc-12",
+#             "config": "defconfig",
+#             "duration": null,
+#             "environment_compatible": [
+#                 "raspberrypi,4-model-b",
+#                 "brcm,bcm2711"
+#             ],
+#             "id": "maestro:67904d0109f33884b18b9763",
+#             "log_url": "https://kciapistagingstorage1.file.core.windows.net/production/baseline-arm64-67904c5509f33884b18b9464/log.txt.gz?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D",
+#             "misc": {
+#                 "platform": "bcm2711-rpi-4-b"
+#             },
+#             "path": "boot.dmesg.alert",
+#             "start_time": "2025-01-22T01:42:25.618000Z",
+#             "status": "PASS"
+#         },
+#         {
+#             "architecture": "arm64",
+#             "compiler": "gcc-12",
+#             "config": "defconfig",
+#             "duration": null,
+#             "environment_compatible": [
+#                 "raspberrypi,4-model-b",
+#                 "brcm,bcm2711"
+#             ],
+#             "id": "maestro:67904d0109f33884b18b9762",
+#             "log_url": "https://kciapistagingstorage1.file.core.windows.net/production/baseline-arm64-67904c5509f33884b18b9464/log.txt.gz?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D",
+#             "misc": {
+#                 "platform": "bcm2711-rpi-4-b"
+#             },
+#             "path": "boot.dmesg.emerg",
+#             "start_time": "2025-01-22T01:42:25.618000Z",
+#             "status": "PASS"
+#         },
+#         ...

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -26,6 +26,40 @@ paths:
               schema:
                 $ref: '#/components/schemas/HardwareDetailsFullResponse'
           description: ''
+  /api/hardware/{hardware_id}/boots:
+    post:
+      operationId: hardware_boots_create
+      parameters:
+      - in: path
+        name: hardware_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - hardware
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+        required: true
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CommonDetailsBootsResponse'
+          description: ''
   /api/hardware/{hardware_id}/summary:
     post:
       operationId: hardware_summary_create
@@ -308,7 +342,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BootResponse'
+                $ref: '#/components/schemas/CommonDetailsBootsResponse'
           description: ''
   /api/tree/{commit_hash}/builds:
     get:
@@ -432,17 +466,6 @@ paths:
           description: ''
 components:
   schemas:
-    BootResponse:
-      properties:
-        bootHistory:
-          items:
-            $ref: '#/components/schemas/TestHistoryItem'
-          title: Boothistory
-          type: array
-      required:
-      - bootHistory
-      title: BootResponse
-      type: object
     BuildArchitectures:
       properties:
         valid:
@@ -613,6 +636,17 @@ components:
       required:
       - builds
       title: BuildsResponse
+      type: object
+    CommonDetailsBootsResponse:
+      properties:
+        boots:
+          items:
+            $ref: '#/components/schemas/TestHistoryItem'
+          title: Boots
+          type: array
+      required:
+      - boots
+      title: CommonDetailsBootsResponse
       type: object
     CommonDetailsTestsResponse:
       properties:


### PR DESCRIPTION
Adds `/hardware/<hardware_name>/boots` endpoint

## How to test
This endpoint is not being used by the frontend, but you can compare the responses by opening the network tab on the dashboard website, going to a hardware details with boots data, checking the request body for the post to hardwareDetails endpoint and use that body in a request from the api view. Check if filters and tree selection work normally.

Example: go to localhost:8000/api/hardware/brcm,bcm2711/boots and send the body
```
{
    "origin":"maestro",
    "startTimestampInSeconds":1737487800,
    "endTimestampInSeconds":1737574200,
    "selectedCommits":{},
    "filter":{}
}
```
in the POST request


Part of #751 
Closes #761 