### PR TITLE
feat(hardware-details): add compatibles filter

### DIFF
--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -720,6 +720,7 @@ def decide_if_is_full_record_filtered_out(
         return True
 
     is_record_filtered_out_result = instance.filters.is_record_filtered_out(
+        hardwares=record["environment_compatible"],
         architecture=record["build__architecture"],
         compiler=record["build__compiler"],
         config_name=record["build__config_name"],

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -170,8 +170,8 @@ class HardwareDetailsSummary(APIView):
 
             self._process_build(record, tree_index)
 
-    def _format_processing_for_response(self) -> None:
-        self.compatibles = list(self.processed_compatibles)
+    def _format_processing_for_response(self, hardware_id: str) -> None:
+        self.compatibles = list(self.processed_compatibles - {hardware_id})
 
         self.boots_summary.architectures = list(
             self.processed_architectures["boot"].values()
@@ -234,15 +234,13 @@ class HardwareDetailsSummary(APIView):
         )
 
         if len(records) == 0:
-            return Response(
-                data={"error": "Hardware not found"}, status=HTTPStatus.OK
-            )
+            return Response(data={"error": "Hardware not found"}, status=HTTPStatus.OK)
 
         is_all_selected = len(self.selected_commits) == 0
 
         self._sanitize_records(records, trees_with_selected_commits, is_all_selected)
 
-        self._format_processing_for_response()
+        self._format_processing_for_response(hardware_id=hardware_id)
 
         configs, archs, compilers = get_filter_options(
             records=records,

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -250,7 +250,7 @@ class HardwareDetails(APIView):
                 "configs": configs,
                 "architectures": archs,
                 "compilers": compilers,
-                "compatibles": list(self.processed_compatibles),
+                "compatibles": list(self.processed_compatibles - {hardware_id}),
             },
         }
         try:

--- a/dashboard/src/components/Cards/CompatibleHardware.tsx
+++ b/dashboard/src/components/Cards/CompatibleHardware.tsx
@@ -1,17 +1,51 @@
 import { memo, useMemo } from 'react';
 
+import { useSearch } from '@tanstack/react-router';
+
 import { Badge } from '@/components/ui/badge';
+
+import FilterLink from '@/components/Tabs/FilterLink';
+
+import type { TFilter } from '@/types/general';
 
 import BaseCard, { type IBaseCard } from './BaseCard';
 
 interface ICompatible {
   title: IBaseCard['title'];
   compatibles: string[];
+  diffFilter: TFilter;
 }
+
+const CompatibleLink = ({
+  compatible,
+  diffFilter,
+}: {
+  compatible: string;
+  diffFilter: TFilter;
+}): JSX.Element => {
+  const { currentPageTab } = useSearch({ from: '/hardware/$hardwareId' });
+  return (
+    <FilterLink
+      filterValue={compatible}
+      filterSection="hardware"
+      diffFilter={diffFilter}
+      to={`/hardware/$hardwareId`}
+      from={`/hardware/$hardwareId`}
+      key={currentPageTab}
+    >
+      <Badge variant="outline" className="text-sm font-normal">
+        {compatible}
+      </Badge>
+    </FilterLink>
+  );
+};
+
+const MemoizedCompatibleLink = memo(CompatibleLink);
 
 const CompatibleHardware = ({
   title,
   compatibles,
+  diffFilter,
 }: ICompatible): JSX.Element => {
   const compatiblesSorted = useMemo(() => compatibles.sort(), [compatibles]);
 
@@ -22,13 +56,11 @@ const CompatibleHardware = ({
       content={
         <div className="flex flex-row flex-wrap gap-4 p-4">
           {compatiblesSorted.map(compatible => (
-            <Badge
+            <MemoizedCompatibleLink
               key={compatible}
-              variant="outline"
-              className="text-sm font-normal"
-            >
-              {compatible}
-            </Badge>
+              compatible={compatible}
+              diffFilter={diffFilter}
+            />
           ))}
         </div>
       }

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -319,6 +319,7 @@ function HardwareDetails(): JSX.Element {
                       <FormattedMessage id="hardwareDetails.compatibles" />
                     }
                     compatibles={summaryResponse.data.compatibles}
+                    diffFilter={diffFilter}
                   />
                 </div>
               )}


### PR DESCRIPTION
- Add filter for compatibles card in hardware details
- Remove the hardware id of the page from compatibles card

Closes #712

# How to test
From my experience, most of the hardwares have tests that share the same environment_compatible array. For that reason, is kind of hard to find a hardware detail where the filter has an effect. This is one of them: http://localhost:5173/hardware/amlogic%2Cg12b?et=1737981000&p=bt&st=1737549000. In this example, we have two different sets of tests, one where the environment_compatible includes `libretech,aml-a311d-cc` and the other where environment_compatible includes `khadas,vim3`. Testing in this page would go:

- Filter by `libretech,aml-a311d-cc`. Save the status values for later and verify that all the boots/tests have `libretech/aml-a311d-cc` in the hardware field. For builds you could open each tree named in the build details page and check if `libretech,aml-a311d-cc` is one of the hardwares used.
- Filter by `khadas,vim3`. In this case, since there aren't hardwares that include both `khadas,vim3` and `libretech,aml-a311d-cc` the status values should be equal to `unfiltered_status_values - libretech_status_values`. You can also perform the same tests in last path, opening tests details to verify `khadas,vim3` appears in hardware (and that `libretech.aml-a311d-cc` does not appear since the values correspond to them being exclusive values). Alternatively you could write a SQL query that gets all rows in a time period that contains `amlogic,g12b`, `libretech,aml-a311d-cc` and `khadas,vim3` and the result should be empty
- Filter by `amlogic,a311d` and check that it's the same value as the unfiltered page since `amlogc.a311d` is in all tests.