### PR TITLE
Add Issue List in Log Viewer component

### DIFF
--- a/dashboard/src/api/buildDetails.ts
+++ b/dashboard/src/api/buildDetails.ts
@@ -38,5 +38,6 @@ export const useBuildIssues = (buildId: string): UseQueryResult<TIssue[]> => {
   return useQuery({
     queryKey: ['buildIssues', buildId],
     queryFn: () => fetchBuildIssues(buildId),
+    enabled: buildId !== '',
   });
 };

--- a/dashboard/src/api/testDetails.ts
+++ b/dashboard/src/api/testDetails.ts
@@ -30,6 +30,7 @@ const fetchTestIssues = async (testId: string): Promise<TIssue[]> => {
 export const useTestIssues = (testId: string): UseQueryResult<TIssue[]> => {
   return useQuery({
     queryKey: ['testIssues', testId],
+    enabled: testId !== '',
     queryFn: () => fetchTestIssues(testId),
   });
 };

--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -106,6 +106,7 @@ interface IBootsTable {
   onClickFilter: (newFilter: TestsTableFilter) => void;
   updatePathFilter?: (pathFilter: string) => void;
   currentPathFilter?: string;
+  searchParams?: LinkProps['search'];
 }
 
 // TODO: would be useful if the navigation happened within the table, so the parent component would only be required to pass the navigation url instead of the whole function for the update and the currentPath diffFilter (boots/tests Table)
@@ -117,6 +118,7 @@ export function BootsTable({
   onClickFilter,
   updatePathFilter,
   currentPathFilter,
+  searchParams,
 }: IBootsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const { pagination, paginationUpdater } = usePaginationState(tableKey);
@@ -376,6 +378,7 @@ export function BootsTable({
       issues={issues}
       status={status}
       error={error}
+      previousSearch={searchParams}
     >
       <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
       <BaseTable headerComponents={tableHeaders}>

--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -36,7 +36,7 @@ import { TableHeader } from '@/components/Table/TableHeader';
 
 import { PaginationInfo } from '@/components/Table/PaginationInfo';
 import DebounceInput from '@/components/DebounceInput/DebounceInput';
-import { useTestDetails } from '@/api/testDetails';
+import { useTestDetails, useTestIssues } from '@/api/testDetails';
 import WrapperTableWithLogSheet from '@/pages/TreeDetails/Tabs/WrapperTableWithLogSheet';
 import { usePaginationState } from '@/hooks/usePaginationState';
 
@@ -357,6 +357,14 @@ export function BootsTable({
     return getRowLink(dataTest?.id ?? '');
   }, [dataTest?.id, getRowLink]);
 
+  const {
+    data: issues,
+    status,
+    error,
+  } = useTestIssues(
+    currentLog !== undefined ? sortedItems[currentLog]?.id : '',
+  );
+
   return (
     <WrapperTableWithLogSheet
       currentLog={currentLog}
@@ -365,6 +373,9 @@ export function BootsTable({
       navigationLogsActions={navigationLogsActions}
       onOpenChange={onOpenChange}
       currentLinkProps={currentLinkProps}
+      issues={issues}
+      status={status}
+      error={error}
     >
       <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
       <BaseTable headerComponents={tableHeaders}>

--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -4,11 +4,7 @@ import { useIntl } from 'react-intl';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useCallback, useMemo, useState } from 'react';
 
-import {
-  useSearch,
-  type HistoryState,
-  type LinkProps,
-} from '@tanstack/react-router';
+import { useSearch, type LinkProps } from '@tanstack/react-router';
 
 import SectionGroup from '@/components/Section/SectionGroup';
 import type { ISection } from '@/components/Section/Section';
@@ -48,7 +44,6 @@ interface BuildDetailsProps {
   onClickFilter: (filter: TestsTableFilter) => void;
   tableFilter: TableFilter;
   getTestTableRowLink: (testId: string) => LinkProps;
-  historyState?: HistoryState;
 }
 
 const BuildDetails = ({
@@ -57,7 +52,6 @@ const BuildDetails = ({
   onClickFilter,
   tableFilter,
   getTestTableRowLink,
-  historyState,
 }: BuildDetailsProps): JSX.Element => {
   const searchParams = useSearch({ from: '/build/$buildId' });
   const { data, isLoading, status, error } = useBuildDetails(buildId ?? '');
@@ -251,7 +245,6 @@ const BuildDetails = ({
             data={issueData}
             status={issueStatus}
             error={issueError?.message}
-            historyState={historyState}
             previousSearch={searchParams}
           />
           <LogOrJsonSheetContent

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -44,6 +44,7 @@ export interface IBuildsTable {
   filter: BuildsTableFilter;
   onClickFilter: (filter: BuildsTableFilter) => void;
   getRowLink: (buildId: string) => LinkProps;
+  searchParams?: LinkProps['search'];
 }
 
 export function BuildsTable({
@@ -53,6 +54,7 @@ export function BuildsTable({
   filter,
   onClickFilter,
   getRowLink,
+  searchParams,
 }: IBuildsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const { pagination, paginationUpdater } = usePaginationState(tableKey);
@@ -293,6 +295,7 @@ export function BuildsTable({
       issues={issues}
       status={status}
       error={error}
+      previousSearch={searchParams}
     >
       <div className="flex items-center justify-between">
         <TableStatusFilter filters={filters} onClickBuild={onClickFilter} />

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -33,7 +33,7 @@ import type { TableKeys } from '@/utils/constants/tables';
 
 import { TableRowMemoized } from '@/components/Table/TableComponents';
 
-import { useBuildDetails } from '@/api/buildDetails';
+import { useBuildDetails, useBuildIssues } from '@/api/buildDetails';
 
 import { defaultBuildColumns } from './DefaultBuildsColumns';
 
@@ -272,6 +272,14 @@ export function BuildsTable({
     return getRowLink(sortedItems[currentLog ?? 0]?.id ?? '');
   }, [currentLog, getRowLink, sortedItems]);
 
+  const {
+    data: issues,
+    status,
+    error,
+  } = useBuildIssues(
+    currentLog !== undefined ? sortedItems[currentLog]?.id : '',
+  );
+
   return (
     <WrapperTableWithLogSheet
       currentLog={currentLog}
@@ -282,6 +290,9 @@ export function BuildsTable({
       navigationLogsActions={navigationLogsActions}
       onOpenChange={onOpenChange}
       currentLinkProps={currentLinkProps}
+      issues={issues}
+      status={status}
+      error={error}
     >
       <div className="flex items-center justify-between">
         <TableStatusFilter filters={filters} onClickBuild={onClickFilter} />

--- a/dashboard/src/components/DetailsPages/SectionError.tsx
+++ b/dashboard/src/components/DetailsPages/SectionError.tsx
@@ -3,13 +3,31 @@ import { RiProhibited2Line } from 'react-icons/ri';
 import type { MessageDescriptor } from 'react-intl';
 import { FormattedMessage } from 'react-intl';
 
+export type TErrorVariant = 'warning' | 'error';
 interface ISectionError {
   errorMessage?: string;
   isLoading?: boolean;
   isEmpty?: boolean;
   emptyLabel?: MessageDescriptor['id'];
   customEmptyDataComponent?: JSX.Element;
+  variant?: TErrorVariant;
 }
+
+type IErrorMessage = {
+  label: string;
+  id: MessageDescriptor['id'];
+};
+
+const globalErrorMessage: Record<TErrorVariant, IErrorMessage> = {
+  warning: {
+    label: 'Warning',
+    id: 'global.warning',
+  },
+  error: {
+    label: 'Error',
+    id: 'global.error',
+  },
+};
 
 const SectionError = ({
   errorMessage,
@@ -17,6 +35,7 @@ const SectionError = ({
   isEmpty,
   emptyLabel = 'global.noResults',
   customEmptyDataComponent,
+  variant = 'error',
 }: ISectionError): JSX.Element => {
   const message = useMemo((): MessageDescriptor['id'] => {
     if (isLoading) {
@@ -24,10 +43,10 @@ const SectionError = ({
     } else if (isEmpty) {
       return emptyLabel;
     } else if (errorMessage) {
-      return 'global.error';
+      return globalErrorMessage[variant].id;
     }
-    return 'global.error';
-  }, [emptyLabel, errorMessage, isEmpty, isLoading]);
+    return globalErrorMessage[variant].id;
+  }, [emptyLabel, errorMessage, isEmpty, isLoading, variant]);
 
   if (isLoading === undefined) {
     return customEmptyDataComponent ?? <Fragment />;
@@ -35,11 +54,17 @@ const SectionError = ({
 
   return (
     <div className="flex flex-col items-center py-6 text-weakGray">
-      {!isLoading && <RiProhibited2Line className="h-14 w-14" />}
+      {variant === 'error' && !isLoading && (
+        <RiProhibited2Line className="h-14 w-14" />
+      )}
       <p className="text-2xl font-semibold">
         <FormattedMessage id={message} />
       </p>
-      {errorMessage && <p>Error: {errorMessage}</p>}
+      {errorMessage && (
+        <p>
+          {globalErrorMessage[variant].label}: {errorMessage}
+        </p>
+      )}
     </div>
   );
 };

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import type { UseQueryResult } from '@tanstack/react-query';
 
-import type { HistoryState, LinkProps } from '@tanstack/react-router';
+import type { LinkProps } from '@tanstack/react-router';
 import { Link } from '@tanstack/react-router';
 
 import { RiProhibited2Line } from 'react-icons/ri';
@@ -33,14 +33,12 @@ const IssueSection = ({
   data,
   status,
   error,
-  historyState,
   previousSearch,
   variant = 'error',
 }: {
   data?: TIssue[];
   status: UseQueryResult['status'];
   error?: string;
-  historyState?: HistoryState;
   previousSearch: LinkProps['search'];
   variant?: TErrorVariant;
 }): JSX.Element => {
@@ -52,7 +50,7 @@ const IssueSection = ({
           className="mb-16 flex [&:not(:last-child)]:mb-2 [&:not(:last-child)]:border-b [&:not(:last-child)]:pb-2"
           to="/issue/$issueId/version/$versionNumber"
           params={{ issueId: issue.id, versionNumber: issue.version }}
-          state={historyState}
+          state={s => s}
           search={previousSearch}
         >
           <ListingItem
@@ -62,7 +60,7 @@ const IssueSection = ({
           />
         </Link>
       )),
-    [data, historyState, previousSearch],
+    [data, previousSearch],
   );
 
   return (

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -13,6 +13,7 @@ import ListingItem from '@/components/ListingItem/ListingItem';
 import type { TIssue } from '@/types/general';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
+import type { TErrorVariant } from '@/components/DetailsPages/SectionError';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import { IssueTooltip } from './IssueTooltip';
@@ -34,12 +35,14 @@ const IssueSection = ({
   error,
   historyState,
   previousSearch,
+  variant = 'error',
 }: {
   data?: TIssue[];
   status: UseQueryResult['status'];
   error?: string;
   historyState?: HistoryState;
   previousSearch: LinkProps['search'];
+  variant?: TErrorVariant;
 }): JSX.Element => {
   const issueList = useMemo(
     () =>
@@ -79,6 +82,7 @@ const IssueSection = ({
             isLoading={status === 'pending'}
             errorMessage={error}
             emptyLabel={'global.error'}
+            variant={variant}
           />
         }
       >

--- a/dashboard/src/components/Sheet/LogOrJsonSheetContent.tsx
+++ b/dashboard/src/components/Sheet/LogOrJsonSheetContent.tsx
@@ -44,6 +44,7 @@ export const LogOrJsonSheetContent = ({
   issues,
   status,
   error,
+  previousSearch,
 }: ILogSheet): JSX.Element => {
   return (
     <WrapperSheetContent
@@ -69,7 +70,6 @@ export const LogOrJsonSheetContent = ({
             data={issues}
             status={status ?? 'success'}
             error={error?.message}
-            historyState={historyState}
             previousSearch={previousSearch}
             variant="warning"
           />

--- a/dashboard/src/components/Sheet/LogOrJsonSheetContent.tsx
+++ b/dashboard/src/components/Sheet/LogOrJsonSheetContent.tsx
@@ -2,6 +2,8 @@ import type { LinkProps } from '@tanstack/react-router';
 
 import ReactJsonView from '@microlink/react-json-view';
 
+import type { UseQueryResult } from '@tanstack/react-query';
+
 import type { TNavigationLogActions } from '@/components/Sheet/WrapperSheetContent';
 import { WrapperSheetContent } from '@/components/Sheet/WrapperSheetContent';
 
@@ -9,6 +11,8 @@ import { MemoizedMoreDetailsButton } from '@/components/Button/MoreDetailsButton
 
 import { LogViewerCard } from '@/components/Log/LogViewerCard';
 import { LogExcerpt } from '@/components/Log/LogExcerpt';
+import IssueSection from '@/components/Issue/IssueSection';
+import type { TIssue } from '@/types/general';
 
 export type SheetType = 'log' | 'json';
 
@@ -19,6 +23,10 @@ interface ILogSheet {
   logUrl?: string;
   navigationLogsActions?: TNavigationLogActions;
   currentLinkProps?: LinkProps;
+  issues?: TIssue[];
+  status?: UseQueryResult['status'];
+  error?: UseQueryResult['error'];
+  previousSearch?: LinkProps['search'];
 }
 
 export interface IJsonContent {
@@ -33,6 +41,9 @@ export const LogOrJsonSheetContent = ({
   logUrl,
   navigationLogsActions,
   currentLinkProps,
+  issues,
+  status,
+  error,
 }: ILogSheet): JSX.Element => {
   return (
     <WrapperSheetContent
@@ -53,6 +64,14 @@ export const LogOrJsonSheetContent = ({
           <LogExcerpt
             logExcerpt={logExcerpt}
             isLoading={navigationLogsActions?.isLoading}
+          />
+          <IssueSection
+            data={issues}
+            status={status ?? 'success'}
+            error={error?.message}
+            historyState={historyState}
+            previousSearch={previousSearch}
+            variant="warning"
           />
         </>
       ) : (

--- a/dashboard/src/components/Sheet/WrapperSheetContent.tsx
+++ b/dashboard/src/components/Sheet/WrapperSheetContent.tsx
@@ -84,7 +84,7 @@ export const WrapperSheetContent = ({
 
   return (
     <SheetContent
-      className="flex flex-col overflow-auto sm:w-full sm:max-w-[clamp(650px,75vw,1300px)]"
+      className="flex flex-col overflow-scroll sm:w-full sm:max-w-[clamp(650px,75vw,1300px)]"
       onKeyDown={handleKeyDown}
     >
       <SheetHeader className="mb-3">

--- a/dashboard/src/components/Tabs/FilterLink.tsx
+++ b/dashboard/src/components/Tabs/FilterLink.tsx
@@ -35,6 +35,7 @@ const FilterLink = ({
         ...previousParams,
         diffFilter: handleDiffFilter,
       })}
+      state={s => s}
       from={from}
       to={to}
       key={filterValue}

--- a/dashboard/src/components/Tabs/Summary.tsx
+++ b/dashboard/src/components/Tabs/Summary.tsx
@@ -113,6 +113,7 @@ const SummaryItem = ({
             ...previousParams,
             diffFilter: handleDiffFilter,
           }),
+          state: s => s,
         }}
       >
         <ListingItem

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -246,7 +246,6 @@ const TestDetails = ({
   breadcrumb,
   testId,
 }: TestsDetailsProps): JSX.Element => {
-  const historyState = useRouterState({ select: s => s.location.state });
   const searchParams = useSearch({ from: '/test/$testId' });
   const { data, isLoading, status, error } = useTestDetails(testId ?? '');
   const {
@@ -285,7 +284,6 @@ const TestDetails = ({
             data={issueData}
             status={issueStatus}
             error={issueError?.message}
-            historyState={historyState}
             previousSearch={searchParams}
           />
         </div>

--- a/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
+++ b/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
@@ -17,7 +17,7 @@ import type { TestHistory, TIndividualTest } from '@/types/general';
 import { DumbTableHeader, TableHead } from '@/components/Table/BaseTable';
 import { TableBody } from '@/components/ui/table';
 
-import { useTestDetails } from '@/api/testDetails';
+import { useTestDetails, useTestIssues } from '@/api/testDetails';
 import WrapperTableWithLogSheet from '@/pages/TreeDetails/Tabs/WrapperTableWithLogSheet';
 
 import { TableRowMemoized } from '@/components/Table/TableComponents';
@@ -172,6 +172,14 @@ export function IndividualTestsTable({
     return getRowLink(dataTest?.id ?? '');
   }, [dataTest?.id, getRowLink]);
 
+  const {
+    data: issues,
+    status,
+    error,
+  } = useTestIssues(
+    currentLog !== undefined ? sortedItems[currentLog]?.id : '',
+  );
+
   return (
     <WrapperTableWithLogSheet
       currentLog={currentLog}
@@ -180,6 +188,9 @@ export function IndividualTestsTable({
       navigationLogsActions={navigationLogsActions}
       onOpenChange={onOpenChange}
       currentLinkProps={currentLinkProps}
+      issues={issues}
+      status={status}
+      error={error}
     >
       <div
         ref={parentRef}

--- a/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
+++ b/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
@@ -28,12 +28,14 @@ interface IIndividualTestsTable {
   columns: ColumnDef<TIndividualTest>[];
   data: TIndividualTest[];
   getRowLink: (testId: TestHistory['id']) => LinkProps;
+  searchParams?: LinkProps['search'];
 }
 
 export function IndividualTestsTable({
   data,
   columns,
   getRowLink,
+  searchParams,
 }: IIndividualTestsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -191,6 +193,7 @@ export function IndividualTestsTable({
       issues={issues}
       status={status}
       error={error}
+      previousSearch={searchParams}
     >
       <div
         ref={parentRef}

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -53,6 +53,7 @@ export interface ITestsTable {
   getRowLink: (testId: TestHistory['id']) => LinkProps;
   updatePathFilter?: (pathFilter: string) => void;
   currentPathFilter?: string;
+  searchParams?: LinkProps['search'];
 }
 
 // TODO: would be useful if the navigation happened within the table, so the parent component would only be required to pass the navigation url instead of the whole function for the update and the currentPath diffFilter (boots/tests Table)
@@ -66,6 +67,7 @@ export function TestsTable({
   getRowLink,
   updatePathFilter,
   currentPathFilter,
+  searchParams,
 }: ITestsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
@@ -333,6 +335,7 @@ export function TestsTable({
                   getRowLink={getRowLink}
                   data={data[row.index].individual_tests}
                   columns={innerColumns}
+                  searchParams={searchParams}
                 />
               </TableCell>
             </TableRow>
@@ -346,7 +349,7 @@ export function TestsTable({
         </TableCell>
       </TableRow>
     );
-  }, [columns.length, data, getRowLink, innerColumns, modelRows]);
+  }, [columns.length, data, getRowLink, innerColumns, modelRows, searchParams]);
 
   return (
     <div className="flex flex-col gap-6 pb-4">

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -23,7 +23,7 @@ import { Link, useSearch } from '@tanstack/react-router';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 
 import type { TreeTableBody } from '@/types/tree/Tree';
-import { zOrigin } from '@/types/general';
+import { RedirectFrom, zOrigin } from '@/types/general';
 import type { TFilter, TOrigins } from '@/types/general';
 
 import { formattedBreakLineValue } from '@/locales/messages';
@@ -75,7 +75,10 @@ const getLinkProps = (
   return {
     to: '/tree/$treeId',
     params: { treeId: row.original.id },
-
+    state: {
+      id: row.original.id,
+      from: RedirectFrom.Tree,
+    },
     search: previousSearch => ({
       tableFilter: {
         bootsTable: possibleTestsTableFilter[0],

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -171,6 +171,7 @@ export const messages = {
     'global.url': 'URL',
     'global.viewJson': 'View Json',
     'global.viewLog': 'View Log',
+    'global.warning': 'Warning',
     'globalDetails.artifacts': 'Artifacts',
     'globalDetails.environmentMiscData': 'Environment Misc Data',
     'globalDetails.gitCommitTag': 'Git Commit Tag',

--- a/dashboard/src/pages/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetails.tsx
@@ -70,7 +70,6 @@ const BuildDetailsPage = (): JSX.Element => {
       onClickFilter={onClickFilter}
       tableFilter={searchParams.tableFilter ?? zTableFilterInfoDefault}
       getTestTableRowLink={getTestTableRowLink}
-      historyState={historyState}
     />
   );
 };

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -48,7 +48,7 @@ import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
 
 import type { ListingTableColumnMeta } from '@/types/table';
 
-import type { TFilter } from '@/types/general';
+import { RedirectFrom, type TFilter } from '@/types/general';
 
 import { InputTime } from './InputTime';
 
@@ -71,7 +71,10 @@ const getLinkProps = (
     from: '/hardware',
     to: '/hardware/$hardwareId',
     params: { hardwareId: row.original.hardware_name },
-
+    state: {
+      id: row.original.hardware_name,
+      from: RedirectFrom.Hardware,
+    },
     search: previousSearch => ({
       ...previousSearch,
       currentPageTab: zPossibleTabValidator.parse(tabTarget),

--- a/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
+++ b/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
@@ -68,7 +68,6 @@ const HardwareBuildDetails = (): JSX.Element => {
       onClickFilter={onClickFilter}
       tableFilter={searchParams.tableFilter ?? zTableFilterInfoDefault}
       getTestTableRowLink={getTestTableRowLink}
-      historyState={historyState}
     />
   );
 };

--- a/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
+++ b/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
@@ -66,7 +66,6 @@ const TreeBuildDetails = (): JSX.Element => {
       onClickFilter={onClickFilter}
       tableFilter={searchParams.tableFilter ?? zTableFilterInfoDefault}
       getTestTableRowLink={getTestTableRowLink}
-      historyState={historyState}
     />
   );
 };

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -40,9 +40,12 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
   const { treeId } = useParams({
     from: '/tree/$treeId',
   });
-  const { tableFilter, diffFilter } = useSearch({
+
+  const searchParams = useSearch({
     from: '/tree/$treeId',
   });
+
+  const { tableFilter, diffFilter } = searchParams;
   const currentPathFilter = diffFilter.bootPath
     ? Object.keys(diffFilter.bootPath)[0]
     : undefined;
@@ -59,6 +62,7 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
             bootPath: pathFilter === '' ? undefined : { [pathFilter]: true },
           },
         }),
+        state: s => s,
       });
     },
     [navigate],
@@ -76,6 +80,7 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
             },
           };
         },
+        state: s => s,
       });
     },
     [navigate],
@@ -221,6 +226,7 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
           getRowLink={getRowLink}
           updatePathFilter={updatePathFilter}
           currentPathFilter={currentPathFilter}
+          searchParams={searchParams}
         />
       </QuerySwitcher>
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -93,6 +93,7 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
             diffFilter: newFilter,
           };
         },
+        state: s => s,
       });
     },
     [navigate],

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -18,7 +18,8 @@ export function TreeDetailsBuildsTable({
   buildItems,
 }: TTreeDetailsBuildsTable): JSX.Element {
   const { treeId } = useParams({ from: '/tree/$treeId' });
-  const { tableFilter } = useSearch({ from: '/tree/$treeId' });
+  const searchParams = useSearch({ from: '/tree/$treeId' });
+  const { tableFilter } = searchParams;
   const navigate = useNavigate({ from: '/tree/$treeId' });
 
   const getRowLink = useCallback(
@@ -45,6 +46,7 @@ export function TreeDetailsBuildsTable({
             },
           };
         },
+        state: s => s,
       });
     },
     [navigate],
@@ -57,6 +59,7 @@ export function TreeDetailsBuildsTable({
       buildItems={buildItems}
       onClickFilter={onClickFilter}
       getRowLink={getRowLink}
+      searchParams={searchParams}
     />
   );
 }

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -46,9 +46,11 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
   const { isLoading: isSummaryLoading, error: summaryError } = summaryQuery;
   const summaryData = treeDetailsLazyLoaded.summary.data?.summary.tests;
 
-  const { tableFilter, diffFilter } = useSearch({
+  const searchParams = useSearch({
     from: '/tree/$treeId',
   });
+  const { tableFilter, diffFilter } = searchParams;
+
   const currentPathFilter = diffFilter.testPath
     ? Object.keys(diffFilter.testPath)[0]
     : undefined;
@@ -96,6 +98,7 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
             },
           };
         },
+        state: s => s,
       });
     },
     [navigate],
@@ -222,6 +225,7 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
           getRowLink={getRowLink}
           updatePathFilter={updatePathFilter}
           currentPathFilter={currentPathFilter}
+          searchParams={searchParams}
         />
       </QuerySwitcher>
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
@@ -27,6 +27,10 @@ const TreeCommitNavigationGraph = (): React.ReactNode => {
         params: {
           treeId: commitHash,
         },
+        state: s => ({
+          ...s,
+          id: commitHash,
+        }),
         search: previousParams => ({
           ...previousParams,
           treeInfo: {

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -68,6 +68,7 @@ const TreeDetailsTab = ({
             currentPageTab: validatedValue,
           };
         },
+        state: s => s,
       });
     },
     [navigate],

--- a/dashboard/src/pages/TreeDetails/Tabs/WrapperTableWithLogSheet.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/WrapperTableWithLogSheet.tsx
@@ -1,11 +1,14 @@
 import type { PropsWithChildren } from 'react';
 
-import type { LinkProps } from '@tanstack/react-router';
+import type { HistoryState, LinkProps } from '@tanstack/react-router';
+
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import { Sheet } from '@/components/Sheet';
 
 import { LogOrJsonSheetContent } from '@/components/Sheet/LogOrJsonSheetContent';
 import type { TNavigationLogActions } from '@/components/Sheet/WrapperSheetContent';
+import type { TIssue } from '@/types/general';
 
 interface TableWithLogSheetProps {
   currentLog?: number;
@@ -14,6 +17,11 @@ interface TableWithLogSheetProps {
   logUrl?: string;
   navigationLogsActions?: TNavigationLogActions;
   currentLinkProps: LinkProps;
+  issues?: TIssue[];
+  status?: UseQueryResult['status'];
+  error?: UseQueryResult['error'];
+  previousSearch?: LinkProps['search'];
+  historyState?: HistoryState;
 }
 
 const WrapperTableWithLogSheet = ({
@@ -24,6 +32,11 @@ const WrapperTableWithLogSheet = ({
   navigationLogsActions,
   onOpenChange,
   currentLinkProps,
+  issues,
+  previousSearch,
+  status,
+  error,
+  historyState,
 }: PropsWithChildren<TableWithLogSheetProps>): JSX.Element => {
   return (
     <div className="flex flex-col gap-6 pb-4">
@@ -35,6 +48,11 @@ const WrapperTableWithLogSheet = ({
           logUrl={logUrl}
           navigationLogsActions={navigationLogsActions}
           currentLinkProps={currentLinkProps}
+          issues={issues}
+          status={status}
+          previousSearch={previousSearch}
+          historyState={historyState}
+          error={error}
         />
       </Sheet>
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/WrapperTableWithLogSheet.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/WrapperTableWithLogSheet.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react';
 
-import type { HistoryState, LinkProps } from '@tanstack/react-router';
+import type { LinkProps } from '@tanstack/react-router';
 
 import type { UseQueryResult } from '@tanstack/react-query';
 
@@ -21,7 +21,6 @@ interface TableWithLogSheetProps {
   status?: UseQueryResult['status'];
   error?: UseQueryResult['error'];
   previousSearch?: LinkProps['search'];
-  historyState?: HistoryState;
 }
 
 const WrapperTableWithLogSheet = ({
@@ -33,10 +32,9 @@ const WrapperTableWithLogSheet = ({
   onOpenChange,
   currentLinkProps,
   issues,
-  previousSearch,
   status,
   error,
-  historyState,
+  previousSearch,
 }: PropsWithChildren<TableWithLogSheetProps>): JSX.Element => {
   return (
     <div className="flex flex-col gap-6 pb-4">
@@ -51,7 +49,6 @@ const WrapperTableWithLogSheet = ({
           issues={issues}
           status={status}
           previousSearch={previousSearch}
-          historyState={historyState}
           error={error}
         />
       </Sheet>

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -148,6 +148,7 @@ function TreeDetails(): JSX.Element {
             diffFilter: newFilter,
           };
         },
+        state: s => s,
       });
     },
     [navigate],
@@ -161,6 +162,7 @@ function TreeDetails(): JSX.Element {
           diffFilter: {},
         };
       },
+      state: s => s,
     });
   }, [navigate]);
 
@@ -242,6 +244,7 @@ function TreeDetails(): JSX.Element {
                     origin: previousParams.origin,
                   };
                 }}
+                state={s => s}
               >
                 <FormattedMessage id="tree.path" />
               </BreadcrumbLink>

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -152,6 +152,7 @@ const TreeDetailsFilter = ({
           diffFilter: cleanedFilter,
         };
       },
+      state: s => s,
     });
   }, [diffFilter, navigate]);
 

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -107,6 +107,7 @@ function HardwareDetails(): JSX.Element {
           ...previousSearch,
           treeIndexes: selectedIndexes,
         }),
+        state: s => s,
       });
     },
     [navigate],
@@ -121,6 +122,7 @@ function HardwareDetails(): JSX.Element {
             diffFilter: newFilter,
           };
         },
+        state: s => s,
       });
     },
     [navigate],
@@ -134,6 +136,7 @@ function HardwareDetails(): JSX.Element {
           diffFilter: {},
         };
       },
+      state: s => s,
     });
   }, [navigate]);
 
@@ -279,6 +282,7 @@ function HardwareDetails(): JSX.Element {
                         hardwareSearch: previousParams.hardwareSearch,
                       };
                     }}
+                    state={s => s}
                   >
                     <FormattedMessage id="hardware.path" />
                   </BreadcrumbLink>

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -207,6 +207,7 @@ const HardwareDetailsFilter = ({
           diffFilter: cleanedFilter,
         };
       },
+      state: s => s,
     });
   }, [diffFilter, navigate, treeIndexes]);
 

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
@@ -94,6 +94,7 @@ const CommitSelector = ({
             treeIndexes: parsedTreeIndex,
           };
         },
+        state: s => s,
       });
     },
     [navigate, rowLength, treeIndex, treeCommits],

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -52,9 +52,12 @@ const BootsTab = ({
   bootsSummary,
   fullDataResult,
 }: IBootsTab): JSX.Element => {
-  const { tableFilter, diffFilter } = useSearch({
+  const searchParams = useSearch({
     from: '/hardware/$hardwareId',
   });
+
+  const { tableFilter, diffFilter } = searchParams;
+
   const currentPathFilter = diffFilter.bootPath
     ? Object.keys(diffFilter.bootPath)[0]
     : undefined;
@@ -83,6 +86,7 @@ const BootsTab = ({
             bootPath: pathFilter === '' ? undefined : { [pathFilter]: true },
           },
         }),
+        state: s => s,
       });
     },
     [navigate],
@@ -100,6 +104,7 @@ const BootsTab = ({
             },
           };
         },
+        state: s => s,
       });
     },
     [navigate],
@@ -197,6 +202,7 @@ const BootsTab = ({
           onClickFilter={onClickFilter}
           updatePathFilter={updatePathFilter}
           currentPathFilter={currentPathFilter}
+          searchParams={searchParams}
         />
       </HardwareDetailsTabsQuerySwitcher>
     </div>

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -73,6 +73,7 @@ const BuildTab = ({
             diffFilter: newFilter,
           };
         },
+        state: s => s,
       });
     },
     [navigate],

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -36,7 +36,9 @@ export function HardwareDetailsBuildsTable({
   buildsData,
   hardwareId,
 }: THardwareDetailsBuildsTable): JSX.Element {
-  const { tableFilter } = useSearch({ from: '/hardware/$hardwareId' });
+  const searchParams = useSearch({ from: '/hardware/$hardwareId' });
+
+  const { tableFilter } = searchParams;
 
   const navigate = useNavigate({ from: '/hardware/$hardwareId' });
 
@@ -79,6 +81,7 @@ export function HardwareDetailsBuildsTable({
       columns={hardwareDetailsBuildColumns}
       onClickFilter={onClickFilter}
       getRowLink={getRowLink}
+      previousSearch={searchParams}
     />
   );
 }

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -68,6 +68,7 @@ export function HardwareDetailsBuildsTable({
             },
           };
         },
+        state: s => s,
       });
     },
     [navigate],
@@ -81,7 +82,7 @@ export function HardwareDetailsBuildsTable({
       columns={hardwareDetailsBuildColumns}
       onClickFilter={onClickFilter}
       getRowLink={getRowLink}
-      previousSearch={searchParams}
+      searchParams={searchParams}
     />
   );
 }

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
@@ -45,6 +45,7 @@ const HardwareCommitNavigationGraph = ({
           ...current,
           treeCommits: { ...treeCommits, [treeIdx]: commitHash },
         }),
+        state: s => s,
       });
     },
     [navigate, treeIdx, treeCommits],

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -55,6 +55,7 @@ const HardwareDetailsTabs = ({
             currentPageTab: validatedValue,
           };
         },
+        state: s => s,
       });
     },
     [navigate],

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/HardwareDetailsTestsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/HardwareDetailsTestsTable.tsx
@@ -75,6 +75,7 @@ const innerColumns: ColumnDef<TIndividualTest>[] = [
 interface IHardwareDetailsTestTable
   extends Omit<ITestsTable, 'columns' | 'innerColumns ' | 'getRowLink'> {
   hardwareId: string;
+  searchParams?: LinkProps['search'];
 }
 
 const HardwareDetailsTestTable = ({
@@ -85,6 +86,7 @@ const HardwareDetailsTestTable = ({
   hardwareId,
   updatePathFilter,
   currentPathFilter,
+  searchParams,
 }: IHardwareDetailsTestTable): JSX.Element => {
   const getRowLink = useCallback(
     (bootId: string): LinkProps => ({
@@ -108,6 +110,7 @@ const HardwareDetailsTestTable = ({
       getRowLink={getRowLink}
       updatePathFilter={updatePathFilter}
       currentPathFilter={currentPathFilter}
+      searchParams={searchParams}
     />
   );
 };

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -51,9 +51,11 @@ const TestsTab = ({
   testsSummary,
   fullDataResult,
 }: ITestsTab): JSX.Element => {
-  const { tableFilter, diffFilter } = useSearch({
+  const searchParams = useSearch({
     from: '/hardware/$hardwareId',
   });
+
+  const { tableFilter, diffFilter } = searchParams;
   const currentPathFilter = diffFilter.testPath
     ? Object.keys(diffFilter.testPath)[0]
     : undefined;
@@ -70,6 +72,7 @@ const TestsTab = ({
             testPath: pathFilter === '' ? undefined : { [pathFilter]: true },
           },
         }),
+        state: s => s,
       });
     },
     [navigate],
@@ -87,6 +90,7 @@ const TestsTab = ({
             },
           };
         },
+        state: s => s,
       });
     },
     [navigate],
@@ -184,6 +188,7 @@ const TestsTab = ({
           onClickFilter={onClickFilter}
           updatePathFilter={updatePathFilter}
           currentPathFilter={currentPathFilter}
+          searchParams={searchParams}
         />
       </HardwareDetailsTabsQuerySwitcher>
     </div>


### PR DESCRIPTION
Using the `getIssues` hooks defined for build and tests, fetch the issues.
Show the issue list similar to issue list in build/tests details.

Close #805 

### **How to test**
Go to a tree details, open any tab, search for a build or test with issues in the table and open the log viewer.
Try to click in a issue and return to the previous page using the breadcrum.

_Examples:_
- [with build issue](http://localhost:5173/tree/a95d721f13a42c0ec4eb248effb964cae88c4254?ti%7Cc=ASB-2025-01-05_mainline-466-ga95d721f13a4&ti%7Cch=a95d721f13a42c0ec4eb248effb964cae88c4254&ti%7Cgb=android-mainline&ti%7Cgu=https%3A%2F%2Fandroid.googlesource.com%2Fkernel%2Fcommon&ti%7Ct=android)
- [with test issue (boot)](http://localhost:5173/tree/3c28eb3350c8e187fca5c4ab0098a70273cef1ee?p=bt&ti%7Cc=v6.13-rc7-18-g3c28eb3350c8e&ti%7Cch=3c28eb3350c8e187fca5c4ab0098a70273cef1ee&ti%7Cgb=for-next&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fbroonie%2Fregulator.git&ti%7Ct=broonie-regulator)