### PR TITLE
Feat: hardwareDetails lazy load

### DIFF
--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -5,51 +5,20 @@ import type {
   CommitHead,
   CommitHistoryResponse,
   CommitHistoryTable,
+  HardwareDetailsSummaryResponse,
   THardwareDetails,
   THardwareDetailsFilter,
   TTreeCommits,
 } from '@/types/hardware/hardwareDetails';
-import type { TFilter, TOrigins } from '@/types/general';
+import type {
+  BuildsTabBuild,
+  TestHistory,
+  TFilter,
+  TOrigins,
+} from '@/types/general';
 import { getTargetFilter } from '@/types/general';
 
 import { RequestData } from './commonRequest';
-
-type fetchHardwareDetailsBody = {
-  startTimestampInSeconds: number;
-  endTimestampInSeconds: number;
-  origin: TOrigins;
-  selectedCommits: Record<string, string>;
-  filter?: Record<string, string[]>;
-};
-
-const mapFiltersKeysToBackendCompatible = (
-  filter: THardwareDetailsFilter | Record<string, never>,
-): Record<string, string[]> => {
-  const filterParam: { [key: string]: string[] } = {};
-
-  Object.keys(filter).forEach(key => {
-    const filterList = filter[key as keyof THardwareDetailsFilter];
-    filterList?.forEach(value => {
-      if (!filterParam[`filter_${key}`])
-        filterParam[`filter_${key}`] = [value.toString()];
-      else filterParam[`filter_${key}`].push(value.toString());
-    });
-  });
-
-  return filterParam;
-};
-
-const fetchHardwareDetails = async (
-  hardwareId: string,
-  body: fetchHardwareDetailsBody,
-): Promise<THardwareDetails> => {
-  const data = await RequestData.post<THardwareDetails>(
-    `/api/hardware/${hardwareId}`,
-    body,
-  );
-
-  return data;
-};
 
 const TREE_SELECT_HEAD_VALUE = 'head';
 
@@ -68,15 +37,103 @@ const mapIndexesToSelectedTrees = (
   return selectedTrees;
 };
 
-export const useHardwareDetails = (
-  hardwareId: string,
-  startTimestampInSeconds: number,
-  endTimestampInSeconds: number,
-  origin: TOrigins,
-  filter: TFilter,
-  selectedIndexes: number[],
-  treeCommits: TTreeCommits,
-): UseQueryResult<THardwareDetails> => {
+// TODO: remove this function to combine with the solution for the same function in utils.ts
+const mapFiltersKeysToBackendCompatible = (
+  filter: THardwareDetailsFilter | Record<string, never>,
+): Record<string, string[]> => {
+  const filterParam: { [key: string]: string[] } = {};
+
+  Object.keys(filter).forEach(key => {
+    const filterList = filter[key as keyof THardwareDetailsFilter];
+    filterList?.forEach(value => {
+      if (!filterParam[`filter_${key}`])
+        filterParam[`filter_${key}`] = [value.toString()];
+      else filterParam[`filter_${key}`].push(value.toString());
+    });
+  });
+
+  return filterParam;
+};
+
+type HardwareDetailsVariants =
+  | 'full'
+  | 'builds'
+  | 'boots'
+  | 'tests'
+  | 'summary';
+
+type fetchHardwareDetailsBody = {
+  startTimestampInSeconds: number;
+  endTimestampInSeconds: number;
+  origin: TOrigins;
+  selectedCommits: Record<string, string>;
+  filter?: Record<string, string[]>;
+};
+
+const fetchHardwareDetails = async ({
+  hardwareId,
+  body,
+  variant,
+}: {
+  hardwareId: string;
+  body: fetchHardwareDetailsBody;
+  variant: HardwareDetailsVariants;
+}): Promise<THardwareDetails> => {
+  const urlTable: Record<HardwareDetailsVariants, string> = {
+    full: `/api/hardware/${hardwareId}`,
+    builds: `/api/hardware/${hardwareId}/builds`,
+    boots: `/api/hardware/${hardwareId}/boots`,
+    tests: `/api/hardware/${hardwareId}/tests`,
+    summary: `/api/hardware/${hardwareId}/summary`,
+  };
+
+  const data = await RequestData.post<THardwareDetails>(
+    urlTable[variant],
+    body,
+  );
+
+  return data;
+};
+
+type HardwareDetailsResponseTable = {
+  full: THardwareDetails;
+  summary: HardwareDetailsSummaryResponse;
+  builds: BuildsTabBuild[];
+  boots: TestHistory[];
+  tests: TestHistory[];
+};
+
+type HardwareDetailsResponse<T extends keyof HardwareDetailsResponseTable> =
+  HardwareDetailsResponseTable[T];
+
+export type UseHardwareDetailsWithoutVariant = {
+  hardwareId: string;
+  startTimestampInSeconds: number;
+  endTimestampInSeconds: number;
+  origin: TOrigins;
+  filter: TFilter;
+  selectedIndexes: number[];
+  treeCommits: TTreeCommits;
+  enabled?: boolean;
+};
+
+type UseHardwareDetailsParameters<T extends HardwareDetailsVariants> = {
+  variant: T;
+} & UseHardwareDetailsWithoutVariant;
+
+export const useHardwareDetails = <T extends HardwareDetailsVariants>({
+  hardwareId,
+  startTimestampInSeconds,
+  endTimestampInSeconds,
+  origin,
+  filter,
+  selectedIndexes,
+  treeCommits,
+  enabled = true,
+  variant,
+}: UseHardwareDetailsParameters<T>): UseQueryResult<
+  HardwareDetailsResponse<T>
+> => {
   const testFilter = getTargetFilter(filter, 'test');
   const detailsFilter = getTargetFilter(filter, 'hardwareDetails');
 
@@ -98,9 +155,10 @@ export const useHardwareDetails = (
   };
 
   return useQuery({
-    queryKey: ['HardwareDetails', hardwareId, body],
-    queryFn: () => fetchHardwareDetails(hardwareId, body),
+    queryKey: ['HardwareDetails', hardwareId, body, variant],
+    queryFn: () => fetchHardwareDetails({ hardwareId, body, variant }),
     placeholderData: previousData => previousData,
+    enabled: enabled,
   });
 };
 

--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -100,7 +100,7 @@ const columns: ColumnDef<TestByCommitHash>[] = [
 
 interface IBootsTable {
   tableKey: TableKeys;
-  testHistory: TestHistory[];
+  testHistory?: TestHistory[];
   filter: TestsTableFilter;
   getRowLink: (testId: TestHistory['id']) => LinkProps;
   onClickFilter: (newFilter: TestsTableFilter) => void;
@@ -125,15 +125,17 @@ export function BootsTable({
 
   const rawData = useMemo(
     (): TTestByCommitHashResponse => ({
-      tests: testHistory.map(
-        (e): TestByCommitHash => ({
-          duration: e.duration?.toString() ?? '',
-          id: e.id,
-          path: e.path,
-          startTime: e.start_time,
-          status: e.status,
-        }),
-      ),
+      tests: testHistory
+        ? testHistory.map(
+            (e): TestByCommitHash => ({
+              duration: e.duration?.toString() ?? '',
+              id: e.id,
+              path: e.path,
+              startTime: e.start_time,
+              status: e.status,
+            }),
+          )
+        : [],
     }),
     [testHistory],
   );

--- a/dashboard/src/components/DetailsPages/SectionError.tsx
+++ b/dashboard/src/components/DetailsPages/SectionError.tsx
@@ -1,13 +1,14 @@
-import { memo, useMemo } from 'react';
+import { Fragment, memo, useMemo } from 'react';
 import { RiProhibited2Line } from 'react-icons/ri';
 import type { MessageDescriptor } from 'react-intl';
 import { FormattedMessage } from 'react-intl';
 
 interface ISectionError {
   errorMessage?: string;
-  isLoading: boolean;
+  isLoading?: boolean;
   isEmpty?: boolean;
   emptyLabel?: MessageDescriptor['id'];
+  customEmptyDataComponent?: JSX.Element;
 }
 
 const SectionError = ({
@@ -15,6 +16,7 @@ const SectionError = ({
   isLoading,
   isEmpty,
   emptyLabel = 'global.noResults',
+  customEmptyDataComponent,
 }: ISectionError): JSX.Element => {
   const message = useMemo((): MessageDescriptor['id'] => {
     if (isLoading) {
@@ -26,6 +28,10 @@ const SectionError = ({
     }
     return 'global.error';
   }, [emptyLabel, errorMessage, isEmpty, isLoading]);
+
+  if (isLoading === undefined) {
+    return customEmptyDataComponent ?? <Fragment />;
+  }
 
   return (
     <div className="flex flex-col items-center py-6 text-weakGray">

--- a/dashboard/src/components/QuerySwitcher/QuerySwitcher.tsx
+++ b/dashboard/src/components/QuerySwitcher/QuerySwitcher.tsx
@@ -1,5 +1,5 @@
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { ReactNode } from 'react';
+import { Fragment, type ReactNode } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -10,11 +10,12 @@ import { Skeleton } from '@/components/ui/skeleton';
 export type QuerySelectorStatus = UseQueryResult['status'];
 
 type QuerySwitcherProps = {
-  status: QuerySelectorStatus;
+  status?: QuerySelectorStatus;
   children: ReactNode;
   skeletonClassname?: string;
   data?: unknown;
   customError?: ReactNode;
+  customEmptyDataComponent?: JSX.Element;
 };
 
 const QuerySwitcher = ({
@@ -23,7 +24,12 @@ const QuerySwitcher = ({
   skeletonClassname,
   data,
   customError,
+  customEmptyDataComponent,
 }: QuerySwitcherProps): JSX.Element => {
+  if (!status) {
+    return customEmptyDataComponent ?? <Fragment />;
+  }
+
   switch (status) {
     case 'pending':
       return (

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -45,7 +45,7 @@ import { defaultColumns, defaultInnerColumns } from './DefaultTestsColumns';
 
 export interface ITestsTable {
   tableKey: TableKeys;
-  testHistory: TestHistory[];
+  testHistory?: TestHistory[];
   onClickFilter: (filter: TestsTableFilter) => void;
   filter: TestsTableFilter;
   columns?: ColumnDef<TPathTests>[];
@@ -78,55 +78,57 @@ export function TestsTable({
       [K: string]: TPathTests;
     };
     const groups: Groups = {};
-    testHistory.forEach(e => {
-      const parts = e.path.split('.', 1);
-      const group = parts.length > 0 ? parts[0] : '-';
-      if (!(group in groups)) {
-        groups[group] = {
-          done_tests: 0,
-          fail_tests: 0,
-          miss_tests: 0,
-          pass_tests: 0,
-          null_tests: 0,
-          skip_tests: 0,
-          error_tests: 0,
-          total_tests: 0,
-          path_group: group,
-          individual_tests: [],
-        };
-      }
-      groups[group].total_tests++;
-      groups[group].individual_tests.push({
-        id: e.id,
-        duration: e.duration?.toString() ?? '',
-        path: e.path,
-        start_time: e.start_time,
-        status: e.status,
-        hardware: e.environment_compatible,
+    if (testHistory !== undefined) {
+      testHistory.forEach(e => {
+        const parts = e.path.split('.', 1);
+        const group = parts.length > 0 ? parts[0] : '-';
+        if (!(group in groups)) {
+          groups[group] = {
+            done_tests: 0,
+            fail_tests: 0,
+            miss_tests: 0,
+            pass_tests: 0,
+            null_tests: 0,
+            skip_tests: 0,
+            error_tests: 0,
+            total_tests: 0,
+            path_group: group,
+            individual_tests: [],
+          };
+        }
+        groups[group].total_tests++;
+        groups[group].individual_tests.push({
+          id: e.id,
+          duration: e.duration?.toString() ?? '',
+          path: e.path,
+          start_time: e.start_time,
+          status: e.status,
+          hardware: e.environment_compatible,
+        });
+        switch (e.status) {
+          case 'DONE':
+            groups[group].done_tests++;
+            break;
+          case 'ERROR':
+            groups[group].error_tests++;
+            break;
+          case 'FAIL':
+            groups[group].fail_tests++;
+            break;
+          case 'MISS':
+            groups[group].miss_tests++;
+            break;
+          case 'PASS':
+            groups[group].pass_tests++;
+            break;
+          case 'SKIP':
+            groups[group].skip_tests++;
+            break;
+          default:
+            groups[group].null_tests++;
+        }
       });
-      switch (e.status) {
-        case 'DONE':
-          groups[group].done_tests++;
-          break;
-        case 'ERROR':
-          groups[group].error_tests++;
-          break;
-        case 'FAIL':
-          groups[group].fail_tests++;
-          break;
-        case 'MISS':
-          groups[group].miss_tests++;
-          break;
-        case 'PASS':
-          groups[group].pass_tests++;
-          break;
-        case 'SKIP':
-          groups[group].skip_tests++;
-          break;
-        default:
-          groups[group].null_tests++;
-      }
-    });
+    }
     return Object.values(groups);
   }, [testHistory]);
 

--- a/dashboard/src/hooks/useHardwareDetailsLazyLoadQuery.ts
+++ b/dashboard/src/hooks/useHardwareDetailsLazyLoadQuery.ts
@@ -1,0 +1,54 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import type { QuerySelectorStatus } from '@/components/QuerySwitcher/QuerySwitcher';
+import type { UseHardwareDetailsWithoutVariant } from '@/api/hardwareDetails';
+import { useHardwareDetails } from '@/api/hardwareDetails';
+import type {
+  HardwareSummary,
+  THardwareDetails,
+} from '@/types/hardware/hardwareDetails';
+
+export type HardwareDetailsLazyLoaded = {
+  summary: {
+    data?: HardwareSummary;
+    isLoading: boolean;
+    status: QuerySelectorStatus;
+    error: UseQueryResult['error'];
+    isPlaceholderData: boolean;
+  };
+  full: UseQueryResult<THardwareDetails>;
+  common: {
+    isAllReady: boolean;
+    isAnyLoading: boolean;
+  };
+};
+
+export const useHardwareDetailsLazyLoadQuery = (
+  useHardwareDetailsArgs: UseHardwareDetailsWithoutVariant,
+): HardwareDetailsLazyLoaded => {
+  const summaryResult = useHardwareDetails({
+    ...useHardwareDetailsArgs,
+    variant: 'summary',
+  });
+
+  const fullResult = useHardwareDetails({
+    ...useHardwareDetailsArgs,
+    variant: 'full',
+    enabled: !!summaryResult.data,
+  });
+
+  return {
+    summary: {
+      data: summaryResult.data?.summary,
+      isLoading: summaryResult.isLoading,
+      status: summaryResult.status,
+      isPlaceholderData: summaryResult.isPlaceholderData,
+      error: summaryResult.error,
+    },
+    full: fullResult,
+    common: {
+      isAllReady: !!summaryResult && !!fullResult,
+      isAnyLoading: summaryResult.isLoading || fullResult.isLoading,
+    },
+  };
+};

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { status as testStatuses } from '@/utils/constants/database';
 import type { IDrawerLink } from '@/components/Filter/Drawer';
 import FilterDrawer from '@/components/Filter/Drawer';
-import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import type { HardwareSummary } from '@/types/hardware/hardwareDetails';
 import { Skeleton } from '@/components/Skeleton';
 
 import {
@@ -24,7 +24,7 @@ type TFilterValues = Record<string, boolean>;
 interface IHardwareDetailsFilter {
   paramFilter: TFilter;
   hardwareName: string;
-  data: THardwareDetails;
+  data: HardwareSummary | undefined;
   selectedTrees?: number[];
 }
 
@@ -33,7 +33,7 @@ type TFilterCreate = TFilter & {
 };
 
 export const createFilter = (
-  data: THardwareDetails | undefined,
+  data: HardwareSummary | undefined,
 ): TFilterCreate => {
   const buildStatus = { Success: false, Failure: false, Inconclusive: false };
 
@@ -57,7 +57,7 @@ export const createFilter = (
   const treeIndexes: number[] = [];
 
   if (data) {
-    data.summary.trees.forEach(tree => {
+    data.trees.forEach(tree => {
       const treeIdx = Number(tree.index);
       const treeName = tree.tree_name ?? 'Unknown';
       const treeBranch = tree.git_repository_branch ?? 'Unknown';
@@ -71,22 +71,22 @@ export const createFilter = (
       treeIndexes.push(treeIdx);
     });
 
-    data.summary.architectures.forEach(arch => {
+    data.architectures.forEach(arch => {
       archs[arch ?? 'Unknown'] = false;
     });
-    data.summary.compilers.forEach(compiler => {
+    data.compilers.forEach(compiler => {
       compilers[compiler ?? 'Unknown'] = false;
     });
-    data.summary.configs.forEach(config => {
+    data.configs.forEach(config => {
       configs[config ?? 'Unknown'] = false;
     });
-    data.summary.builds.issues.forEach(i => (buildIssue[i.id] = false));
-    data.summary.boots.issues.forEach(i => (bootIssue[i.id] = false));
-    data.summary.tests.issues.forEach(i => (testIssue[i.id] = false));
-    Object.keys(data.summary.boots.platforms ?? {}).forEach(
+    data.builds.issues.forEach(i => (buildIssue[i.id] = false));
+    data.boots.issues.forEach(i => (bootIssue[i.id] = false));
+    data.tests.issues.forEach(i => (testIssue[i.id] = false));
+    Object.keys(data.boots.platforms ?? {}).forEach(
       i => (bootPlatform[i] = false),
     );
-    Object.keys(data.summary.tests.platforms ?? {}).forEach(
+    Object.keys(data.tests.platforms ?? {}).forEach(
       i => (testPlatform[i] = false),
     );
   }

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -6,11 +6,16 @@ import type { LinkProps } from '@tanstack/react-router';
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
+import type { UseQueryResult } from '@tanstack/react-query';
+
 import { BootsTable } from '@/components/BootsTable/BootsTable';
 
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
-import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import type {
+  HardwareSummary,
+  THardwareDetails,
+} from '@/types/hardware/hardwareDetails';
 
 import {
   zTableFilterInfoDefault,
@@ -32,19 +37,20 @@ import { sanitizePlatforms } from '@/utils/utils';
 
 import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph';
 import { RedirectFrom } from '@/types/general';
+import { HardwareDetailsTabsQuerySwitcher } from '@/pages/hardwareDetails/Tabs/HardwareDetailsTabsQuerySwitcher';
 
 interface IBootsTab {
-  boots: THardwareDetails['boots'];
-  bootsSummary: THardwareDetails['summary']['boots'];
-  trees: THardwareDetails['summary']['trees'];
   hardwareId: string;
+  trees: HardwareSummary['trees'];
+  bootsSummary: HardwareSummary['boots'];
+  fullDataResult?: UseQueryResult<THardwareDetails>;
 }
 
 const BootsTab = ({
-  bootsSummary,
-  boots,
   hardwareId,
   trees,
+  bootsSummary,
+  fullDataResult,
 }: IBootsTab): JSX.Element => {
   const { tableFilter, diffFilter } = useSearch({
     from: '/hardware/$hardwareId',
@@ -179,15 +185,20 @@ const BootsTab = ({
           </div>
         </InnerMobileGrid>
       </MobileGrid>
-      <BootsTable
-        tableKey="hardwareDetailsBoots"
-        getRowLink={getRowLink}
-        filter={tableFilter.bootsTable}
-        testHistory={boots}
-        onClickFilter={onClickFilter}
-        updatePathFilter={updatePathFilter}
-        currentPathFilter={currentPathFilter}
-      />
+      <HardwareDetailsTabsQuerySwitcher
+        fullDataResult={fullDataResult}
+        tabData={fullDataResult?.data?.boots}
+      >
+        <BootsTable
+          tableKey="hardwareDetailsBoots"
+          getRowLink={getRowLink}
+          filter={tableFilter.bootsTable}
+          testHistory={fullDataResult?.data?.boots}
+          onClickFilter={onClickFilter}
+          updatePathFilter={updatePathFilter}
+          currentPathFilter={currentPathFilter}
+        />
+      </HardwareDetailsTabsQuerySwitcher>
     </div>
   );
 };

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -4,7 +4,12 @@ import { useCallback, useMemo } from 'react';
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
-import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import type {
+  HardwareSummary,
+  THardwareDetails,
+} from '@/types/hardware/hardwareDetails';
 import { sanitizeArchs, sanitizeConfigs } from '@/utils/utils';
 
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
@@ -23,20 +28,22 @@ import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/Hardware
 
 import { RedirectFrom, type TFilterObjectsKeys } from '@/types/general';
 
+import { HardwareDetailsTabsQuerySwitcher } from '@/pages/hardwareDetails/Tabs/HardwareDetailsTabsQuerySwitcher';
+
 import { HardwareDetailsBuildsTable } from './HardwareDetailsBuildsTable';
 
 interface IBuildTab {
-  builds: THardwareDetails['builds'];
-  buildsSummary: THardwareDetails['summary']['builds'];
-  trees: THardwareDetails['summary']['trees'];
+  trees: HardwareSummary['trees'];
   hardwareId: string;
+  buildsSummary: HardwareSummary['builds'];
+  fullDataResult?: UseQueryResult<THardwareDetails>;
 }
 
 const BuildTab = ({
-  buildsSummary,
-  builds,
   hardwareId,
   trees,
+  buildsSummary,
+  fullDataResult,
 }: IBuildTab): JSX.Element => {
   const navigate = useNavigate({
     from: '/hardware/$hardwareId',
@@ -149,10 +156,15 @@ const BuildTab = ({
         <div className="text-lg">
           <FormattedMessage id="global.builds" />
         </div>
-        <HardwareDetailsBuildsTable
-          buildsData={builds}
-          hardwareId={hardwareId}
-        />
+        <HardwareDetailsTabsQuerySwitcher
+          fullDataResult={fullDataResult}
+          tabData={fullDataResult?.data?.builds}
+        >
+          <HardwareDetailsBuildsTable
+            buildsData={fullDataResult?.data?.builds}
+            hardwareId={hardwareId}
+          />
+        </HardwareDetailsTabsQuerySwitcher>
       </div>
     </div>
   );

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
 import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
-import { sanitizeArchs, sanitizeBuilds, sanitizeConfigs } from '@/utils/utils';
+import { sanitizeArchs, sanitizeConfigs } from '@/utils/utils';
 
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
@@ -81,8 +81,6 @@ const BuildTab = ({
     [buildsSummary.configs],
   );
 
-  const buildItems = useMemo(() => sanitizeBuilds(builds), [builds]);
-
   return (
     <div className="flex flex-col gap-8 pt-4">
       <DesktopGrid>
@@ -152,7 +150,7 @@ const BuildTab = ({
           <FormattedMessage id="global.builds" />
         </div>
         <HardwareDetailsBuildsTable
-          buildItems={buildItems}
+          buildsData={builds}
           hardwareId={hardwareId}
         />
       </div>

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -3,7 +3,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import type { LinkProps } from '@tanstack/react-router';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { BuildsTable } from '@/components/BuildsTable/BuildsTable';
 import { TableHeader } from '@/components/Table/TableHeader';
@@ -14,9 +14,11 @@ import {
   type BuildsTableFilter,
 } from '@/types/tree/TreeDetails';
 import { defaultBuildColumns } from '@/components/BuildsTable/DefaultBuildsColumns';
+import { sanitizeBuilds } from '@/utils/utils';
+import type { BuildsTabBuild } from '@/types/general';
 
 export interface THardwareDetailsBuildsTable {
-  buildItems: AccordionItemBuilds[];
+  buildsData?: BuildsTabBuild[];
   hardwareId: string;
 }
 
@@ -31,12 +33,14 @@ const hardwareDetailsBuildColumns: ColumnDef<AccordionItemBuilds>[] = [
 ];
 
 export function HardwareDetailsBuildsTable({
-  buildItems,
+  buildsData,
   hardwareId,
 }: THardwareDetailsBuildsTable): JSX.Element {
   const { tableFilter } = useSearch({ from: '/hardware/$hardwareId' });
 
   const navigate = useNavigate({ from: '/hardware/$hardwareId' });
+
+  const buildItems = useMemo(() => sanitizeBuilds(buildsData), [buildsData]);
 
   const getRowLink = useCallback(
     (buildId: string): LinkProps => ({

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -3,12 +3,17 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import type { ReactElement } from 'react';
 import { useCallback, useMemo } from 'react';
 
+import type { UseQueryResult } from '@tanstack/react-query';
+
 import type { ITabItem } from '@/components/Tabs/Tabs';
 import Tabs from '@/components/Tabs/Tabs';
 
 import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
 
-import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import type {
+  HardwareSummary,
+  THardwareDetails,
+} from '@/types/hardware/hardwareDetails';
 
 import BuildTab from './Build';
 import BootsTab from './Boots';
@@ -20,17 +25,19 @@ export type TreeDetailsTabRightElement = Record<
 >;
 
 export interface IHardwareDetailsTab {
-  hardwareDetailsData: THardwareDetails;
   hardwareId: string;
   filterListElement?: JSX.Element;
   countElements: TreeDetailsTabRightElement;
+  fullDataResult?: UseQueryResult<THardwareDetails>;
+  summaryData: HardwareSummary;
 }
 
 const HardwareDetailsTabs = ({
-  hardwareDetailsData,
   hardwareId,
   filterListElement,
   countElements,
+  fullDataResult,
+  summaryData,
 }: IHardwareDetailsTab): JSX.Element => {
   const { currentPageTab } = useSearch({
     from: '/hardware/$hardwareId',
@@ -59,10 +66,10 @@ const HardwareDetailsTabs = ({
         name: 'global.builds',
         content: (
           <BuildTab
-            buildsSummary={hardwareDetailsData.summary.builds}
-            builds={hardwareDetailsData.builds}
-            trees={hardwareDetailsData.summary.trees}
             hardwareId={hardwareId}
+            trees={summaryData.trees}
+            buildsSummary={summaryData.builds}
+            fullDataResult={fullDataResult}
           />
         ),
         rightElement: countElements['global.builds'],
@@ -72,10 +79,10 @@ const HardwareDetailsTabs = ({
         name: 'global.boots',
         content: (
           <BootsTab
-            bootsSummary={hardwareDetailsData.summary.boots}
-            boots={hardwareDetailsData.boots}
             hardwareId={hardwareId}
-            trees={hardwareDetailsData.summary.trees}
+            trees={summaryData.trees}
+            bootsSummary={summaryData.boots}
+            fullDataResult={fullDataResult}
           />
         ),
         rightElement: countElements['global.boots'],
@@ -85,10 +92,10 @@ const HardwareDetailsTabs = ({
         name: 'global.tests',
         content: (
           <TestsTab
-            testsSummary={hardwareDetailsData.summary.tests}
-            tests={hardwareDetailsData.tests}
             hardwareId={hardwareId}
-            trees={hardwareDetailsData.summary.trees}
+            trees={summaryData.trees}
+            testsSummary={summaryData.tests}
+            fullDataResult={fullDataResult}
           />
         ),
         rightElement: countElements['global.tests'],
@@ -96,14 +103,12 @@ const HardwareDetailsTabs = ({
       },
     ],
     [
-      hardwareDetailsData.summary.builds,
-      hardwareDetailsData.summary.trees,
-      hardwareDetailsData.summary.boots,
-      hardwareDetailsData.summary.tests,
-      hardwareDetailsData.builds,
-      hardwareDetailsData.boots,
-      hardwareDetailsData.tests,
       hardwareId,
+      summaryData.trees,
+      summaryData.builds,
+      summaryData.boots,
+      summaryData.tests,
+      fullDataResult,
       countElements,
     ],
   );

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabsQuerySwitcher.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabsQuerySwitcher.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from 'react';
+
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+
+import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+
+import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
+
+export const HardwareDetailsTabsQuerySwitcher = ({
+  fullDataResult,
+  tabData,
+  children,
+}: {
+  fullDataResult?: UseQueryResult<THardwareDetails>;
+  tabData?:
+    | THardwareDetails['builds']
+    | THardwareDetails['boots']
+    | THardwareDetails['tests'];
+  children: ReactElement;
+}): JSX.Element => {
+  return (
+    <QuerySwitcher
+      data={tabData}
+      status={fullDataResult?.status}
+      customError={
+        <MemoizedSectionError
+          isLoading={fullDataResult?.isLoading}
+          errorMessage={fullDataResult?.error?.message}
+          emptyLabel={'global.error'}
+        />
+      }
+    >
+      {children}
+    </QuerySwitcher>
+  );
+};

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -4,9 +4,14 @@ import { useCallback, useMemo } from 'react';
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
+import type { UseQueryResult } from '@tanstack/react-query';
+
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
-import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import type {
+  HardwareSummary,
+  THardwareDetails,
+} from '@/types/hardware/hardwareDetails';
 
 import {
   zTableFilterInfoDefault,
@@ -29,20 +34,22 @@ import { sanitizePlatforms } from '@/utils/utils';
 
 import { RedirectFrom } from '@/types/general';
 
+import { HardwareDetailsTabsQuerySwitcher } from '@/pages/hardwareDetails/Tabs/HardwareDetailsTabsQuerySwitcher';
+
 import HardwareDetailsTestTable from './HardwareDetailsTestsTable';
 
 interface ITestsTab {
-  tests: THardwareDetails['tests'];
-  testsSummary: THardwareDetails['summary']['tests'];
-  trees: THardwareDetails['summary']['trees'];
   hardwareId: string;
+  trees: HardwareSummary['trees'];
+  testsSummary: HardwareSummary['tests'];
+  fullDataResult?: UseQueryResult<THardwareDetails>;
 }
 
 const TestsTab = ({
-  testsSummary,
-  tests,
-  trees,
   hardwareId,
+  trees,
+  testsSummary,
+  fullDataResult,
 }: ITestsTab): JSX.Element => {
   const { tableFilter, diffFilter } = useSearch({
     from: '/hardware/$hardwareId',
@@ -165,15 +172,20 @@ const TestsTab = ({
           </div>
         </InnerMobileGrid>
       </MobileGrid>
-      <HardwareDetailsTestTable
-        tableKey="hardwareDetailsTests"
-        testHistory={tests}
-        filter={tableFilter.testsTable}
-        hardwareId={hardwareId}
-        onClickFilter={onClickFilter}
-        updatePathFilter={updatePathFilter}
-        currentPathFilter={currentPathFilter}
-      />
+      <HardwareDetailsTabsQuerySwitcher
+        fullDataResult={fullDataResult}
+        tabData={fullDataResult?.data?.tests}
+      >
+        <HardwareDetailsTestTable
+          tableKey="hardwareDetailsTests"
+          testHistory={fullDataResult?.data?.tests}
+          filter={tableFilter.testsTable}
+          hardwareId={hardwareId}
+          onClickFilter={onClickFilter}
+          updatePathFilter={updatePathFilter}
+          currentPathFilter={currentPathFilter}
+        />
+      </HardwareDetailsTabsQuerySwitcher>
     </div>
   );
 };

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -31,7 +31,7 @@ export type PreparedTrees = Trees & {
   isMainPageLoading: boolean;
 };
 
-type HardwareSummary = {
+export type HardwareSummary = {
   builds: BuildSummary;
   boots: TestSummary;
   tests: TestSummary;
@@ -40,6 +40,10 @@ type HardwareSummary = {
   architectures: string[];
   compilers: string[];
   compatibles: string[];
+};
+
+export type HardwareDetailsSummaryResponse = {
+  summary: HardwareSummary;
 };
 
 export type THardwareDetails = {


### PR DESCRIPTION
Adds a lazy load to hardwareDetails data, fetching the summary data first, and then the full data.
- Adds variants to `useHardwareDetails` and `fetchHardwareDetails`
- Adds the hook `useHardwareDetailsLazyLoaded`
- Adds HardwareDetailsTabsQuerySwitcher component to be reused between hardwareDetails tabs
- Refactors some of the tables to accept undefined data
- Changes HardwareDetailsFilters to use the response from the summary data instead of the full data

## How to test
Go to a hardwareDetails page with the network dev tools tab open and see that it will fetch the summary data first, load it, and then fetch the full data and load that.

Closes #758 