### PR TITLE
feat: add Issue tooltip

### DIFF
--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -27,6 +27,7 @@ import LinkWithIcon from '@/components/LinkWithIcon/LinkWithIcon';
 import { UNKNOWN_STRING } from '@/utils/constants/backend';
 
 import { MemoizedMoreDetailsIconLink } from '@/components/Button/MoreDetailsButton';
+import { IssueTooltip } from '@/components/Issue/IssueTooltip';
 
 interface IIssuesList {
   issues: TIssue[];
@@ -68,16 +69,19 @@ const IssuesList = ({
   const hasIssue = issues.length > 0 || failedWithUnknownIssues;
 
   const titleElement = (
-    <span>
-      {title}
-      {hasIssue && (
-        <ColoredCircle
-          className="ml-2 font-normal"
-          backgroundClassName={ItemType.Error}
-          quantity={issues.length + (failedWithUnknownIssues ? 1 : 0)}
-        />
-      )}
-    </span>
+    <div className="flex items-center gap-4 pr-4">
+      <span>
+        {title}
+        {hasIssue && (
+          <ColoredCircle
+            className="ml-2 font-normal"
+            backgroundClassName={ItemType.Error}
+            quantity={issues.length + (failedWithUnknownIssues ? 1 : 0)}
+          />
+        )}
+      </span>
+      <IssueTooltip />
+    </div>
   );
 
   const contentElement = !hasIssue ? (

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -15,6 +15,8 @@ import type { TIssue } from '@/types/general';
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
+import { IssueTooltip } from './IssueTooltip';
+
 export const NoIssueFound = (): JSX.Element => {
   return (
     <div className="flex flex-col items-center py-6 text-weakGray">
@@ -62,9 +64,12 @@ const IssueSection = ({
 
   return (
     <div>
-      <h2 className="mb-3 border-b border-gray-300 pb-3 text-2xl font-semibold">
-        <FormattedMessage id="global.issues" />
-      </h2>
+      <div className="mb-3 flex items-center gap-4 border-b border-gray-300 pb-3">
+        <h2 className="text-2xl font-semibold">
+          <FormattedMessage id="global.issues" />
+        </h2>
+        <IssueTooltip />
+      </div>
       <QuerySwitcher
         skeletonClassname="h-[100px]"
         status={status}

--- a/dashboard/src/components/Issue/IssueTooltip.tsx
+++ b/dashboard/src/components/Issue/IssueTooltip.tsx
@@ -1,0 +1,26 @@
+import { LiaQuestionCircle } from 'react-icons/lia';
+
+import { FormattedMessage } from 'react-intl';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
+import { formattedBreakLineValue } from '@/locales/messages';
+import { cn } from '@/lib/utils';
+
+export const IssueTooltip = ({
+  iconClassName,
+  tooltipClassName,
+}: {
+  iconClassName?: string;
+  tooltipClassName?: string;
+}): JSX.Element => {
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <LiaQuestionCircle className={cn('h-5 w-5', iconClassName)} />
+      </TooltipTrigger>
+      <TooltipContent className={cn('font-normal', tooltipClassName)}>
+        <FormattedMessage id="issue.tooltip" values={formattedBreakLineValue} />
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -188,6 +188,8 @@ export const messages = {
       'Results from {startDate} and {startTime} to {endDate} {endTime}',
     'hardwareDetails.treeBranch': 'Tree / Branch',
     'issue.noIssueFound': 'No issue found.',
+    'issue.tooltip':
+      'Issues are objects that group several builds or tests based on their result, being related through an incident.{br}They can also be linked to an issue tracker website by a report URL.',
     'issueDetails.buildValid': 'Build Valid',
     'issueDetails.comment': 'Comment',
     'issueDetails.culpritCode': 'Culprit Code',


### PR DESCRIPTION
Adds a tooltip for issues for better explanation of what they are.
- Adds a IssueTooltip component
- Adds the tooltip on IssuesList and IssueSection

## How to test
Go to a treeDetails or hardwareDetails page and see the tooltip on the "Issues" card (even when there are no issues the card is still shown)
Go to a buildDetails or testDetails page and see the tooltip on the "Issues" section (only shows if the section is shown, such as http://localhost:5173/test/redhat%3A1638594222-x86_64-kernel_upt_9 )

Closes #822
Closes #800