### PR TITLE
Fix: hardware commit selector

### DIFF
--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -18,18 +18,29 @@ import type {
 } from '@/types/general';
 import { getTargetFilter } from '@/types/general';
 
+import { isEmptyObject } from '@/utils/utils';
+
 import { RequestData } from './commonRequest';
 
 const TREE_SELECT_HEAD_VALUE = 'head';
 
 const mapIndexesToSelectedTrees = (
   selectedIndexes: number[],
+  treeIndexesLength?: number,
   treeCommits: TTreeCommits = {},
 ): Record<string, string> => {
   const selectedTrees: Record<string, string> = {};
 
-  selectedIndexes.forEach(idx => {
-    const key = idx.toString();
+  if (selectedIndexes.length === 0 && isEmptyObject(treeCommits))
+    return selectedTrees;
+
+  const selectedArray =
+    treeIndexesLength && selectedIndexes.length === 0
+      ? Array.from({ length: treeIndexesLength }, (_, i) => i)
+      : selectedIndexes;
+
+  selectedArray.forEach(i => {
+    const key = i.toString();
     const value = treeCommits[key] || TREE_SELECT_HEAD_VALUE;
     selectedTrees[key] = value;
   });
@@ -114,6 +125,7 @@ export type UseHardwareDetailsWithoutVariant = {
   filter: TFilter;
   selectedIndexes: number[];
   treeCommits: TTreeCommits;
+  treeIndexesLength?: number;
   enabled?: boolean;
 };
 
@@ -129,6 +141,7 @@ export const useHardwareDetails = <T extends HardwareDetailsVariants>({
   filter,
   selectedIndexes,
   treeCommits,
+  treeIndexesLength,
   enabled = true,
   variant,
 }: UseHardwareDetailsParameters<T>): UseQueryResult<
@@ -144,7 +157,11 @@ export const useHardwareDetails = <T extends HardwareDetailsVariants>({
 
   const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
 
-  const selectedTrees = mapIndexesToSelectedTrees(selectedIndexes, treeCommits);
+  const selectedTrees = mapIndexesToSelectedTrees(
+    selectedIndexes,
+    treeIndexesLength,
+    treeCommits,
+  );
 
   const body: fetchHardwareDetailsBody = {
     origin,

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 
 import { FormattedMessage } from 'react-intl';
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import {
   Breadcrumb,
@@ -137,6 +137,7 @@ function HardwareDetails(): JSX.Element {
     });
   }, [navigate]);
 
+  const [treeIndexesLength, setTreeIndexesLength] = useState(0);
   const { summary: summaryResponse, full: fullResponse } =
     useHardwareDetailsLazyLoadQuery({
       hardwareId: hardwareId,
@@ -146,6 +147,7 @@ function HardwareDetails(): JSX.Element {
       filter: reqFilter,
       selectedIndexes: treeIndexes ?? [],
       treeCommits: treeCommits,
+      treeIndexesLength: treeIndexesLength,
     });
 
   const hardwareTableForCommitHistory = useMemo(() => {
@@ -311,6 +313,7 @@ function HardwareDetails(): JSX.Element {
                 treeItems={treeData}
                 selectedIndexes={treeIndexes}
                 updateTreeFilters={updateTreeFilters}
+                setTreeIndexesLength={setTreeIndexesLength}
               />
               {summaryResponse.data && (
                 <div className="mt-5">

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tanstack/react-table';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { SetStateAction, Dispatch } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -54,6 +55,7 @@ interface IHardwareHeader {
   treeItems: PreparedTrees[];
   selectedIndexes?: number[];
   updateTreeFilters: (selectedIndexes: number[]) => void;
+  setTreeIndexesLength: Dispatch<SetStateAction<number>>;
 }
 
 const CommitSelector = ({
@@ -65,6 +67,7 @@ const CommitSelector = ({
   treeIndex,
   rowLength,
   isMainPageLoading,
+  setTreeIndexesLength,
 }: {
   headCommitName?: string;
   headCommitHash?: string;
@@ -74,6 +77,7 @@ const CommitSelector = ({
   isMainPageLoading: boolean;
   treeIndex: string;
   rowLength: number;
+  setTreeIndexesLength: IHardwareHeader['setTreeIndexesLength'];
 }): JSX.Element => {
   const navigate = useNavigate({ from: '/hardware/$hardwareId/' });
   const { treeCommits } = useSearch({ from: '/hardware/$hardwareId' });
@@ -81,22 +85,28 @@ const CommitSelector = ({
   const navigateToThePast = useCallback(
     (commitHash: string) => {
       if (treeIndex === null) return;
+      setTreeIndexesLength(rowLength);
+
+      const newTreeCommits = { ...treeCommits, [treeIndex]: commitHash };
+      if (commitHash === headCommitHash) delete newTreeCommits[treeIndex];
 
       navigate({
         search: current => {
-          const parsedTreeIndex =
-            current.treeIndexes?.length ?? 0 > 0
-              ? current.treeIndexes
-              : Array.from(Array(rowLength).keys());
           return {
             ...current,
-            treeCommits: { ...treeCommits, [treeIndex]: commitHash },
-            treeIndexes: parsedTreeIndex,
+            treeCommits: newTreeCommits,
           };
         },
       });
     },
-    [navigate, rowLength, treeIndex, treeCommits],
+    [
+      navigate,
+      setTreeIndexesLength,
+      headCommitHash,
+      rowLength,
+      treeIndex,
+      treeCommits,
+    ],
   );
 
   const gitValues = useMemo(() => {
@@ -144,7 +154,7 @@ const CommitSelector = ({
     <div className="flex items-center gap-4">
       <Select
         onValueChange={navigateToThePast}
-        value={treeCommits[treeIndex] ?? headCommitHash}
+        value={commitHash}
         disabled={isMainPageLoading}
       >
         <SelectTrigger className="w-[180px]">
@@ -187,125 +197,130 @@ const CommitSelector = ({
   );
 };
 
-const columns: ColumnDef<PreparedTrees>[] = [
-  {
-    id: 'select',
-    header: ({ table }) => (
-      <IndeterminateCheckbox
-        {...{
-          checked: table.getIsAllRowsSelected(),
-          indeterminate: table.getIsSomeRowsSelected(),
-          onChange: table.getToggleAllRowsSelectedHandler(),
-          disabled: table.getIsAllRowsSelected(),
-        }}
-      />
-    ),
-    cell: ({ row, table }) => (
-      <IndeterminateCheckbox
-        {...{
-          checked: row.getIsSelected(),
-          disabled:
-            !row.getCanSelect() ||
-            (Object.keys(table.getState().rowSelection).length === 1 &&
-              row.getIsSelected()),
-          onChange: row.getToggleSelectedHandler(),
-        }}
-      />
-    ),
-  },
-  {
-    accessorKey: 'tree_name',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.tree" />
-    ),
-    cell: ({ row }): JSX.Element => (
-      <Tooltip>
-        <TooltipTrigger>{row.getValue('tree_name')}</TooltipTrigger>
-        <TooltipContent>{row.original.git_repository_url}</TooltipContent>
-      </Tooltip>
-    ),
-  },
-  {
-    accessorKey: 'git_repository_branch',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.branch" />
-    ),
-  },
-  {
-    accessorKey: 'head_git_commit_name',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.commitTag" />
-    ),
-    cell: ({ row, table }): JSX.Element => {
-      return (
-        <CommitSelector
-          headCommitName={row.original.head_git_commit_name}
-          headCommitHash={row.original.head_git_commit_hash}
-          headCommitTags={row.original.head_git_commit_tags}
-          selectableCommits={row.original.selectableCommits}
-          isCommitsLoading={row.original.isCommitHistoryDataLoading}
-          treeIndex={row.original.index}
-          rowLength={table.getCoreRowModel().rows.length}
-          isMainPageLoading={row.original.isMainPageLoading}
+const getColumns = (
+  setTreeIndexesLength: IHardwareHeader['setTreeIndexesLength'],
+): ColumnDef<PreparedTrees>[] => {
+  return [
+    {
+      id: 'select',
+      header: ({ table }) => (
+        <IndeterminateCheckbox
+          {...{
+            checked: table.getIsAllRowsSelected(),
+            indeterminate: table.getIsSomeRowsSelected(),
+            onChange: table.getToggleAllRowsSelectedHandler(),
+            disabled: table.getIsAllRowsSelected(),
+          }}
         />
-      );
-    },
-  },
-  {
-    accessorKey: 'selectedCommitStatusSummaryBuilds',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.build" />
-    ),
-    cell: ({ row }): JSX.Element => {
-      const statusSummary = row.original.selected_commit_status?.builds;
-      return (
-        <GroupedTestStatus
-          fail={statusSummary?.invalid}
-          pass={statusSummary?.valid}
-          nullStatus={statusSummary?.null}
+      ),
+      cell: ({ row, table }) => (
+        <IndeterminateCheckbox
+          {...{
+            checked: row.getIsSelected(),
+            disabled:
+              !row.getCanSelect() ||
+              (Object.keys(table.getState().rowSelection).length === 1 &&
+                row.getIsSelected()),
+            onChange: row.getToggleSelectedHandler(),
+          }}
         />
-      );
+      ),
     },
-  },
-  {
-    accessorKey: 'selectedCommitStatusSummaryBoots',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.bootStatus" />
-    ),
-    cell: ({ row }): JSX.Element => {
-      const statusSummary = row.original.selected_commit_status?.boots;
-      return (
-        <GroupedTestStatus
-          fail={statusSummary?.FAIL}
-          pass={statusSummary?.PASS}
-          done={statusSummary?.DONE}
-          error={statusSummary?.ERROR}
-          miss={statusSummary?.MISS}
-          skip={statusSummary?.SKIP}
-        />
-      );
+    {
+      accessorKey: 'tree_name',
+      header: ({ column }): JSX.Element => (
+        <TableHeader column={column} intlKey="globalTable.tree" />
+      ),
+      cell: ({ row }): JSX.Element => (
+        <Tooltip>
+          <TooltipTrigger>{row.getValue('tree_name')}</TooltipTrigger>
+          <TooltipContent>{row.original.git_repository_url}</TooltipContent>
+        </Tooltip>
+      ),
     },
-  },
-  {
-    accessorKey: 'selectedCommitStatusSummaryTests',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.test" />
-    ),
-    cell: ({ row }): JSX.Element => {
-      const statusSummary = row.original.selected_commit_status?.tests;
-      return (
-        <GroupedTestStatus
-          fail={statusSummary?.FAIL}
-          pass={statusSummary?.PASS}
-          done={statusSummary?.DONE}
-          error={statusSummary?.ERROR}
-          miss={statusSummary?.MISS}
-          skip={statusSummary?.SKIP}
-        />
-      );
+    {
+      accessorKey: 'git_repository_branch',
+      header: ({ column }): JSX.Element => (
+        <TableHeader column={column} intlKey="globalTable.branch" />
+      ),
     },
-  },
-];
+    {
+      accessorKey: 'head_git_commit_name',
+      header: ({ column }): JSX.Element => (
+        <TableHeader column={column} intlKey="globalTable.commitTag" />
+      ),
+      cell: ({ row, table }): JSX.Element => {
+        return (
+          <CommitSelector
+            headCommitName={row.original.head_git_commit_name}
+            headCommitHash={row.original.head_git_commit_hash}
+            headCommitTags={row.original.head_git_commit_tags}
+            selectableCommits={row.original.selectableCommits}
+            isCommitsLoading={row.original.isCommitHistoryDataLoading}
+            treeIndex={row.original.index}
+            rowLength={table.getCoreRowModel().rows.length}
+            isMainPageLoading={row.original.isMainPageLoading}
+            setTreeIndexesLength={setTreeIndexesLength}
+          />
+        );
+      },
+    },
+    {
+      accessorKey: 'selectedCommitStatusSummaryBuilds',
+      header: ({ column }): JSX.Element => (
+        <TableHeader column={column} intlKey="globalTable.build" />
+      ),
+      cell: ({ row }): JSX.Element => {
+        const statusSummary = row.original.selected_commit_status?.builds;
+        return (
+          <GroupedTestStatus
+            fail={statusSummary?.invalid}
+            pass={statusSummary?.valid}
+            nullStatus={statusSummary?.null}
+          />
+        );
+      },
+    },
+    {
+      accessorKey: 'selectedCommitStatusSummaryBoots',
+      header: ({ column }): JSX.Element => (
+        <TableHeader column={column} intlKey="globalTable.bootStatus" />
+      ),
+      cell: ({ row }): JSX.Element => {
+        const statusSummary = row.original.selected_commit_status?.boots;
+        return (
+          <GroupedTestStatus
+            fail={statusSummary?.FAIL}
+            pass={statusSummary?.PASS}
+            done={statusSummary?.DONE}
+            error={statusSummary?.ERROR}
+            miss={statusSummary?.MISS}
+            skip={statusSummary?.SKIP}
+          />
+        );
+      },
+    },
+    {
+      accessorKey: 'selectedCommitStatusSummaryTests',
+      header: ({ column }): JSX.Element => (
+        <TableHeader column={column} intlKey="globalTable.test" />
+      ),
+      cell: ({ row }): JSX.Element => {
+        const statusSummary = row.original.selected_commit_status?.tests;
+        return (
+          <GroupedTestStatus
+            fail={statusSummary?.FAIL}
+            pass={statusSummary?.PASS}
+            done={statusSummary?.DONE}
+            error={statusSummary?.ERROR}
+            miss={statusSummary?.MISS}
+            skip={statusSummary?.SKIP}
+          />
+        );
+      },
+    },
+  ];
+};
 
 const getInitialRowSelection = (
   selectedIndexes: number[],
@@ -339,6 +354,7 @@ export function HardwareHeader({
   treeItems,
   selectedIndexes = [],
   updateTreeFilters,
+  setTreeIndexesLength,
 }: IHardwareHeader): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'tree_name', desc: false },
@@ -369,6 +385,11 @@ export function HardwareHeader({
       getInitialRowSelection(selectedIndexes, treeItems.length),
     );
   }, [selectedIndexes, treeItems.length]);
+
+  const columns = useMemo(
+    () => getColumns(setTreeIndexesLength),
+    [setTreeIndexesLength],
+  );
 
   const table = useReactTable({
     data: treeItems,

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
@@ -142,7 +142,11 @@ const CommitSelector = ({
 
   return (
     <div className="flex items-center gap-4">
-      <Select onValueChange={navigateToThePast} disabled={isMainPageLoading}>
+      <Select
+        onValueChange={navigateToThePast}
+        value={treeCommits[treeIndex] ?? headCommitHash}
+        disabled={isMainPageLoading}
+      >
         <SelectTrigger className="w-[180px]">
           <SelectValue placeholder={headCommitHash} />
         </SelectTrigger>
@@ -337,7 +341,7 @@ export function HardwareHeader({
   updateTreeFilters,
 }: IHardwareHeader): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([
-    { id: 'treeName', desc: false },
+    { id: 'tree_name', desc: false },
   ]);
   const { pagination, paginationUpdater } = usePaginationState(
     'hardwareDetailsTrees',

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -199,3 +199,10 @@ export const isStringRecord = (
     !Array.isArray(obj)
   );
 };
+
+export const isEmptyObject = (obj: Record<string, unknown>): boolean => {
+  for (const prop in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, prop)) return false;
+  }
+  return true;
+};


### PR DESCRIPTION
Added a new state `treeIndexesLength` that keep track of the size of number of trees there are in the header table. This was necessary because the backend expects a object that maps each tree index to its respective selected commit, but it couldn't correctly get all the tree indexes from the query parameter since it defaults to an empty array when all trees are selected. This state is then used when the query param is an empty array to create this object
    
Closes #783 

## How to test
This hardware is a good one for testing: [google,kingoftown](http://localhost:5173/hardware/google%2Ckingoftown?et=1738087200&st=1737655200), specially the `mainline/master` branch that has a lot of commits and different values between them. 
- Try to change the commits and see if the status in the header table change accordingly, also check for the data in the tabs. 
- Try to select or deselect trees from the header table and check if the data from the tabs are updated correctly. Also try to do it with changed commits in other trees to see if they don't update alone when selecting or deselecting trees.