### PR TITLE
Feat: change summary response for hardwareDetails

### DIFF
--- a/backend/kernelCI_app/helpers/commonDetails.py
+++ b/backend/kernelCI_app/helpers/commonDetails.py
@@ -1,0 +1,10 @@
+from kernelCI_app.helpers.filters import UNKNOWN_STRING
+
+
+def add_unfiltered_issue(
+    *, issue_id, issue_version, should_increment, issue_set, is_invalid
+):
+    if issue_id is not None and issue_version is not None and should_increment:
+        issue_set.add(issue_id)
+    elif is_invalid is True:
+        issue_set.add(UNKNOWN_STRING)

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -1,5 +1,6 @@
+from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
 
 from kernelCI_app.typeModels.issues import Issue
 from pydantic import BaseModel
@@ -69,8 +70,8 @@ class TestSummary(BaseModel):
     configs: Dict[str, TestStatusCount]
     issues: List[Issue]
     unknown_issues: int
-    fail_reasons: Dict[str, int]
-    failed_platforms: List[str]
+    fail_reasons: defaultdict[str, int]
+    failed_platforms: Set
     environment_compatible: Optional[Dict] = None
     environment_misc: Optional[Dict] = None
     platforms: Optional[Dict[str, TestStatusCount]] = None
@@ -88,6 +89,23 @@ class Summary(BaseModel):
     builds: BuildSummary
     boots: TestSummary
     tests: TestSummary
+
+
+class GlobalFilters(BaseModel):
+    configs: List[str]
+    architectures: List[str]
+    compilers: List[str]
+
+
+class LocalFilters(BaseModel):
+    issues: List[str]
+
+
+class DetailsFilters(BaseModel):
+    all: GlobalFilters
+    builds: LocalFilters
+    boots: LocalFilters
+    tests: LocalFilters
 
 
 class CommonDetailsTestsResponse(BaseModel):

--- a/backend/kernelCI_app/typeModels/hardwareDetails.py
+++ b/backend/kernelCI_app/typeModels/hardwareDetails.py
@@ -3,6 +3,8 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from kernelCI_app.typeModels.commonDetails import (
     BuildHistoryItem,
+    GlobalFilters,
+    LocalFilters,
     Summary,
     TestHistoryItem,
 )
@@ -64,12 +66,20 @@ class Tree(BaseModel):
     is_selected: Optional[bool]
 
 
-class HardwareSummary(Summary):
+class HardwareCommon(BaseModel):
     trees: List[Tree]
-    configs: List[str]
-    architectures: List[str]
-    compilers: List[str]
     compatibles: List[str]
+
+
+class HardwareTestLocalFilters(LocalFilters):
+    platforms: List[str]
+
+
+class HardwareDetailsFilters(BaseModel):
+    all: GlobalFilters
+    builds: LocalFilters
+    boots: HardwareTestLocalFilters
+    tests: HardwareTestLocalFilters
 
 
 class HardwareBuildHistoryItem(BuildHistoryItem):
@@ -82,11 +92,15 @@ class HardwareDetailsFullResponse(BaseModel):
     builds: List[HardwareBuildHistoryItem]
     boots: List[TestHistoryItem]
     tests: List[TestHistoryItem]
-    summary: HardwareSummary
+    summary: Summary
+    filters: HardwareDetailsFilters
+    common: HardwareCommon
 
 
 class HardwareDetailsSummaryResponse(BaseModel):
-    summary: HardwareSummary
+    summary: Summary
+    filters: HardwareDetailsFilters
+    common: HardwareCommon
 
 
 class HardwareDetailsBuildsResponse(BaseModel):

--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 from kernelCI_app.typeModels.commonDetails import (
     BuildHistoryItem,
+    DetailsFilters,
     Summary,
 )
 from pydantic import BaseModel
@@ -18,27 +19,10 @@ class TreeCommon(BaseModel):
     git_commit_tags: Optional[List[str]]
 
 
-class TreeGlobalFilters(BaseModel):
-    configs: List[str]
-    architectures: List[str]
-    compilers: List[str]
-
-
-class TreeLocalFilters(BaseModel):
-    issues: List[str]
-
-
-class TreeFilters(BaseModel):
-    all: TreeGlobalFilters
-    builds: TreeLocalFilters
-    boots: TreeLocalFilters
-    tests: TreeLocalFilters
-
-
 class SummaryResponse(BaseModel):
     common: TreeCommon
     summary: Summary
-    filters: TreeFilters
+    filters: DetailsFilters
 
 
 class TreeDetailsBuildsResponse(BaseModel):

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -15,6 +15,18 @@ paths:
         required: true
       tags:
       - hardware
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+        required: true
       security:
       - cookieAuth: []
       - basicAuth: []
@@ -682,6 +694,46 @@ components:
       - tests
       title: CommonDetailsTestsResponse
       type: object
+    DetailsFilters:
+      properties:
+        all:
+          $ref: '#/components/schemas/GlobalFilters'
+        builds:
+          $ref: '#/components/schemas/LocalFilters'
+        boots:
+          $ref: '#/components/schemas/LocalFilters'
+        tests:
+          $ref: '#/components/schemas/LocalFilters'
+      required:
+      - all
+      - builds
+      - boots
+      - tests
+      title: DetailsFilters
+      type: object
+    GlobalFilters:
+      properties:
+        configs:
+          items:
+            type: string
+          title: Configs
+          type: array
+        architectures:
+          items:
+            type: string
+          title: Architectures
+          type: array
+        compilers:
+          items:
+            type: string
+          title: Compilers
+          type: array
+      required:
+      - configs
+      - architectures
+      - compilers
+      title: GlobalFilters
+      type: object
     HardwareBuildHistoryItem:
       properties:
         id:
@@ -778,6 +830,23 @@ components:
       - issue_version
       title: HardwareBuildHistoryItem
       type: object
+    HardwareCommon:
+      properties:
+        trees:
+          items:
+            $ref: '#/components/schemas/Tree'
+          title: Trees
+          type: array
+        compatibles:
+          items:
+            type: string
+          title: Compatibles
+          type: array
+      required:
+      - trees
+      - compatibles
+      title: HardwareCommon
+      type: object
     HardwareDetailsBuildsResponse:
       properties:
         builds:
@@ -788,6 +857,23 @@ components:
       required:
       - builds
       title: HardwareDetailsBuildsResponse
+      type: object
+    HardwareDetailsFilters:
+      properties:
+        all:
+          $ref: '#/components/schemas/GlobalFilters'
+        builds:
+          $ref: '#/components/schemas/LocalFilters'
+        boots:
+          $ref: '#/components/schemas/HardwareTestLocalFilters'
+        tests:
+          $ref: '#/components/schemas/HardwareTestLocalFilters'
+      required:
+      - all
+      - builds
+      - boots
+      - tests
+      title: HardwareDetailsFilters
       type: object
     HardwareDetailsFullResponse:
       properties:
@@ -807,12 +893,18 @@ components:
           title: Tests
           type: array
         summary:
-          $ref: '#/components/schemas/HardwareSummary'
+          $ref: '#/components/schemas/Summary'
+        filters:
+          $ref: '#/components/schemas/HardwareDetailsFilters'
+        common:
+          $ref: '#/components/schemas/HardwareCommon'
       required:
       - builds
       - boots
       - tests
       - summary
+      - filters
+      - common
       title: HardwareDetailsFullResponse
       type: object
     HardwareDetailsPostBody:
@@ -851,54 +943,33 @@ components:
     HardwareDetailsSummaryResponse:
       properties:
         summary:
-          $ref: '#/components/schemas/HardwareSummary'
+          $ref: '#/components/schemas/Summary'
+        filters:
+          $ref: '#/components/schemas/HardwareDetailsFilters'
+        common:
+          $ref: '#/components/schemas/HardwareCommon'
       required:
       - summary
+      - filters
+      - common
       title: HardwareDetailsSummaryResponse
       type: object
-    HardwareSummary:
+    HardwareTestLocalFilters:
       properties:
-        builds:
-          $ref: '#/components/schemas/BuildSummary'
-        boots:
-          $ref: '#/components/schemas/TestSummary'
-        tests:
-          $ref: '#/components/schemas/TestSummary'
-        trees:
-          items:
-            $ref: '#/components/schemas/Tree'
-          title: Trees
-          type: array
-        configs:
+        issues:
           items:
             type: string
-          title: Configs
+          title: Issues
           type: array
-        architectures:
+        platforms:
           items:
             type: string
-          title: Architectures
-          type: array
-        compilers:
-          items:
-            type: string
-          title: Compilers
-          type: array
-        compatibles:
-          items:
-            type: string
-          title: Compatibles
+          title: Platforms
           type: array
       required:
-      - builds
-      - boots
-      - tests
-      - trees
-      - configs
-      - architectures
-      - compilers
-      - compatibles
-      title: HardwareSummary
+      - issues
+      - platforms
+      title: HardwareTestLocalFilters
       type: object
     IncidentInfo:
       properties:
@@ -937,6 +1008,17 @@ components:
       - incidents_info
       title: Issue
       type: object
+    LocalFilters:
+      properties:
+        issues:
+          items:
+            type: string
+          title: Issues
+          type: array
+      required:
+      - issues
+      title: LocalFilters
+      type: object
     Misc:
       properties:
         platform:
@@ -967,7 +1049,7 @@ components:
         summary:
           $ref: '#/components/schemas/Summary'
         filters:
-          $ref: '#/components/schemas/TreeFilters'
+          $ref: '#/components/schemas/DetailsFilters'
       required:
       - common
       - summary
@@ -1132,10 +1214,10 @@ components:
           title: Fail Reasons
           type: object
         failed_platforms:
-          items:
-            type: string
+          items: {}
           title: Failed Platforms
           type: array
+          uniqueItems: true
         environment_compatible:
           anyOf:
           - type: object
@@ -1262,57 +1344,6 @@ components:
       required:
       - builds
       title: TreeDetailsBuildsResponse
-      type: object
-    TreeFilters:
-      properties:
-        all:
-          $ref: '#/components/schemas/TreeGlobalFilters'
-        builds:
-          $ref: '#/components/schemas/TreeLocalFilters'
-        boots:
-          $ref: '#/components/schemas/TreeLocalFilters'
-        tests:
-          $ref: '#/components/schemas/TreeLocalFilters'
-      required:
-      - all
-      - builds
-      - boots
-      - tests
-      title: TreeFilters
-      type: object
-    TreeGlobalFilters:
-      properties:
-        configs:
-          items:
-            type: string
-          title: Configs
-          type: array
-        architectures:
-          items:
-            type: string
-          title: Architectures
-          type: array
-        compilers:
-          items:
-            type: string
-          title: Compilers
-          type: array
-      required:
-      - configs
-      - architectures
-      - compilers
-      title: TreeGlobalFilters
-      type: object
-    TreeLocalFilters:
-      properties:
-        issues:
-          items:
-            type: string
-          title: Issues
-          type: array
-      required:
-      - issues
-      title: TreeLocalFilters
       type: object
   securitySchemes:
     basicAuth:

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -5,7 +5,7 @@ import type {
   CommitHead,
   CommitHistoryResponse,
   CommitHistoryTable,
-  HardwareDetailsSummaryResponse,
+  HardwareDetailsSummary,
   THardwareDetails,
   THardwareDetailsFilter,
   TTreeCommits,
@@ -97,7 +97,7 @@ const fetchHardwareDetails = async ({
 
 type HardwareDetailsResponseTable = {
   full: THardwareDetails;
-  summary: HardwareDetailsSummaryResponse;
+  summary: HardwareDetailsSummary;
   builds: BuildsTabBuild[];
   boots: TestHistory[];
   tests: TestHistory[];

--- a/dashboard/src/hooks/useHardwareDetailsLazyLoadQuery.ts
+++ b/dashboard/src/hooks/useHardwareDetailsLazyLoadQuery.ts
@@ -4,13 +4,13 @@ import type { QuerySelectorStatus } from '@/components/QuerySwitcher/QuerySwitch
 import type { UseHardwareDetailsWithoutVariant } from '@/api/hardwareDetails';
 import { useHardwareDetails } from '@/api/hardwareDetails';
 import type {
-  HardwareSummary,
+  HardwareDetailsSummary,
   THardwareDetails,
 } from '@/types/hardware/hardwareDetails';
 
 export type HardwareDetailsLazyLoaded = {
   summary: {
-    data?: HardwareSummary;
+    data?: HardwareDetailsSummary;
     isLoading: boolean;
     status: QuerySelectorStatus;
     error: UseQueryResult['error'];
@@ -39,7 +39,7 @@ export const useHardwareDetailsLazyLoadQuery = (
 
   return {
     summary: {
-      data: summaryResult.data?.summary,
+      data: summaryResult.data,
       isLoading: summaryResult.isLoading,
       status: summaryResult.status,
       isPlaceholderData: summaryResult.isPlaceholderData,

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -75,6 +75,7 @@ export const messages = {
     'filter.buildDuration': 'Build duration',
     'filter.buildIssue': 'Build Issue',
     'filter.buildStatus': 'Build Status',
+    'filter.compatiblesSubtitle': 'Please select one or more compatibles:',
     'filter.compilersSubtitle': 'Please select one or more compilers:',
     'filter.configsSubtitle': 'Please select one or more configs:',
     'filter.durationSubtitle': 'Please select the duration range:',

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -151,7 +151,7 @@ function HardwareDetails(): JSX.Element {
   const hardwareTableForCommitHistory = useMemo(() => {
     const result: CommitHead[] = [];
     if (!summaryResponse.isLoading && summaryResponse.data) {
-      summaryResponse.data.trees.forEach(tree => {
+      summaryResponse.data.common.trees.forEach(tree => {
         const commitHead: CommitHead = {
           treeName: tree.tree_name ?? '',
           repositoryUrl: tree.git_repository_url ?? '',
@@ -195,9 +195,12 @@ function HardwareDetails(): JSX.Element {
   const endDate = getFormattedDate(endTimestampInSeconds);
 
   const tabsCounts: TreeDetailsTabRightElement = useMemo(() => {
-    const { status: buildStatusSummary } = summaryResponse.data?.builds ?? {};
-    const { status: testStatusSummary } = summaryResponse.data?.tests ?? {};
-    const { status: bootStatusSummary } = summaryResponse.data?.boots ?? {};
+    const { status: buildStatusSummary } =
+      summaryResponse.data?.summary.builds ?? {};
+    const { status: testStatusSummary } =
+      summaryResponse.data?.summary.tests ?? {};
+    const { status: bootStatusSummary } =
+      summaryResponse.data?.summary.boots ?? {};
 
     return {
       'global.tests': testStatusSummary ? (
@@ -229,23 +232,23 @@ function HardwareDetails(): JSX.Element {
       ),
     };
   }, [
-    summaryResponse.data?.boots,
-    summaryResponse.data?.builds,
-    summaryResponse.data?.tests,
+    summaryResponse.data?.summary.boots,
+    summaryResponse.data?.summary.builds,
+    summaryResponse.data?.summary.tests,
   ]);
 
   const treeData = useMemo(
     () =>
       prepareTreeItems({
         isCommitHistoryDataLoading: commitHistoryIsLoading,
-        treeItems: summaryResponse.data?.trees,
+        treeItems: summaryResponse.data?.common.trees,
         commitHistoryData: commitHistoryData?.commit_history_table,
         isMainPageLoading:
           fullResponse.isLoading || fullResponse.isPlaceholderData,
       }),
     [
       commitHistoryIsLoading,
-      summaryResponse.data?.trees,
+      summaryResponse.data?.common.trees,
       commitHistoryData?.commit_history_table,
       fullResponse.isLoading,
       fullResponse.isPlaceholderData,
@@ -318,7 +321,7 @@ function HardwareDetails(): JSX.Element {
                     title={
                       <FormattedMessage id="hardwareDetails.compatibles" />
                     }
-                    compatibles={summaryResponse.data.compatibles}
+                    compatibles={summaryResponse.data.common.compatibles}
                     diffFilter={diffFilter}
                   />
                 </div>

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -6,7 +6,6 @@ import { useNavigate } from '@tanstack/react-router';
 import { status as testStatuses } from '@/utils/constants/database';
 import type { IDrawerLink } from '@/components/Filter/Drawer';
 import FilterDrawer from '@/components/Filter/Drawer';
-import type { HardwareSummary } from '@/types/hardware/hardwareDetails';
 import { Skeleton } from '@/components/Skeleton';
 
 import {
@@ -18,13 +17,14 @@ import {
 import type { ISectionItem } from '@/components/Filter/CheckboxSection';
 import { isTFilterObjectKeys, type TFilter } from '@/types/general';
 import { cleanFalseFilters } from '@/components/Tabs/tabsUtils';
+import type { HardwareDetailsSummary } from '@/types/hardware/hardwareDetails';
 
 type TFilterValues = Record<string, boolean>;
 
 interface IHardwareDetailsFilter {
   paramFilter: TFilter;
   hardwareName: string;
-  data: HardwareSummary | undefined;
+  data: HardwareDetailsSummary | undefined;
   selectedTrees?: number[];
 }
 
@@ -33,7 +33,7 @@ type TFilterCreate = TFilter & {
 };
 
 export const createFilter = (
-  data: HardwareSummary | undefined,
+  data: HardwareDetailsSummary | undefined,
 ): TFilterCreate => {
   const buildStatus = { Success: false, Failure: false, Inconclusive: false };
 
@@ -54,10 +54,11 @@ export const createFilter = (
   const archs: TFilterValues = {};
   const compilers: TFilterValues = {};
   const trees: TFilterValues = {};
+  const compatibles: TFilterValues = {};
   const treeIndexes: number[] = [];
 
   if (data) {
-    data.trees.forEach(tree => {
+    data.common.trees.forEach(tree => {
       const treeIdx = Number(tree.index);
       const treeName = tree.tree_name ?? 'Unknown';
       const treeBranch = tree.git_repository_branch ?? 'Unknown';
@@ -71,24 +72,25 @@ export const createFilter = (
       treeIndexes.push(treeIdx);
     });
 
-    data.architectures.forEach(arch => {
+    data.filters.all.architectures.forEach(arch => {
       archs[arch ?? 'Unknown'] = false;
     });
-    data.compilers.forEach(compiler => {
+    data.filters.all.compilers.forEach(compiler => {
       compilers[compiler ?? 'Unknown'] = false;
     });
-    data.configs.forEach(config => {
+    data.filters.all.configs.forEach(config => {
       configs[config ?? 'Unknown'] = false;
     });
-    data.builds.issues.forEach(i => (buildIssue[i.id] = false));
-    data.boots.issues.forEach(i => (bootIssue[i.id] = false));
-    data.tests.issues.forEach(i => (testIssue[i.id] = false));
-    Object.keys(data.boots.platforms ?? {}).forEach(
-      i => (bootPlatform[i] = false),
+    data.filters.builds.issues.forEach(i => (buildIssue[i] = false));
+    data.filters.boots.issues.forEach(i => (bootIssue[i] = false));
+    data.filters.tests.issues.forEach(i => (testIssue[i] = false));
+    (data.filters.boots.platforms ?? []).forEach(
+      p => (bootPlatform[p] = false),
     );
-    Object.keys(data.tests.platforms ?? {}).forEach(
-      i => (testPlatform[i] = false),
+    (data.filters.tests.platforms ?? []).forEach(
+      p => (testPlatform[p] = false),
     );
+    data.common.compatibles.forEach(c => (compatibles[c] = false));
   }
 
   return {
@@ -105,6 +107,7 @@ export const createFilter = (
     testIssue,
     bootPlatform,
     testPlatform,
+    hardware: compatibles,
   };
 };
 
@@ -165,6 +168,12 @@ const sectionHardware: ISectionItem[] = [
     title: 'global.compilers',
     subtitle: 'filter.compilersSubtitle',
     sectionKey: 'compilers',
+    isGlobal: true,
+  },
+  {
+    title: 'hardwareDetails.compatibles',
+    subtitle: 'filter.compatiblesSubtitle',
+    sectionKey: 'hardware',
     isGlobal: true,
   },
 ];

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -13,7 +13,7 @@ import { BootsTable } from '@/components/BootsTable/BootsTable';
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
 import type {
-  HardwareSummary,
+  HardwareDetailsSummary,
   THardwareDetails,
 } from '@/types/hardware/hardwareDetails';
 
@@ -41,8 +41,8 @@ import { HardwareDetailsTabsQuerySwitcher } from '@/pages/hardwareDetails/Tabs/H
 
 interface IBootsTab {
   hardwareId: string;
-  trees: HardwareSummary['trees'];
-  bootsSummary: HardwareSummary['boots'];
+  trees: HardwareDetailsSummary['common']['trees'];
+  bootsSummary: HardwareDetailsSummary['summary']['boots'];
   fullDataResult?: UseQueryResult<THardwareDetails>;
 }
 

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -7,7 +7,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import type {
-  HardwareSummary,
+  HardwareDetailsSummary,
   THardwareDetails,
 } from '@/types/hardware/hardwareDetails';
 import { sanitizeArchs, sanitizeConfigs } from '@/utils/utils';
@@ -33,9 +33,9 @@ import { HardwareDetailsTabsQuerySwitcher } from '@/pages/hardwareDetails/Tabs/H
 import { HardwareDetailsBuildsTable } from './HardwareDetailsBuildsTable';
 
 interface IBuildTab {
-  trees: HardwareSummary['trees'];
+  trees: HardwareDetailsSummary['common']['trees'];
   hardwareId: string;
-  buildsSummary: HardwareSummary['builds'];
+  buildsSummary: HardwareDetailsSummary['summary']['builds'];
   fullDataResult?: UseQueryResult<THardwareDetails>;
 }
 

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
@@ -2,11 +2,11 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 
 import { useCallback, useMemo } from 'react';
 
-import type { THardwareDetails } from '@/types/hardware/hardwareDetails';
+import type { HardwareDetailsSummary } from '@/types/hardware/hardwareDetails';
 import CommitNavigationGraph from '@/components/CommitNavigationGraph/CommitNavigationGraph';
 
 interface ICommitNavigationGraph {
-  trees: THardwareDetails['summary']['trees'];
+  trees: HardwareDetailsSummary['common']['trees'];
   hardwareId: string;
 }
 const HardwareCommitNavigationGraph = ({

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -11,7 +11,7 @@ import Tabs from '@/components/Tabs/Tabs';
 import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
 
 import type {
-  HardwareSummary,
+  HardwareDetailsSummary,
   THardwareDetails,
 } from '@/types/hardware/hardwareDetails';
 
@@ -29,7 +29,7 @@ export interface IHardwareDetailsTab {
   filterListElement?: JSX.Element;
   countElements: TreeDetailsTabRightElement;
   fullDataResult?: UseQueryResult<THardwareDetails>;
-  summaryData: HardwareSummary;
+  summaryData: HardwareDetailsSummary;
 }
 
 const HardwareDetailsTabs = ({
@@ -67,8 +67,8 @@ const HardwareDetailsTabs = ({
         content: (
           <BuildTab
             hardwareId={hardwareId}
-            trees={summaryData.trees}
-            buildsSummary={summaryData.builds}
+            trees={summaryData.common.trees}
+            buildsSummary={summaryData.summary.builds}
             fullDataResult={fullDataResult}
           />
         ),
@@ -80,8 +80,8 @@ const HardwareDetailsTabs = ({
         content: (
           <BootsTab
             hardwareId={hardwareId}
-            trees={summaryData.trees}
-            bootsSummary={summaryData.boots}
+            trees={summaryData.common.trees}
+            bootsSummary={summaryData.summary.boots}
             fullDataResult={fullDataResult}
           />
         ),
@@ -93,8 +93,8 @@ const HardwareDetailsTabs = ({
         content: (
           <TestsTab
             hardwareId={hardwareId}
-            trees={summaryData.trees}
-            testsSummary={summaryData.tests}
+            trees={summaryData.common.trees}
+            testsSummary={summaryData.summary.tests}
             fullDataResult={fullDataResult}
           />
         ),
@@ -104,10 +104,10 @@ const HardwareDetailsTabs = ({
     ],
     [
       hardwareId,
-      summaryData.trees,
-      summaryData.builds,
-      summaryData.boots,
-      summaryData.tests,
+      summaryData.common.trees,
+      summaryData.summary.builds,
+      summaryData.summary.boots,
+      summaryData.summary.tests,
       fullDataResult,
       countElements,
     ],

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -9,7 +9,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 
 import type {
-  HardwareSummary,
+  HardwareDetailsSummary,
   THardwareDetails,
 } from '@/types/hardware/hardwareDetails';
 
@@ -40,8 +40,8 @@ import HardwareDetailsTestTable from './HardwareDetailsTestsTable';
 
 interface ITestsTab {
   hardwareId: string;
-  trees: HardwareSummary['trees'];
-  testsSummary: HardwareSummary['tests'];
+  trees: HardwareDetailsSummary['common']['trees'];
+  testsSummary: HardwareDetailsSummary['summary']['tests'];
   fullDataResult?: UseQueryResult<THardwareDetails>;
 }
 

--- a/dashboard/src/types/commonDetails.ts
+++ b/dashboard/src/types/commonDetails.ts
@@ -1,0 +1,52 @@
+import type {
+  ArchCompilerStatus,
+  Architecture,
+  BuildStatus,
+  PropertyStatusCounts,
+  StatusCounts,
+  TIssue,
+} from './general';
+
+type TestSummary = {
+  status: StatusCounts;
+  architectures: ArchCompilerStatus[];
+  configs: PropertyStatusCounts;
+  issues: TIssue[];
+  unknown_issues: number;
+  fail_reasons: Record<string, number>;
+  failed_platforms: string[];
+  environment_compatible?: PropertyStatusCounts;
+  environment_misc?: PropertyStatusCounts;
+  platforms?: PropertyStatusCounts;
+};
+
+type BuildSummary = {
+  status: BuildStatus;
+  architectures: Architecture;
+  configs: Record<string, BuildStatus>;
+  issues: TIssue[];
+  unknown_issues: number;
+};
+
+export type Summary = {
+  builds: BuildSummary;
+  boots: TestSummary;
+  tests: TestSummary;
+};
+
+export type GlobalFilters = {
+  configs: string[];
+  architectures: string[];
+  compilers: string[];
+};
+
+export type LocalFilters = {
+  issues: string[];
+};
+
+export type DetailsFilters = {
+  all: GlobalFilters;
+  builds: LocalFilters;
+  boots: LocalFilters;
+  tests: LocalFilters;
+};

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -113,6 +113,8 @@ export type StatusCounts = {
   [key in Status]: number | undefined;
 };
 
+export type PropertyStatusCounts = Record<string, StatusCounts>;
+
 export type ArchCompilerStatus = {
   arch: string;
   compiler: string;

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -6,7 +6,12 @@ import type {
   StatusCount,
   TestHistory,
 } from '@/types/general';
-import type { BuildSummary, TestSummary } from '@/types/tree/TreeDetails';
+
+import type {
+  GlobalFilters,
+  LocalFilters,
+  Summary,
+} from '@/types/commonDetails';
 
 type TTreesStatusSummary = {
   builds: Partial<BuildStatus>;
@@ -31,26 +36,35 @@ export type PreparedTrees = Trees & {
   isMainPageLoading: boolean;
 };
 
-export type HardwareSummary = {
-  builds: BuildSummary;
-  boots: TestSummary;
-  tests: TestSummary;
+type HardwareCommon = {
   trees: Trees[];
-  configs: string[];
-  architectures: string[];
-  compilers: string[];
   compatibles: string[];
 };
 
-export type HardwareDetailsSummaryResponse = {
-  summary: HardwareSummary;
+interface HardwareTestLocalFilters extends LocalFilters {
+  platforms: string[];
+}
+
+type HardwareDetailsFilters = {
+  all: GlobalFilters;
+  builds: LocalFilters;
+  boots: HardwareTestLocalFilters;
+  tests: HardwareTestLocalFilters;
+};
+
+export type HardwareDetailsSummary = {
+  summary: Summary;
+  filters: HardwareDetailsFilters;
+  common: HardwareCommon;
 };
 
 export type THardwareDetails = {
   builds: BuildsTabBuild[];
   tests: TestHistory[];
   boots: TestHistory[];
-  summary: HardwareSummary;
+  summary: Summary;
+  filters: HardwareDetailsFilters;
+  common: HardwareCommon;
 };
 
 export interface THardwareDetailsFilter

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -4,15 +4,13 @@ import type { ReactNode } from 'react';
 
 import type {
   BuildsTabBuild,
-  BuildStatus,
-  Architecture,
   TestHistory,
-  TIssue,
   StatusCounts,
-  ArchCompilerStatus,
+  PropertyStatusCounts,
 } from '@/types/general';
 
 import type { Status } from '@/types/database';
+import type { DetailsFilters, Summary } from '@/types/commonDetails';
 
 export type AccordionItemBuilds = {
   id: string;
@@ -50,8 +48,6 @@ type ErrorMessageCounts = {
   [key: string]: number;
 };
 
-type PropertyStatusCounts = Record<string, StatusCounts>;
-
 export type TTreeTestsData = {
   statusCounts: StatusCounts;
   configStatusCounts: PropertyStatusCounts;
@@ -63,69 +59,25 @@ export type TTreeTestsData = {
   environmentCompatible: PropertyStatusCounts;
 };
 
-export type TestSummary = {
-  status: StatusCounts;
-  architectures: ArchCompilerStatus[];
-  configs: PropertyStatusCounts;
-  issues: TIssue[];
-  unknown_issues: number;
-  fail_reasons: Record<string, number>;
-  failed_platforms: string[];
-  environment_compatible?: PropertyStatusCounts;
-  environment_misc?: PropertyStatusCounts;
-  platforms?: PropertyStatusCounts;
-};
-
-export type BuildSummary = {
-  status: BuildStatus;
-  architectures: Architecture;
-  configs: Record<string, BuildStatus>;
-  issues: TIssue[];
-  unknown_issues: number;
-};
-
-type TreeSummary = {
-  boots: TestSummary;
-  builds: BuildSummary;
-  tests: TestSummary;
-};
-
 type TreeCommon = {
   hardware: string[];
   tree_url: string;
   git_commit_tags: string[];
 };
 
-type TreeGlobalFilters = {
-  configs: string[];
-  architectures: string[];
-  compilers: string[];
-};
-
-type TreeLocalFilters = {
-  issues: string[];
-};
-
-type TreeFilters = {
-  all: TreeGlobalFilters;
-  builds: TreeLocalFilters;
-  boots: TreeLocalFilters;
-  tests: TreeLocalFilters;
-};
-
 export type TreeDetailsFullData = {
   builds: BuildsTabBuild[];
   boots: TestHistory[];
   tests: TestHistory[];
-  summary: TreeSummary;
+  summary: Summary;
   common: TreeCommon;
-  filters: TreeFilters;
+  filters: DetailsFilters;
 };
 
 export type TreeDetailsSummary = {
-  summary: TreeSummary;
+  summary: Summary;
   common: TreeCommon;
-  filters: TreeFilters;
+  filters: DetailsFilters;
 };
 
 export type TreeDetailsBuilds = {


### PR DESCRIPTION
Splits the summary response to summary/filters/common
Adds platforms as another field for unfiltered filters
Adds compatibles to the filter modal

## How to test
- Go to a hardwareDetails page that has more than one value of any property (more than one config or arch or compiler or platform, etc.), such as amlogic,a311d (2 boot platforms) or google,juniper (2 configs) or fsl,imx6q (2 boot platforms, 2 boot issues)
- Filter by one of those values
- See in the filter modal that the other value is still shown there


Closes #799