### PR TITLE
Feat: filter by issue version

### DIFF
--- a/backend/kernelCI_app/helpers/commonDetails.py
+++ b/backend/kernelCI_app/helpers/commonDetails.py
@@ -1,10 +1,16 @@
 from kernelCI_app.helpers.filters import UNKNOWN_STRING
+from typing import Set
 
 
 def add_unfiltered_issue(
-    *, issue_id, issue_version, should_increment, issue_set, is_invalid
-):
+    *,
+    issue_id: str,
+    issue_version: int,
+    should_increment: bool,
+    issue_set: Set,
+    is_invalid: bool
+) -> None:
     if issue_id is not None and issue_version is not None and should_increment:
-        issue_set.add(issue_id)
+        issue_set.add((issue_id, issue_version))
     elif is_invalid is True:
-        issue_set.add(UNKNOWN_STRING)
+        issue_set.add((UNKNOWN_STRING, None))

--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -674,7 +674,7 @@ def process_issue(
 def update_issues(
     *,
     issue_id: Optional[str],
-    issue_version: Optional[str],
+    issue_version: Optional[int],
     incident_test_id: Optional[str],
     build_valid: Optional[bool],
     issue_comment: Optional[str],
@@ -746,6 +746,7 @@ def decide_if_is_build_in_filter(
         valid=build["valid"],
         duration=build["duration"],
         issue_id=build["issue_id"],
+        issue_version=build["issue_version"],
         incident_test_id=incident_test_id,
     )
     return is_build_not_processed and not is_build_filtered_out_result
@@ -764,6 +765,7 @@ def decide_if_is_test_in_filter(
     duration = record["duration"]
     path = record["path"]
     issue_id = record["incidents__issue__id"]
+    issue_version = record["incidents__issue__version"]
     incidents_test_id = record["incidents__test_id"]
     platform = env_misc_value_or_default(
         handle_environment_misc(record["environment_misc"])
@@ -775,6 +777,7 @@ def decide_if_is_test_in_filter(
             duration=duration,
             path=path,
             issue_id=issue_id,
+            issue_version=issue_version,
             incident_test_id=incidents_test_id,
             platform=platform,
         )
@@ -784,6 +787,7 @@ def decide_if_is_test_in_filter(
             duration=duration,
             path=path,
             issue_id=issue_id,
+            issue_version=issue_version,
             incident_test_id=incidents_test_id,
             platform=platform,
         )

--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -378,6 +378,7 @@ def process_boots_issue(instance, row_data):
 
 def decide_if_is_build_filtered_out(instance, row_data):
     issue_id = row_data["issue_id"]
+    issue_version = row_data["issue_version"]
     build_valid = row_data["build_valid"]
     build_duration = row_data["build_duration"]
     incident_test_id = row_data["incident_test_id"]
@@ -386,6 +387,7 @@ def decide_if_is_build_filtered_out(instance, row_data):
         valid=build_valid,
         duration=build_duration,
         issue_id=issue_id,
+        issue_version=issue_version,
         incident_test_id=incident_test_id,
     )
     return is_build_filtered_out
@@ -395,12 +397,14 @@ def decide_if_is_boot_filtered_out(instance, row_data):
     test_status = row_data["test_status"]
     test_duration = row_data["test_duration"]
     issue_id = row_data["issue_id"]
+    issue_version = row_data["issue_version"]
     test_path = row_data["test_path"]
     incident_test_id = row_data["incident_test_id"]
 
     return instance.filters.is_boot_filtered_out(
         duration=test_duration,
         issue_id=issue_id,
+        issue_version=issue_version,
         path=test_path,
         status=test_status,
         incident_test_id=incident_test_id,

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union, Tuple
 
 from kernelCI_app.typeModels.issues import Issue
 from pydantic import BaseModel
@@ -98,7 +98,7 @@ class GlobalFilters(BaseModel):
 
 
 class LocalFilters(BaseModel):
-    issues: List[str]
+    issues: List[Tuple[str, Optional[int]]]
 
 
 class DetailsFilters(BaseModel):

--- a/backend/kernelCI_app/typeModels/hardwareDetails.py
+++ b/backend/kernelCI_app/typeModels/hardwareDetails.py
@@ -85,7 +85,7 @@ class HardwareDetailsFilters(BaseModel):
 class HardwareBuildHistoryItem(BuildHistoryItem):
     tree_name: Optional[str]
     issue_id: Optional[str]
-    issue_version: Optional[str]
+    issue_version: Optional[int]
 
 
 class HardwareDetailsFullResponse(BaseModel):

--- a/backend/kernelCI_app/unitTests/treeDetails.test.py
+++ b/backend/kernelCI_app/unitTests/treeDetails.test.py
@@ -7,23 +7,34 @@ class TestShouldFilterTestIssue(unittest.TestCase):
 
     def test_no_issue_filters(self):
         self.assertFalse(
-            should_filter_test_issue(set(), UNKNOWN_STRING, "incident_test_1", "FAIL")
+            should_filter_test_issue(
+                issue_filters=set(),
+                issue_id=UNKNOWN_STRING,
+                issue_version=None,
+                incident_test_id="incident_test_1",
+                test_status="FAIL"
+            )
         )
 
     def test_unknown_filter_with_exclusively_build_issue(self):
         self.assertTrue(
             should_filter_test_issue(
-                {UNKNOWN_STRING}, "issue1", "incident_test_1", "PASS"
+                issue_filters={UNKNOWN_STRING},
+                issue_id="issue1",
+                issue_version=1,
+                incident_test_id="incident_test_1",
+                test_status="PASS"
             )
         )
 
     def test_unknown_issue_but_not_from_test(self):
         self.assertFalse(
             should_filter_test_issue(
-                {UNKNOWN_STRING},
-                "maestro:72697a4efbbd0eff7080781839b405bbf0902f79",
-                None,
-                "FAIL",
+                issue_filters={UNKNOWN_STRING},
+                issue_id="maestro:72697a4efbbd0eff7080781839b405bbf0902f79",
+                issue_version=0,
+                incident_test_id=None,
+                test_status="FAIL",
             )
         )
 

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -28,6 +28,7 @@ import { MemoizedMoreDetailsIconLink } from '@/components/Button/MoreDetailsButt
 import { IssueTooltip } from '@/components/Issue/IssueTooltip';
 
 import { LinkIcon } from '@/components/Icons/Link';
+import { getIssueFilterLabel } from '@/utils/utils';
 
 interface IIssuesList {
   issues: TIssue[];
@@ -98,7 +99,7 @@ const IssuesList = ({
             <div className="overflow-hidden">
               <FilterLink
                 filterSection={issueFilterSection}
-                filterValue={issue.id}
+                filterValue={getIssueFilterLabel(issue)}
                 diffFilter={diffFilter}
               >
                 <ListingItem

--- a/dashboard/src/components/Tabs/Filters.tsx
+++ b/dashboard/src/components/Tabs/Filters.tsx
@@ -19,6 +19,8 @@ import type {
   TFilterNumberKeys,
 } from '@/types/general';
 import { filterFieldMap, zFilterObjectsKeys } from '@/types/general';
+import { UNKNOWN_STRING } from '@/utils/constants/backend';
+import { version_prefix } from '@/utils/utils';
 
 export const NO_VALID_INDEX = -1;
 
@@ -45,8 +47,22 @@ export const mapFilterToReq = (filter: TFilter): TFilter => {
               value = 'none';
             }
           }
+
           if (!filterMapped[reqField]) {
             filterMapped[reqField] = [];
+          }
+
+          if (reqField.includes('issue')) {
+            let issue_id = UNKNOWN_STRING;
+            let issue_version = null;
+
+            if (value !== UNKNOWN_STRING) {
+              const split_issue_data = value.split(` ${version_prefix}`);
+              issue_version = split_issue_data.pop();
+              issue_id = split_issue_data.join(` ${version_prefix}`);
+            }
+
+            value = `${issue_id},${issue_version}`;
           }
           filterMapped[reqField].push(value);
         }
@@ -55,6 +71,7 @@ export const mapFilterToReq = (filter: TFilter): TFilter => {
       filterMapped[reqField] = [values.toString()];
     }
   });
+
   return filterMapped;
 };
 

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -15,6 +15,7 @@ import {
 
 import { isTFilterObjectKeys, type TFilter } from '@/types/general';
 import { cleanFalseFilters } from '@/components/Tabs/tabsUtils';
+import { getIssueFilterLabel } from '@/utils/utils';
 
 type TFilterValues = Record<string, boolean>;
 
@@ -53,9 +54,18 @@ export const createFilter = (data: TreeDetailsSummary | undefined): TFilter => {
 
     data.common.hardware.forEach(h => (hardware[h] = false));
 
-    data.filters.builds.issues.forEach(i => (buildIssue[i] = false));
-    data.filters.boots.issues.forEach(i => (bootIssue[i] = false));
-    data.filters.tests.issues.forEach(i => (testIssue[i] = false));
+    data.filters.builds.issues.forEach(
+      i =>
+        (buildIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
+    );
+    data.filters.boots.issues.forEach(
+      i =>
+        (bootIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
+    );
+    data.filters.tests.issues.forEach(
+      i =>
+        (testIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
+    );
   }
 
   return {

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -18,6 +18,7 @@ import type { ISectionItem } from '@/components/Filter/CheckboxSection';
 import { isTFilterObjectKeys, type TFilter } from '@/types/general';
 import { cleanFalseFilters } from '@/components/Tabs/tabsUtils';
 import type { HardwareDetailsSummary } from '@/types/hardware/hardwareDetails';
+import { getIssueFilterLabel } from '@/utils/utils';
 
 type TFilterValues = Record<string, boolean>;
 
@@ -81,9 +82,18 @@ export const createFilter = (
     data.filters.all.configs.forEach(config => {
       configs[config ?? 'Unknown'] = false;
     });
-    data.filters.builds.issues.forEach(i => (buildIssue[i] = false));
-    data.filters.boots.issues.forEach(i => (bootIssue[i] = false));
-    data.filters.tests.issues.forEach(i => (testIssue[i] = false));
+    data.filters.builds.issues.forEach(
+      i =>
+        (buildIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
+    );
+    data.filters.boots.issues.forEach(
+      i =>
+        (bootIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
+    );
+    data.filters.tests.issues.forEach(
+      i =>
+        (testIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
+    );
     (data.filters.boots.platforms ?? []).forEach(
       p => (bootPlatform[p] = false),
     );

--- a/dashboard/src/types/commonDetails.ts
+++ b/dashboard/src/types/commonDetails.ts
@@ -40,8 +40,10 @@ export type GlobalFilters = {
   compilers: string[];
 };
 
+export type IssueFilterItem = [string, number?];
+
 export type LocalFilters = {
-  issues: string[];
+  issues: IssueFilterItem[];
 };
 
 export type DetailsFilters = {

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -206,3 +206,21 @@ export const isEmptyObject = (obj: Record<string, unknown>): boolean => {
   }
   return true;
 };
+
+type TIssueFilter = {
+  id: string;
+  version?: number;
+};
+
+export const version_prefix = 'v.';
+
+export const getIssueFilterLabel = (issueFilter: TIssueFilter): string => {
+  const issueId = issueFilter.id;
+  const issueVersion = issueFilter.version;
+
+  if (!issueVersion) return issueId;
+
+  const versionFormatted = `${version_prefix}${issueVersion}`;
+
+  return `${issueId} ${versionFormatted}`;
+};


### PR DESCRIPTION
Use issue version to filter the builds/tests data from Tree and Hardware Details. Change the issue label to `issue_id v.issue_version` insteand only `issue_id`. Example: `maestro:1bad4fd734ada1f413164870f3d66961f9eccbfb v.1`

Close #739

### **How to test**
Go to any Tree or Hardware and try apply the filter by issue. Observe if the behavior is the same for the staging. See the examples below:
- [android-mainline](http://localhost:5173/tree/5f191bee6f942c90bc33ed2ab9b9343761ed1149?df%7Cbi%7Cmaestro%3A1bad4fd734ada1f413164870f3d66961f9eccbfb%20v.1=true&ti%7Cc=ASB-2025-01-05_mainline-493-g5f191bee6f94&ti%7Cch=5f191bee6f942c90bc33ed2ab9b9343761ed1149&ti%7Cgb=android-mainline&ti%7Cgu=https%3A%2F%2Fandroid.googlesource.com%2Fkernel%2Fcommon&ti%7Ct=android)
- [broonie-sound](http://localhost:5173/tree/d91054313ab799650198a57a2e2db3c79e379610?df%7Cbti%7Cmaestro%3A721516cb40a17ba5aaddc2e6e410d3eec5c49fc6%20v.1=true&df%7Cbti%7Cmaestro%3Aae160f6f27192c3527b2e88faba35d85d27c285f%20v.1=true&df%7Cbti%7Cmaestro%3Af74cb1ed442fefbfc03ab263c86e54253d4b1a4b%20v.1=true&p=bt&ti%7Cc=asoc-v6.14-39-gd91054313ab7&ti%7Cch=d91054313ab799650198a57a2e2db3c79e379610&ti%7Cgb=for-next&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fbroonie%2Fsound.git&ti%7Ct=broonie-sound)
- [cip](http://localhost:5173/tree/44dc90880a5958c9894adccb669e5ea29fbd3dc2?df%7Cti%7CUnknown=true&p=t&ti%7Cc=v5.10.233-cip56-16-g44dc90880a595&ti%7Cch=44dc90880a5958c9894adccb669e5ea29fbd3dc2&ti%7Cgb=linux-5.10.y-cip&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fcip%2Flinux-cip.git&ti%7Ct=cip)