### PR TITLE
Fix: filter expanded rows

### DIFF
--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -192,6 +192,7 @@ export function TestsTable({
     getRowCanExpand: _ => true,
     getExpandedRowModel: getExpandedRowModel(),
     onExpandedChange: setExpanded,
+    getRowId: row => row.path_group,
     state: {
       sorting,
       pagination,

--- a/dashboard/src/pages/TreeDetails/Tabs/WrapperTableWithLogSheet.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/WrapperTableWithLogSheet.tsx
@@ -9,6 +9,7 @@ import { Sheet } from '@/components/Sheet';
 import { LogOrJsonSheetContent } from '@/components/Sheet/LogOrJsonSheetContent';
 import type { TNavigationLogActions } from '@/components/Sheet/WrapperSheetContent';
 import type { TIssue } from '@/types/general';
+import { cn } from '@/lib/utils';
 
 interface TableWithLogSheetProps {
   currentLog?: number;
@@ -20,6 +21,7 @@ interface TableWithLogSheetProps {
   issues?: TIssue[];
   status?: UseQueryResult['status'];
   error?: UseQueryResult['error'];
+  wrapperClassName?: string;
 }
 
 const WrapperTableWithLogSheet = ({
@@ -33,9 +35,10 @@ const WrapperTableWithLogSheet = ({
   issues,
   status,
   error,
+  wrapperClassName,
 }: PropsWithChildren<TableWithLogSheetProps>): JSX.Element => {
   return (
-    <div className="flex flex-col gap-6 pb-4">
+    <div className={cn('flex flex-col gap-6 pb-4', wrapperClassName)}>
       {children}
 
       <Sheet open={typeof currentLog === 'number'} onOpenChange={onOpenChange}>


### PR DESCRIPTION
- Removes memo with no dependencies from IndividualTestsTable, allowing it to update when the data updates and also makes it follow the pattern of other tables.
- Changes a slight style problem where the expanded rows from a TestsTable would have a small gap bellow them
- Adds [useful row ids](https://tanstack.com/table/latest/docs/guide/row-selection#useful-row-ids) to TestsTable, allowing the expanded state to be tied to the `path_group` instead of the row index

These fixes are applied to the base TestsTable and IndividualTestsTable, meaning it will be spread through any page that uses those tables (treeDetails tests tab, hardwareDetails tests tab, buildDetails and issueDetails). Since no other table is expandable anymore, other tables don't suffer from these problems.

## How to test
For the filter fix, go to any page with a tests table that has data with more than one status (for example this [localhost issueDetails](http://localhost:5173/issue/maestro:3d743effedc9584a60cd699b2df5f38e0773b493?tf|b=a&tf|bt=a&tf|t=f) page), expand the tests and change the filter, then compare it to the behavior on staging (for the current example, this [staging issueDetails](https://staging.dashboard.kernelci.org:9000/issue/maestro:3d743effedc9584a60cd699b2df5f38e0773b493?tf%7Cb=a&tf%7Cbt=a&tf%7Ct=f)). With the current behavior you would need to close and re-expand the row, with the fix you should have the expanded row updated without manual action.

For the expansion fix, go to any page with a tests table that has more than one test path group, expand one of the groups that don't have a certain status present (such as this [localhost treeDetails](http://localhost:5173/tree/995cf0e014b0144edf1125668a97c252c5ab775e?p=t&tf%7Cb=a&tf%7Cbt=a&tf%7Ct=s&ti%7Cc=v6.14-rc1-1-g995cf0e014b0&ti%7Cch=995cf0e014b0144edf1125668a97c252c5ab775e&ti%7Cgb=for-next&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fbroonie%2Fregmap.git&ti%7Ct=broonie-regmap), where many path groups don't have failed tests), then filter the table by the status where that path group won't show, and compare to staging (such as [staging treeDetails](https://staging.dashboard.kernelci.org:9000/tree/995cf0e014b0144edf1125668a97c252c5ab775e?p=t&tf%7Cb=a&tf%7Cbt=a&tf%7Ct=s&ti%7Cc=v6.14-rc1-1-g995cf0e014b0&ti%7Cch=995cf0e014b0144edf1125668a97c252c5ab775e&ti%7Cgb=for-next&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fbroonie%2Fregmap.git&ti%7Ct=broonie-regmap)). The current behavior would be that the row with the index that you opened (first or second or n-th) would still be opened, with the fix it should stay hidden and closed until you see it again.

Closes #851 and #442 