### PR TITLE
feat: change hardware priority in tests table

### DIFF
--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -25,7 +25,7 @@ from kernelCI_app.typeModels.commonDetails import (
     BuildArchitectures,
     BuildStatusCount,
     BuildSummary,
-    Misc,
+    EnvironmentMisc,
     TestArchSummaryItem,
     TestStatusCount,
     TestSummary,
@@ -524,7 +524,7 @@ def handle_test_history(
         log_url=record["log_url"],
         architecture=record["build__architecture"],
         compiler=record["build__compiler"],
-        misc=Misc(platform=record["test_platform"]),
+        environment_misc=EnvironmentMisc(platform=record["test_platform"]),
         tree_name=record["build__checkout__tree_name"],
         git_repository_branch=record["build__checkout__git_repository_branch"],
     )

--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -234,7 +234,7 @@ def get_current_row_data(current_row: dict) -> dict:
         "log_url": current_row_data["test_log_url"],
         "architecture": current_row_data["build_architecture"],
         "compiler": current_row_data["build_compiler"],
-        "misc": {"platform": current_row_data["test_platform"]},
+        "environment_misc": {"platform": current_row_data["test_platform"]},
     }
 
     return current_row_data

--- a/backend/kernelCI_app/typeModels/buildDetails.py
+++ b/backend/kernelCI_app/typeModels/buildDetails.py
@@ -21,6 +21,7 @@ from kernelCI_app.typeModels.databases import (
     Test__Status,
     Test__StartTime,
     Test__EnvironmentCompatible,
+    Test__EnvironmentMisc,
 )
 
 
@@ -46,6 +47,7 @@ class BuildTestItem(BaseModel):
     path: Test__Path
     start_time: Test__StartTime
     environment_compatible: Test__EnvironmentCompatible
+    environment_misc: Test__EnvironmentMisc
 
 
 class BuildTestsResponse(RootModel):

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -31,7 +31,7 @@ class BuildArchitectures(BuildStatusCount):
     compilers: Optional[List[str]] = []
 
 
-class Misc(BaseModel):
+class EnvironmentMisc(BaseModel):
     platform: str
 
 
@@ -46,7 +46,7 @@ class TestHistoryItem(BaseModel):
     log_url: Optional[str]
     architecture: Optional[str]
     compiler: Optional[str]
-    misc: Optional[Misc]
+    environment_misc: Optional[EnvironmentMisc]
 
 
 class BuildHistoryItem(BaseModel):

--- a/backend/kernelCI_app/typeModels/databases.py
+++ b/backend/kernelCI_app/typeModels/databases.py
@@ -1,6 +1,8 @@
 from typing import List, Optional, Dict, Literal, Any, Union
 from datetime import datetime
 
+from kernelCI_app.typeModels.commonDetails import EnvironmentMisc
+
 FAIL_STATUS = "FAIL"
 ERROR_STATUS = "ERROR"
 MISS_STATUS = "MISS"
@@ -46,6 +48,7 @@ type Test__Duration = Optional[float]
 type Test__Path = Optional[str]
 type Test__StartTime = Optional[datetime]
 type Test__EnvironmentCompatible = Optional[List[str]]
+type Test__EnvironmentMisc = Optional[EnvironmentMisc]
 
 type Issue__Id = str
 type Issue__Version = int

--- a/backend/kernelCI_app/typeModels/issueDetails.py
+++ b/backend/kernelCI_app/typeModels/issueDetails.py
@@ -28,6 +28,7 @@ from kernelCI_app.typeModels.databases import (
     Test__Path,
     Test__StartTime,
     Test__EnvironmentCompatible,
+    Test__EnvironmentMisc,
     Timestamp,
     Checkout__TreeName,
     Checkout__GitRepositoryBranch,
@@ -62,6 +63,7 @@ class IssueTestItem(BaseModel):
     environment_compatible: Test__EnvironmentCompatible = Field(
         alias="test__environment_compatible"
     )
+    environment_misc: Test__EnvironmentMisc = Field(alias="test__environment_misc")
     tree_name: Checkout__TreeName = Field(alias="test__build__checkout__tree_name")
     git_repository_branch: Checkout__GitRepositoryBranch = Field(
         alias="test__build__checkout__git_repository_branch"

--- a/backend/kernelCI_app/views/buildTestsView.py
+++ b/backend/kernelCI_app/views/buildTestsView.py
@@ -11,7 +11,13 @@ class BuildTests(APIView):
     @extend_schema(responses=BuildTestsResponse)
     def get(self, request, build_id: str) -> Response:
         result = Tests.objects.filter(build_id=build_id).values(
-            "id", "duration", "status", "path", "start_time", "environment_compatible"
+            "id",
+            "duration",
+            "status",
+            "path",
+            "start_time",
+            "environment_compatible",
+            "environment_misc",
         )
 
         if not result:

--- a/backend/kernelCI_app/views/issueDetailsTestsView.py
+++ b/backend/kernelCI_app/views/issueDetailsTestsView.py
@@ -23,6 +23,7 @@ class IssueDetailsTests(APIView):
             "test__path",
             "test__start_time",
             "test__environment_compatible",
+            "test__environment_misc",
             "test__build__checkout__tree_name",
             "test__build__checkout__git_repository_branch",
         ]

--- a/backend/requests/build-tests-get.sh
+++ b/backend/requests/build-tests-get.sh
@@ -1,49 +1,69 @@
-http 'http://localhost:8000/api/build/kernelci:kernelci.org:66a1d00e546da93e297e7073/tests'
+http 'http://localhost:8000/api/build/maestro:67a17df4661a7bc8748b9147/tests'
 
 # HTTP/1.1 200 OK
-# Content-Length: 9122
+# Allow: GET, HEAD, OPTIONS
+# Cache-Control: max-age=0
+# Content-Length: 2944
 # Content-Type: application/json
 # Cross-Origin-Opener-Policy: same-origin
-# Date: Wed, 31 Jul 2024 18:00:40 GMT
+# Date: Tue, 04 Feb 2025 13:17:47 GMT
+# Expires: Tue, 04 Feb 2025 13:17:47 GMT
 # Referrer-Policy: same-origin
-# Server: WSGIServer/0.2 CPython/3.12.0
-# Vary: origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
 # X-Content-Type-Options: nosniff
 # X-Frame-Options: DENY
 
 # [
-  #   {
-  #     "id": "kernelci:kernelci.org:66a1d0d262f8cae67a7e7095",
-  #     "duration": null,
-  #     "status": "PASS",
-  #     "path": "baseline.login",
-  #     "startTime": "2024-07-25T04:13:06.105Z",
-  #     "hardware": [
-  #               "google,veyron-jaq-rev5",
-  #               "google,veyron-jaq-rev4"
-  #      ]
-  #   },
-  #   {
-  #     "id": "kernelci:kernelci.org:66a1d0a38e8d1053a47e707c",
-  #     "duration": null,
-  #     "status": "PASS",
-  #     "path": "baseline.login",
-  #     "startTime": "2024-07-25T04:12:19.892Z",
-  #      "hardware": [
-  #                "google,veyron-jaq-rev5",
-  #                "google,veyron-jaq-rev4"
-  #            ]
-  #   },
-  #   {
-  #     "id": "kernelci:kernelci.org:66a1d0a38e8d1053a47e707e",
-  #     "duration": null,
-  #     "status": "PASS",
-  #     "path": "baseline.dmesg.emerg",
-  #     "startTime": "2024-07-25T04:12:19.927Z",
-  #     "hardware": [
-  #               "google,veyron-jaq-rev5",
-  #               "google,veyron-jaq-rev4"
-  #      ]
-  #   },
-  #   ...
-  # ]
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "radxa,rock-5b",
+#             "rockchip,rk3588"
+#         ],
+#         "id": "maestro:67a1876b661a7bc8748b9ee0",
+#         "misc": {
+#             "job_id": "17603386",
+#             "job_url": "https://lava.collabora.dev/scheduler/job/17603386",
+#             "platform": "rk3588-rock-5b"
+#         },
+#         "path": "boot",
+#         "start_time": "2025-02-04T03:20:11.382000Z",
+#         "status": "PASS"
+#     },
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "khadas,vim3",
+#             "amlogic,a311d",
+#             "amlogic,g12b"
+#         ],
+#         "id": "maestro:67a18766661a7bc8748b9ece",
+#         "environment_misc": {
+#             "job_id": "17603380",
+#             "job_url": "https://lava.collabora.dev/scheduler/job/17603380",
+#             "platform": "meson-g12b-a311d-khadas-vim3"
+#         },
+#         "path": "boot",
+#         "start_time": "2025-02-04T03:20:06.062000Z",
+#         "status": "PASS"
+#     },
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "mediatek,mt8390-evk",
+#             "mediatek,mt8390",
+#             "mediatek,mt8188"
+#         ],
+#         "id": "maestro:67a18767661a7bc8748b9ed4",
+#         "environemtn_misc": {
+#             "job_id": "17603382",
+#             "job_url": "https://lava.collabora.dev/scheduler/job/17603382",
+#             "platform": "mt8390-genio-700-evk"
+#         },
+#         "path": "boot",
+#         "start_time": "2025-02-04T03:20:07.904000Z",
+#         "status": "PASS"
+#     },
+#     ...
+# ]

--- a/backend/requests/issue-details-tests-get.sh
+++ b/backend/requests/issue-details-tests-get.sh
@@ -1,14 +1,14 @@
 # This will get the tests from the issue with the latest version, for a specific version pass ?version=n (n being an integer)
 http 'http://localhost:8000/api/issue/maestro:0820fe153b255bf52750bbf1fecb198d8772f5a9/tests'
 
-# HTTP/1.1 200 OK
+HTTP/1.1 200 OK
 # Allow: GET, HEAD, OPTIONS
 # Cache-Control: max-age=0
-# Content-Length: 1077
+# Content-Length: 1589
 # Content-Type: application/json
 # Cross-Origin-Opener-Policy: same-origin
-# Date: Tue, 04 Feb 2025 12:22:22 GMT
-# Expires: Tue, 04 Feb 2025 12:22:22 GMT
+# Date: Tue, 04 Feb 2025 13:12:08 GMT
+# Expires: Tue, 04 Feb 2025 13:12:08 GMT
 # Referrer-Policy: same-origin
 # Server: WSGIServer/0.2 CPython/3.12.7
 # Vary: Accept, Cookie, origin
@@ -16,60 +16,80 @@ http 'http://localhost:8000/api/issue/maestro:0820fe153b255bf52750bbf1fecb198d87
 # X-Frame-Options: DENY
 
 # [
-#    {
-#       "id":"maestro:674ef566063ce49a02bf7b6d",
-#       "status":"FAIL",
-#       "duration":null,
-#       "path":"boot.nfs",
-#       "start_time":"2024-12-03T12:11:18.636000Z",
-#       "environment_compatible":[
-#          "google,tomato-rev2",
-#          "google,tomato",
-#          "mediatek,mt8195"
-#       ],
-#       "tree_name":"net-next",
-#       "git_repository_branch":"main"
-#    },
-#    {
-#       "id":"maestro:674fddf9089e99b3f2b506f7",
-#       "status":"FAIL",
-#       "duration":null,
-#       "path":"boot.nfs",
-#       "start_time":"2024-12-04T04:43:37.701000Z",
-#       "environment_compatible":[
-#          "google,tomato-rev2",
-#          "google,tomato",
-#          "mediatek,mt8195"
-#       ],
-#       "tree_name":"net-next",
-#       "git_repository_branch":"main"
-#    },
-#    {
-#       "id":"maestro:674fd928089e99b3f2b4b523",
-#       "status":"FAIL",
-#       "duration":null,
-#       "path":"boot",
-#       "start_time":"2024-12-04T04:23:04.822000Z",
-#       "environment_compatible":[
-#          "google,tomato-rev2",
-#          "google,tomato",
-#          "mediatek,mt8195"
-#       ],
-#       "tree_name":"net-next",
-#       "git_repository_branch":"main"
-#    },
-#    {
-#       "id":"maestro:6750002f089e99b3f2b7e106",
-#       "status":"FAIL",
-#       "duration":null,
-#       "path":"boot",
-#       "start_time":"2024-12-04T07:09:35.087000Z",
-#       "environment_compatible":[
-#          "google,tomato-rev2",
-#          "google,tomato",
-#          "mediatek,mt8195"
-#       ],
-#       "tree_name":"net-next",
-#       "git_repository_branch":"main"
-#    }
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "google,tomato-rev2",
+#             "google,tomato",
+#             "mediatek,mt8195"
+#         ],
+#         "git_repository_branch": "main",
+#         "id": "maestro:674ef566063ce49a02bf7b6d",
+#         "environment_misc": {
+#             "job_id": "16727012",
+#             "job_url": "https://lava.collabora.dev/scheduler/job/16727012",
+#             "platform": "mt8195-cherry-tomato-r2"
+#         },
+#         "path": "boot.nfs",
+#         "start_time": "2024-12-03T12:11:18.636000Z",
+#         "status": "FAIL",
+#         "tree_name": "net-next"
+#     },
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "google,tomato-rev2",
+#             "google,tomato",
+#             "mediatek,mt8195"
+#         ],
+#         "git_repository_branch": "main",
+#         "id": "maestro:674fddf9089e99b3f2b506f7",
+#         "environment_misc": {
+#             "job_id": "16759244",
+#             "job_url": "https://lava.collabora.dev/scheduler/job/16759244",
+#             "platform": "mt8195-cherry-tomato-r2"
+#         },
+#         "path": "boot.nfs",
+#         "start_time": "2024-12-04T04:43:37.701000Z",
+#         "status": "FAIL",
+#         "tree_name": "net-next"
+#     },
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "google,tomato-rev2",
+#             "google,tomato",
+#             "mediatek,mt8195"
+#         ],
+#         "git_repository_branch": "main",
+#         "id": "maestro:674fd928089e99b3f2b4b523",
+#         "environment_misc": {
+#             "job_id": "16757607",
+#             "job_url": "https://lava.collabora.dev/scheduler/job/16757607",
+#             "platform": "mt8195-cherry-tomato-r2"
+#         },
+#         "path": "boot",
+#         "start_time": "2024-12-04T04:23:04.822000Z",
+#         "status": "FAIL",
+#         "tree_name": "net-next"
+#     },
+#     {
+#         "duration": null,
+#         "environment_compatible": [
+#             "google,tomato-rev2",
+#             "google,tomato",
+#             "mediatek,mt8195"
+#         ],
+#         "git_repository_branch": "main",
+#         "id": "maestro:6750002f089e99b3f2b7e106",
+#         "environment_misc": {
+#             "job_id": "16770923",
+#             "job_url": "https://lava.collabora.dev/scheduler/job/16770923",
+#             "platform": "mt8195-cherry-tomato-r2"
+#         },
+#         "path": "boot",
+#         "start_time": "2024-12-04T07:09:35.087000Z",
+#         "status": "FAIL",
+#         "tree_name": "net-next"
+#     }
 # ]

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -907,6 +907,8 @@ components:
           $ref: '#/components/schemas/Test__StartTime'
         environment_compatible:
           $ref: '#/components/schemas/Test__EnvironmentCompatible'
+        environment_misc:
+          $ref: '#/components/schemas/Test__EnvironmentMisc'
       required:
       - id
       - status
@@ -914,6 +916,7 @@ components:
       - path
       - start_time
       - environment_compatible
+      - environment_misc
       title: BuildTestItem
       type: object
     BuildTestsResponse:
@@ -1044,6 +1047,15 @@ components:
       - tests
       title: DetailsFilters
       type: object
+    EnvironmentMisc:
+      properties:
+        platform:
+          title: Platform
+          type: string
+      required:
+      - platform
+      title: EnvironmentMisc
+      type: object
     GlobalFilters:
       properties:
         configs:
@@ -1142,7 +1154,7 @@ components:
           title: Issue Id
         issue_version:
           anyOf:
-          - type: string
+          - type: integer
           - type: 'null'
           title: Issue Version
       required:
@@ -1365,9 +1377,9 @@ components:
           - type: string
           - type: 'null'
           title: Compiler
-        misc:
+        environment_misc:
           anyOf:
-          - $ref: '#/components/schemas/Misc'
+          - $ref: '#/components/schemas/EnvironmentMisc'
           - type: 'null'
         tree_name:
           $ref: '#/components/schemas/Checkout__TreeName'
@@ -1384,7 +1396,7 @@ components:
       - log_url
       - architecture
       - compiler
-      - misc
+      - environment_misc
       - tree_name
       - git_repository_branch
       title: HardwareTestHistoryItem
@@ -1393,7 +1405,14 @@ components:
       properties:
         issues:
           items:
-            type: string
+            maxItems: 2
+            minItems: 2
+            prefixItems:
+            - type: string
+            - anyOf:
+              - type: integer
+              - type: 'null'
+            type: array
           title: Issues
           type: array
         platforms:
@@ -1541,6 +1560,8 @@ components:
           $ref: '#/components/schemas/Test__StartTime'
         test__environment_compatible:
           $ref: '#/components/schemas/Test__EnvironmentCompatible'
+        test__environment_misc:
+          $ref: '#/components/schemas/Test__EnvironmentMisc'
         test__build__checkout__tree_name:
           $ref: '#/components/schemas/Checkout__TreeName'
         test__build__checkout__git_repository_branch:
@@ -1552,6 +1573,7 @@ components:
       - test__path
       - test__start_time
       - test__environment_compatible
+      - test__environment_misc
       - test__build__checkout__tree_name
       - test__build__checkout__git_repository_branch
       title: IssueTestItem
@@ -1611,21 +1633,19 @@ components:
       properties:
         issues:
           items:
-            type: string
+            maxItems: 2
+            minItems: 2
+            prefixItems:
+            - type: string
+            - anyOf:
+              - type: integer
+              - type: 'null'
+            type: array
           title: Issues
           type: array
       required:
       - issues
       title: LocalFilters
-      type: object
-    Misc:
-      properties:
-        platform:
-          title: Platform
-          type: string
-      required:
-      - platform
-      title: Misc
       type: object
     Origin:
       type: string
@@ -1729,9 +1749,9 @@ components:
           - type: string
           - type: 'null'
           title: Compiler
-        misc:
+        environment_misc:
           anyOf:
-          - $ref: '#/components/schemas/Misc'
+          - $ref: '#/components/schemas/EnvironmentMisc'
           - type: 'null'
       required:
       - id
@@ -1744,7 +1764,7 @@ components:
       - log_url
       - architecture
       - compiler
-      - misc
+      - environment_misc
       title: TestHistoryItem
       type: object
     TestStatusCount:
@@ -1858,6 +1878,10 @@ components:
       - items:
           type: string
         type: array
+      - type: 'null'
+    Test__EnvironmentMisc:
+      anyOf:
+      - $ref: '#/components/schemas/EnvironmentMisc'
       - type: 'null'
     Test__Id:
       type: string

--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -146,7 +146,10 @@ export function BootsTable({
               path: e.path,
               startTime: e.start_time,
               status: e.status,
-              hardware: buildHardwareArray(e.environment_compatible, e.misc),
+              hardware: buildHardwareArray(
+                e.environment_compatible,
+                e.environment_misc,
+              ),
               treeBranch: buildTreeBranch(e.tree_name, e.git_repository_branch),
             };
           })

--- a/dashboard/src/components/Table/TooltipHardware.tsx
+++ b/dashboard/src/components/Table/TooltipHardware.tsx
@@ -4,27 +4,33 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 
 import { sanitizeTableValue } from '@/components/Table/tableUtils';
 
+const tooltipStartIdx = 1;
+
 const TooltipHardware = ({
   hardwares,
 }: {
   hardwares: string[] | undefined;
 }): JSX.Element => {
+  const shouldHaveTooltip = hardwares && hardwares.length > 1;
+
   const hardwaresTooltip = useMemo(() => {
-    return hardwares
-      ? hardwares.map(hardware => (
+    return shouldHaveTooltip
+      ? hardwares.slice(tooltipStartIdx).map(hardware => (
           <div key={hardware} className="text-center">
             <span>{hardware}</span>
             <br />
           </div>
         ))
       : '-';
-  }, [hardwares]);
+  }, [hardwares, shouldHaveTooltip]);
+
+  const hardwareTrigger = sanitizeTableValue(hardwares?.[0], false);
+
+  if (!shouldHaveTooltip) return <span>{hardwareTrigger}</span>;
 
   return (
     <Tooltip>
-      <TooltipTrigger>
-        {sanitizeTableValue(hardwares?.[0], false)}
-      </TooltipTrigger>
+      <TooltipTrigger>{hardwareTrigger}</TooltipTrigger>
       <TooltipContent>{hardwaresTooltip}</TooltipContent>
     </Tooltip>
   );

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -104,7 +104,10 @@ export function TestsTable({
           path: e.path,
           start_time: e.start_time,
           status: e.status,
-          hardware: buildHardwareArray(e.environment_compatible, e.misc),
+          hardware: buildHardwareArray(
+            e.environment_compatible,
+            e.environment_misc,
+          ),
           treeBranch: buildTreeBranch(e.tree_name, e.git_repository_branch),
         });
         switch (e.status) {

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -35,7 +35,7 @@ export type TIssue = {
   incidents_info: IncidentsInfo;
 };
 
-interface IMisc {
+interface IEnvironmentMisc {
   platform?: string;
 }
 
@@ -46,7 +46,7 @@ export type TestHistory = {
   id: string;
   duration?: number;
   environment_compatible?: string[];
-  misc?: IMisc;
+  environment_misc?: IEnvironmentMisc;
   tree_name?: string;
   git_repository_branch?: string;
 };

--- a/dashboard/src/utils/table.ts
+++ b/dashboard/src/utils/table.ts
@@ -6,11 +6,9 @@ export const buildHardwareArray = (
   environment_compatible?: TestHistory['environment_compatible'],
   misc?: TestHistory['misc'],
 ): string[] | undefined => {
-  return environment_compatible
-    ? environment_compatible
-    : misc?.platform
-      ? [misc?.platform]
-      : undefined;
+  const miscArray: string[] = misc?.platform ? [misc.platform] : [];
+  const envArray: string[] = environment_compatible ?? [];
+  return miscArray.concat(envArray);
 };
 
 export const buildTreeBranch = (

--- a/dashboard/src/utils/table.ts
+++ b/dashboard/src/utils/table.ts
@@ -4,9 +4,11 @@ import type { TestHistory } from '@/types/general';
 
 export const buildHardwareArray = (
   environment_compatible?: TestHistory['environment_compatible'],
-  misc?: TestHistory['misc'],
+  environment_misc?: TestHistory['environment_misc'],
 ): string[] | undefined => {
-  const miscArray: string[] = misc?.platform ? [misc.platform] : [];
+  const miscArray: string[] = environment_misc?.platform
+    ? [environment_misc.platform]
+    : [];
   const envArray: string[] = environment_compatible ?? [];
   return miscArray.concat(envArray);
 };


### PR DESCRIPTION
- Show platform first and enviroment_compatible in the hover if it exists. Show only environment_compatible if platform is undefined
- [x] Add platforms to hardware column in the Issue Details tests table
- [x] Add platforms to hardware column in the Build Details tests table

## How to test
- Go to a tree details page and verify that the hardware priority is working correctly (to ensure that the tooltip is working you can filter for a hardware and check if the tooltip shows)
- Do the same in a build details page. In this case you can open one of the tests and check if the platform is the one showing in the table and if the tooltip is correctly showing the environment_compatible (field "hardware" in test details) ou showing nothing if hardware is "Unknown"
- Do the same in an issue details page. To quickly find an issue details page with tests you can go to a boots tab with issues and open one of the issues there.

Closes #864 