### PR TITLE
Fix: issuesList counting

### DIFF
--- a/backend/kernelCI_app/constants/general.py
+++ b/backend/kernelCI_app/constants/general.py
@@ -1,1 +1,3 @@
 DEFAULT_ORIGIN = 'maestro'
+
+UNKNOWN_STRING = 'Unknown'

--- a/backend/kernelCI_app/helpers/commonDetails.py
+++ b/backend/kernelCI_app/helpers/commonDetails.py
@@ -1,4 +1,4 @@
-from kernelCI_app.helpers.filters import UNKNOWN_STRING
+from kernelCI_app.constants.general import UNKNOWN_STRING
 from typing import Set
 
 

--- a/backend/kernelCI_app/helpers/filters.py
+++ b/backend/kernelCI_app/helpers/filters.py
@@ -3,8 +3,8 @@ from django.http import HttpResponseBadRequest
 import re
 from kernelCI_app.typeModels.databases import PASS_STATUS, failure_status_list
 from kernelCI_app.utils import getErrorResponseBody
+from kernelCI_app.constants.general import UNKNOWN_STRING
 
-UNKNOWN_STRING = "Unknown"
 NULL_STRINGS = set(["null", UNKNOWN_STRING, "NULL"])
 
 

--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -692,14 +692,17 @@ def update_issues(
 ) -> None:
     can_insert_issue = True
     if issue_from == "build":
-        (issue_id, can_insert_issue) = should_increment_build_issue(
+        (issue_id, issue_version, can_insert_issue) = should_increment_build_issue(
             issue_id=issue_id,
+            issue_version=issue_version,
             incident_test_id=incident_test_id,
             build_valid=build_valid,
         )
     elif issue_from == "test":
-        (issue_id, can_insert_issue) = should_increment_test_issue(
-            issue_id, incident_test_id
+        (issue_id, issue_version, can_insert_issue) = should_increment_test_issue(
+            issue_id=issue_id,
+            issue_version=issue_version,
+            incident_test_id=incident_test_id,
         )
 
     if issue_id and issue_version is not None and can_insert_issue:
@@ -766,11 +769,7 @@ def get_processed_issue_key(*, record: Dict) -> str:
     issue_version = record["incidents__issue__version"]
     issue_version_key = str(issue_version) if issue_version is not None else ""
 
-    processed_issue_key = (
-        record["id"]
-        + issue_id_key
-        + issue_version_key
-    )
+    processed_issue_key = record["id"] + issue_id_key + issue_version_key
     return processed_issue_key
 
 
@@ -851,10 +850,13 @@ def process_filters(*, instance, record: Dict) -> None:
         instance.global_architectures.add(record["build__architecture"])
         instance.global_compilers.add(record["build__compiler"])
 
-        build_issue_id, is_build_issue = should_increment_build_issue(
-            issue_id=build_issue_id,
-            incident_test_id=incident_test_id,
-            build_valid=build_valid,
+        build_issue_id, build_issue_version, is_build_issue = (
+            should_increment_build_issue(
+                issue_id=build_issue_id,
+                issue_version=build_issue_version,
+                incident_test_id=incident_test_id,
+                build_valid=build_valid,
+            )
         )
 
         is_invalid = build_valid is False
@@ -876,8 +878,9 @@ def process_filters(*, instance, record: Dict) -> None:
 
         test_issue_id = record["incidents__issue__id"]
         test_issue_version = record["incidents__issue__version"]
-        test_issue_id, is_test_issue = should_increment_test_issue(
+        test_issue_id, test_issue_version, is_test_issue = should_increment_test_issue(
             issue_id=test_issue_id,
+            issue_version=test_issue_version,
             incident_test_id=incident_test_id,
         )
 

--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -7,10 +7,10 @@ from kernelCI_app.cache import getQueryCache, setQueryCache
 from kernelCI_app.constants.hardwareDetails import (
     SELECTED_HEAD_TREE_VALUE,
 )
+from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.helpers.build import build_status_map
 from kernelCI_app.helpers.commonDetails import add_unfiltered_issue
 from kernelCI_app.helpers.filters import (
-    UNKNOWN_STRING,
     FilterParams,
     is_test_failure,
     should_increment_build_issue,

--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -5,8 +5,8 @@ from kernelCI_app.helpers.filters import (
     is_test_failure,
     should_increment_build_issue,
     should_increment_test_issue,
-    UNKNOWN_STRING,
 )
+from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.typeModels.databases import FAIL_STATUS
 from kernelCI_app.utils import (
     extract_error_message,

--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -300,8 +300,9 @@ def process_builds_issue(instance, row_data):
     build_valid = row_data["build_valid"]
     incident_test_id = row_data["incident_test_id"]
 
-    (issue_id, can_insert_issue) = should_increment_build_issue(
+    (issue_id, issue_version, can_insert_issue) = should_increment_build_issue(
         issue_id=issue_id,
+        issue_version=issue_version,
         incident_test_id=incident_test_id,
         build_valid=build_valid,
     )
@@ -330,8 +331,10 @@ def process_tests_issue(instance, row_data):
     issue_report_url = row_data["issue_report_url"]
     incident_test_id = row_data["incident_test_id"]
 
-    (issue_id, can_insert_issue) = should_increment_test_issue(
-        issue_id, incident_test_id
+    (issue_id, issue_version, can_insert_issue) = should_increment_test_issue(
+        issue_id=issue_id,
+        issue_version=issue_version,
+        incident_test_id=incident_test_id,
     )
 
     if issue_id and issue_version is not None and can_insert_issue:
@@ -357,8 +360,10 @@ def process_boots_issue(instance, row_data):
     issue_report_url = row_data["issue_report_url"]
     incident_test_id = row_data["incident_test_id"]
 
-    (issue_id, can_insert_issue) = should_increment_test_issue(
-        issue_id=issue_id, incident_test_id=incident_test_id
+    (issue_id, issue_version, can_insert_issue) = should_increment_test_issue(
+        issue_id=issue_id,
+        issue_version=issue_version,
+        incident_test_id=incident_test_id,
     )
 
     if issue_id and issue_version is not None and can_insert_issue:
@@ -527,8 +532,9 @@ def process_filters(instance, row_data: dict) -> None:
         instance.global_architectures.add(row_data["build_architecture"])
         instance.global_compilers.add(row_data["build_compiler"])
 
-        build_issue_id, is_build_issue = should_increment_build_issue(
+        build_issue_id, build_issue_version, is_build_issue = should_increment_build_issue(
             issue_id=issue_id,
+            issue_version=issue_version,
             incident_test_id=incident_test_id,
             build_valid=build_valid,
         )
@@ -536,15 +542,16 @@ def process_filters(instance, row_data: dict) -> None:
         is_invalid = build_valid is False
         add_unfiltered_issue(
             issue_id=build_issue_id,
-            issue_version=issue_version,
+            issue_version=build_issue_version,
             should_increment=is_build_issue,
             issue_set=instance.unfiltered_build_issues,
             is_invalid=is_invalid,
         )
 
     if row_data["test_id"] is not None:
-        test_issue_id, is_test_issue = should_increment_test_issue(
+        test_issue_id, test_issue_version, is_test_issue = should_increment_test_issue(
             issue_id=issue_id,
+            issue_version=issue_version,
             incident_test_id=incident_test_id,
         )
 
@@ -556,7 +563,7 @@ def process_filters(instance, row_data: dict) -> None:
         is_invalid = row_data["test_status"] == FAIL_STATUS
         add_unfiltered_issue(
             issue_id=test_issue_id,
-            issue_version=issue_version,
+            issue_version=test_issue_version,
             should_increment=is_test_issue,
             issue_set=issue_set,
             is_invalid=is_invalid,

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -1,9 +1,10 @@
+import json
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Optional, Set, Union, Tuple
+from typing import Dict, List, Optional, Set, Union, Tuple, Any
 
 from kernelCI_app.typeModels.issues import Issue
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class TestStatusCount(BaseModel):
@@ -62,6 +63,12 @@ class BuildHistoryItem(BaseModel):
     start_time: Optional[Union[datetime, str]]
     git_repository_url: Optional[str]
     git_repository_branch: Optional[str]
+
+    @field_validator("misc", mode="before")
+    @classmethod
+    def to_dict(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return json.loads(value)
 
 
 class TestSummary(BaseModel):

--- a/backend/kernelCI_app/unitTests/treeDetails.test.py
+++ b/backend/kernelCI_app/unitTests/treeDetails.test.py
@@ -1,5 +1,6 @@
 import unittest
-from kernelCI_app.helpers.filters import should_filter_test_issue, UNKNOWN_STRING
+from kernelCI_app.helpers.filters import should_filter_test_issue
+from kernelCI_app.constants.general import UNKNOWN_STRING
 
 
 # TODO: replace with pytest

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -34,9 +34,9 @@ def convert_issues_dict_to_list(issues_dict: Dict[str, Issue]) -> List[Issue]:
     return list(issues_dict.values())
 
 
-def convert_issues_dict_to_list_typed(*, issues_dict: Dict) -> List[Issue]:
+def convert_issues_dict_to_list_typed(*, issues_dict_list: Dict) -> List[Issue]:
     issues: List[Issue] = []
-    for issue in issues_dict.values():
+    for issue in issues_dict_list.values():
         issues.append(
             Issue(
                 id=issue["id"],

--- a/backend/kernelCI_app/views/hardwareDetailsBootsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBootsView.py
@@ -13,6 +13,7 @@ from kernelCI_app.helpers.hardwareDetails import (
     get_trees_with_selected_commit,
     get_validated_current_tree,
     handle_test_history,
+    is_test_processed,
     unstable_parse_post_body,
 )
 from kernelCI_app.typeModels.hardwareDetails import (
@@ -52,6 +53,10 @@ class HardwareDetailsBoots(APIView):
         if not is_record_boot:
             return
 
+        is_test_processed_result = is_test_processed(record=record, processed_tests=self.processed_tests)
+        if (is_test_processed_result):
+            return
+
         should_process_test = decide_if_is_test_in_filter(
             instance=self,
             test_type="boot",
@@ -59,12 +64,12 @@ class HardwareDetailsBoots(APIView):
             processed_tests=self.processed_tests,
         )
 
-        self.processed_tests.add(record["id"])
         if should_process_test:
             handle_test_history(
                 record=record,
                 task=self.boots,
             )
+            self.processed_tests.add(record["id"])
 
     def _sanitize_records(
         self, records, trees: List[Tree], is_all_selected: bool

--- a/backend/kernelCI_app/views/hardwareDetailsTestsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsTestsView.py
@@ -13,6 +13,7 @@ from kernelCI_app.helpers.hardwareDetails import (
     get_trees_with_selected_commit,
     get_validated_current_tree,
     handle_test_history,
+    is_test_processed,
     unstable_parse_post_body,
 )
 from kernelCI_app.typeModels.hardwareDetails import (
@@ -50,6 +51,10 @@ class HardwareDetailsTests(APIView):
         if is_record_boot:
             return
 
+        is_test_processed_result = is_test_processed(record=record, processed_tests=self.processed_tests)
+        if (is_test_processed_result):
+            return
+
         should_process_test = decide_if_is_test_in_filter(
             instance=self,
             test_type="test",
@@ -57,12 +62,12 @@ class HardwareDetailsTests(APIView):
             processed_tests=self.processed_tests,
         )
 
-        self.processed_tests.add(record["id"])
         if should_process_test:
             handle_test_history(
                 record=record,
                 task=self.tests,
             )
+            self.processed_tests.add(record["id"])
 
     def _sanitize_records(
         self, records: List[Dict], trees: List[Tree], is_all_selected: bool

--- a/backend/kernelCI_app/views/hardwareView.py
+++ b/backend/kernelCI_app/views/hardwareView.py
@@ -14,7 +14,7 @@ from kernelCI_app.helpers.build import build_status_map
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
-from kernelCI_app.helpers.filters import UNKNOWN_STRING
+from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.helpers.misc import env_misc_value_or_default, handle_environment_misc
 from kernelCI_app.helpers.trees import get_tree_heads

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -3,10 +3,10 @@ from django.db import connection
 from http import HTTPStatus
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
-    UNKNOWN_STRING,
     FilterParams,
     InvalidComparisonOP,
 )
+from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.helpers.misc import (
     handle_build_misc,

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -95,7 +95,10 @@ const IssuesList = ({
     <DumbListingContent>
       {issues.map(issue => {
         return (
-          <div key={issue.id} className="flex w-full justify-between gap-4">
+          <div
+            key={`${issue.id}${issue.version}`}
+            className="flex w-full justify-between gap-4"
+          >
             <div className="overflow-hidden">
               <FilterLink
                 filterSection={issueFilterSection}

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -235,7 +235,7 @@ export const getIssueFilterLabel = (issueFilter: TIssueFilter): string => {
   const issueId = issueFilter.id;
   const issueVersion = issueFilter.version;
 
-  if (!issueVersion) {
+  if (issueVersion === undefined || issueVersion === null) {
     return issueId;
   }
 


### PR DESCRIPTION
- Renames processed_issues to issue_dicts
- Separates processed_tests from decide_test_in_filter
- Update getIssueFilterLabel to check explicitly for undefined
- Update key prop from IssuesList div to include issue version

Closes #872 

## How to test
You can verify that filtering by issues in [this localhost page](http://localhost:5173/hardware/google%2Ctomato-rev2?et=1738602000&hs=tomato-rev2&p=bt&st=1738170000) is working properly, while [staging page](https://staging.dashboard.kernelci.org:9000/hardware/google%2Ctomato-rev2?et=1738602000&hs=tomato-rev2&p=bt&st=1738170000) is showing the problems cited in the issue (issues list not showing all issues, filtering by the unlisted issues through the modal causing errors, etc.) 

## Known issues
While testing this I found out a seemingly unrelated problem with this task, where filtering by an issue will always return the "jobs" (boots/builds/tests) with the latest version instead of the selected version of the issue. This is in more detail in this issue: 
- https://github.com/kernelci/dashboard/issues/902

**UPDATE:** It seems that this issue was caused by how the Django ORM was performing the JOIN in the issues table instead of by the filtering system. This was solved in this PR and I'll close this issue as well when this PR is merged

## Visual Reference
Before
![image](https://github.com/user-attachments/assets/910fc8d9-ad20-4bca-aeb4-781866b84ecf)

After
![image](https://github.com/user-attachments/assets/2c94743a-1fc3-4dd0-8a69-24520f01f989)
