### PR TITLE
Feat: add treeIssues endpoint and detailed issues info

### DIFF
--- a/backend/kernelCI_app/helpers/issueExtras.py
+++ b/backend/kernelCI_app/helpers/issueExtras.py
@@ -1,0 +1,159 @@
+from collections import defaultdict
+from typing import Dict, List, Set, Tuple
+
+from kernelCI_app.helpers.logger import log_message
+from django.db.models import Min
+from kernelCI_app.typeModels.issues import (
+    IssueWithExtraInfo,
+    ProcessedExtraDetailedIssues,
+    TreeSetItem,
+)
+from kernelCI_app.models import Incidents, Checkouts
+
+
+class TagUrls:
+    MAINLINE_URL = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+    STABLE_URL = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
+    LINUX_NEXT_URL = (
+        "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git"
+    )
+
+
+def process_issues_extra_details(
+    *,
+    issue_key_list: List[Tuple[str, int]],
+    processed_issues_table: ProcessedExtraDetailedIssues,
+) -> None:
+    # TODO: combine both queries into one
+    assign_issue_first_seen(
+        issue_key_list=issue_key_list,
+        processed_issues_table=processed_issues_table,
+    )
+    assign_issue_trees(
+        issue_key_list=issue_key_list,
+        processed_issues_table=processed_issues_table,
+    )
+
+
+def assign_issue_first_seen(
+    *,
+    issue_key_list: List[Tuple[str, int]],
+    processed_issues_table: ProcessedExtraDetailedIssues,
+) -> None:
+    issue_id_list: List[str] = []
+    versions_per_issue: Dict[str, Set[int]] = defaultdict(set)
+    for issue_key in issue_key_list:
+        issue_id, issue_version = issue_key
+        issue_id_list.append(issue_id)
+        versions_per_issue[issue_id].add(issue_version)
+
+    # TODO: use '=' instead of 'IN' when the list has a single element
+    incident_records = (
+        Incidents.objects.filter(issue_id__in=issue_id_list)
+        .values("issue_id")
+        .annotate(
+            first_seen=Min("field_timestamp"),
+            issue_version=Min("issue_version"),
+        )
+    )
+
+    for record in incident_records:
+        record_issue_id = record["issue_id"]
+        first_seen = record["first_seen"]
+
+        processed_issue_from_id = processed_issues_table.get(record_issue_id)
+        if processed_issue_from_id is None:
+            processed_issues_table[record_issue_id] = {}
+            processed_issue_from_id = processed_issues_table[record_issue_id]
+
+        for version in versions_per_issue[record_issue_id]:
+            processed_issue_from_version = processed_issue_from_id.get(version)
+            if processed_issue_from_version is None:
+                processed_issue_from_id[version] = IssueWithExtraInfo(
+                    id=record_issue_id, version=version, first_seen=first_seen
+                )
+            else:
+                processed_issue_from_version.first_seen = first_seen
+
+
+def assign_issue_trees(
+    *,
+    issue_key_list: List[Tuple[str, int]],
+    processed_issues_table: ProcessedExtraDetailedIssues,
+) -> None:
+
+    # TODO: use '=' instead of 'IN' when the list has a single element
+    tuple_param_list = []
+    params = {}
+
+    for index, key in enumerate(issue_key_list):
+        id_key = f"id{index}"
+        version_key = f"version{index}"
+
+        tuple_string = f"(%({id_key})s, %({version_key})s)"
+
+        tuple_param_list.append(tuple_string)
+        params[id_key] = key[0]
+        params[version_key] = key[1]
+    tuple_str = ", ".join(tuple_param_list)
+
+    trees_records = Checkouts.objects.raw(
+        f"""
+        SELECT DISTINCT
+          ON (
+            C.TREE_NAME,
+            C.GIT_REPOSITORY_URL,
+            C.GIT_REPOSITORY_BRANCH,
+            IC.ISSUE_ID,
+            IC.ISSUE_VERSION
+          )
+          C.ID,
+          C.TREE_NAME,
+          C.GIT_REPOSITORY_URL,
+          C.GIT_REPOSITORY_BRANCH,
+          IC.ISSUE_ID,
+          IC.ISSUE_VERSION
+        FROM
+          INCIDENTS IC
+          LEFT JOIN TESTS T ON IC.TEST_ID = T.ID
+          LEFT JOIN BUILDS B ON (
+            IC.BUILD_ID = B.ID
+            OR T.BUILD_ID = B.ID
+          )
+          JOIN CHECKOUTS C ON B.CHECKOUT_ID = C.ID
+        WHERE
+          (IC.ISSUE_ID, IC.ISSUE_VERSION) IN ({tuple_str})
+        """,
+        params,
+    )
+
+    for record in trees_records:
+        issue_id = record.issue_id
+        issue_version = record.issue_version
+        git_repository_url = record.git_repository_url
+        git_repository_branch = record.git_repository_branch
+
+        processed_issue_from_id = processed_issues_table.get(issue_id)
+        if processed_issue_from_id is None:
+            processed_issues_table[issue_id] = {}
+            processed_issue_from_id = processed_issues_table[issue_id]
+
+        current_detailed_issue = processed_issue_from_id.get(issue_version)
+        if current_detailed_issue is None:
+            log_message("Got tree for issue version that is not on the list")
+            continue
+
+        current_detailed_issue.trees.append(
+            TreeSetItem(
+                tree_name=record.tree_name,
+                git_repository_branch=git_repository_branch,
+            )
+        )
+
+        match (git_repository_url, git_repository_branch):
+            case (TagUrls.MAINLINE_URL, "master"):
+                current_detailed_issue.tags.add("mainline")
+            case (TagUrls.STABLE_URL, branch) if branch is not None:
+                current_detailed_issue.tags.add("stable")
+            case (TagUrls.LINUX_NEXT_URL, "master" | "pending-fixes"):
+                current_detailed_issue.tags.add("linux-next")

--- a/backend/kernelCI_app/typeModels/issues.py
+++ b/backend/kernelCI_app/typeModels/issues.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional, Tuple
+from datetime import datetime
+from typing import Dict, List, Literal, Optional, Set, Tuple
 from pydantic import BaseModel
 
 
@@ -6,12 +7,40 @@ class IncidentInfo(BaseModel):
     incidentsCount: int
 
 
-class Issue(BaseModel):
+class IssueKeys(BaseModel):
     id: str
     version: int
+
+
+class Issue(IssueKeys):
     comment: Optional[str]
     report_url: Optional[str]
     incidents_info: IncidentInfo
 
 
-type IssueDict = Dict[Tuple[str, str], Issue]
+type IssueDict = Dict[Tuple[str, int], Issue]
+
+
+type PossibleIssueTags = Literal["mainline", "stable", "linux-next"]
+
+
+class TreeSetItem(BaseModel):
+    tree_name: Optional[str]
+    git_repository_branch: Optional[str]
+
+
+class IssueWithExtraInfo(IssueKeys):
+    first_seen: Optional[datetime] = None
+    trees: Optional[List[TreeSetItem]] = []
+    tags: Optional[Set[PossibleIssueTags]] = set()
+
+
+class IssueExtraDetailsRequest(BaseModel):
+    issues: List[Tuple[str, int]]
+
+
+type ProcessedExtraDetailedIssues = Dict[str, Dict[int, IssueWithExtraInfo]]
+
+
+class IssueExtraDetailsResponse(BaseModel):
+    issues: ProcessedExtraDetailedIssues

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -100,6 +100,10 @@ urlpatterns = [
     path("hardware/",
          viewCache(views.HardwareView),
          name="hardware"),
+    path("issue/extras/",
+         viewCache(views.IssueExtraDetails),
+         name="issueExtraDetails"
+         ),
     path("issue/<str:issue_id>",
          viewCache(views.IssueDetails),
          name="issueDetails"),

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -1,5 +1,6 @@
 import json
 from typing import Union, List, Optional, Dict
+import typing_extensions
 from django.utils import timezone
 from datetime import timedelta
 
@@ -25,7 +26,10 @@ def create_issue(
     }
 
 
-# deprecated, use convert_issues_dict_to_list_typed instead and use type validation
+@typing_extensions.deprecated(
+    'The `convert_issues_dict_to_list` method is deprecated; use `convert_issues_dict_to_list_typed` '
+    'and use type validation.',
+)
 def convert_issues_dict_to_list(issues_dict: Dict[str, Issue]) -> List[Issue]:
     return list(issues_dict.values())
 
@@ -41,7 +45,7 @@ def convert_issues_dict_to_list_typed(*, issues_dict: Dict) -> List[Issue]:
                 report_url=issue["report_url"],
                 incidents_info=IncidentInfo(
                     incidentsCount=issue["incidents_info"]["incidentsCount"],
-                )
+                ),
             )
         )
     return issues

--- a/backend/kernelCI_app/views/issueDetailsView.py
+++ b/backend/kernelCI_app/views/issueDetailsView.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 
 class IssueDetails(APIView):
+    # TODO: combine fetching latest version here
     def _fetch_issue(self, *, issue_id: str, version: int) -> Optional[Dict]:
         issue_fields = [
             "field_timestamp",

--- a/backend/kernelCI_app/views/issueExtrasView.py
+++ b/backend/kernelCI_app/views/issueExtrasView.py
@@ -1,0 +1,70 @@
+from http import HTTPStatus
+import json
+
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.helpers.issueExtras import (
+    process_issues_extra_details,
+)
+from kernelCI_app.typeModels.issues import (
+    IssueExtraDetailsRequest,
+    IssueExtraDetailsResponse,
+    ProcessedExtraDetailedIssues,
+)
+from drf_spectacular.utils import extend_schema
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from pydantic import ValidationError
+
+
+# disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/
+# that protection is recommended for ‘unsafe’ methods (POST, PUT, and DELETE)
+# but we are using POST here just to follow the convention to use the request body
+# also the csrf protection require the usage of cookies which is not currently
+# supported in this project
+@method_decorator(csrf_exempt, name="dispatch")
+class IssueExtraDetails(APIView):
+    def __init__(self):
+        self.processed_detailed_issues: ProcessedExtraDetailedIssues = {}
+
+    @extend_schema(
+        request=IssueExtraDetailsRequest,
+        responses=IssueExtraDetailsResponse,
+        methods=["POST"],
+    )
+    def post(self, request) -> Response:
+        try:
+            body = json.loads(request.body)
+            valid_body = IssueExtraDetailsRequest(**body)
+        except json.JSONDecodeError:
+            return create_api_error_response(
+                error_message="Invalid body, request body must be a valid json string",
+            )
+        except ValidationError as e:
+            return Response(e.json(), status=HTTPStatus.BAD_REQUEST)
+
+        issue_list = valid_body.issues
+
+        if len(issue_list) == 0:
+            return create_api_error_response(
+                error_message="Invalid body, the issue list must not be empty"
+            )
+
+        process_issues_extra_details(
+            issue_key_list=issue_list,
+            processed_issues_table=self.processed_detailed_issues,
+        )
+
+        if not self.processed_detailed_issues:
+            return create_api_error_response(
+                error_message="No extra details found", status_code=HTTPStatus.OK
+            )
+
+        try:
+            valid_response = IssueExtraDetailsResponse(
+                issues=self.processed_detailed_issues
+            )
+        except ValidationError as e:
+            return Response(e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+        return Response(valid_response.model_dump(), status=HTTPStatus.OK)

--- a/backend/requests/issue-extras-post.sh
+++ b/backend/requests/issue-extras-post.sh
@@ -1,0 +1,54 @@
+http POST http://localhost:8000/api/issue/extras/ \
+Content-Type:application/json \
+<<< '{
+    "issues": [["maestro:7e50acf75c6dfb35b118a15803da9405327eaf55", 1], ["maestro:a5f01e4f2ffb30ed4d5b8cfaabe736cd8608911c", 1]]
+}'
+
+# HTTP/1.1 200 OK
+# Allow: POST, OPTIONS
+# Content-Length: 528
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Mon, 10 Feb 2025 17:00:36 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "issues": {
+#         "maestro:7e50acf75c6dfb35b118a15803da9405327eaf55": {
+#             "1": {
+#                 "first_seen": "2025-02-03T19:31:10.399653Z",
+#                 "id": "maestro:7e50acf75c6dfb35b118a15803da9405327eaf55",
+#                 "tags": [
+#                     "mainline"
+#                 ],
+#                 "trees": [
+#                     {
+#                         "git_repository_branch": "master",
+#                         "tree_name": "mainline"
+#                     }
+#                 ],
+#                 "version": 1
+#             }
+#         },
+#         "maestro:a5f01e4f2ffb30ed4d5b8cfaabe736cd8608911c": {
+#             "1": {
+#                 "first_seen": "2025-02-03T19:31:10.399653Z",
+#                 "id": "maestro:a5f01e4f2ffb30ed4d5b8cfaabe736cd8608911c",
+#                 "tags": [
+#                     "mainline"
+#                 ],
+#                 "trees": [
+#                     {
+#                         "git_repository_branch": "master",
+#                         "tree_name": "mainline"
+#                     }
+#                 ],
+#                 "version": 1
+#             }
+#         }
+#     }
+# }

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -375,6 +375,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/IssueTestsResponse'
           description: ''
+  /api/issue/extras/:
+    post:
+      operationId: issue_extras_create
+      tags:
+      - issue
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueExtraDetailsRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/IssueExtraDetailsRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/IssueExtraDetailsRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssueExtraDetailsResponse'
+          description: ''
   /api/log-downloader/:
     get:
       operationId: log_downloader_retrieve
@@ -2126,6 +2154,30 @@ components:
       - misc
       title: IssueDetailsResponse
       type: object
+    IssueExtraDetailsRequest:
+      properties:
+        issues:
+          items:
+            maxItems: 2
+            minItems: 2
+            prefixItems:
+            - type: string
+            - type: integer
+            type: array
+          title: Issues
+          type: array
+      required:
+      - issues
+      title: IssueExtraDetailsRequest
+      type: object
+    IssueExtraDetailsResponse:
+      properties:
+        issues:
+          $ref: '#/components/schemas/ProcessedExtraDetailedIssues'
+      required:
+      - issues
+      title: IssueExtraDetailsResponse
+      type: object
     IssueTestItem:
       properties:
         id:
@@ -2163,6 +2215,43 @@ components:
         $ref: '#/components/schemas/IssueTestItem'
       title: IssueTestsResponse
       type: array
+    IssueWithExtraInfo:
+      properties:
+        id:
+          title: Id
+          type: string
+        version:
+          title: Version
+          type: integer
+        first_seen:
+          anyOf:
+          - format: date-time
+            type: string
+          - type: 'null'
+          default: null
+          title: First Seen
+        trees:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TreeSetItem'
+            type: array
+          - type: 'null'
+          default: []
+          title: Trees
+        tags:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/PossibleIssueTags'
+            type: array
+            uniqueItems: true
+          - type: 'null'
+          default: []
+          title: Tags
+      required:
+      - id
+      - version
+      title: IssueWithExtraInfo
+      type: object
     Issue__Comment:
       anyOf:
       - type: string
@@ -2263,6 +2352,18 @@ components:
       type: object
     Origin:
       type: string
+    PossibleIssueTags:
+      enum:
+      - mainline
+      - stable
+      - linux-next
+      type: string
+    ProcessedExtraDetailedIssues:
+      additionalProperties:
+        additionalProperties:
+          $ref: '#/components/schemas/IssueWithExtraInfo'
+        type: object
+      type: object
     Summary:
       properties:
         builds:
@@ -2786,6 +2887,23 @@ components:
         $ref: '#/components/schemas/Checkout'
       title: TreeListingResponse
       type: array
+    TreeSetItem:
+      properties:
+        tree_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tree Name
+        git_repository_branch:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Git Repository Branch
+      required:
+      - tree_name
+      - git_repository_branch
+      title: TreeSetItem
+      type: object
   securitySchemes:
     basicAuth:
       type: http


### PR DESCRIPTION
## Changes
- Adds a new endpoint to get the detailed information of a list of issues (id and version)
- Adds query to get the timestamp of the first incident of an issue
- Adds query to get the trees where that issue_id and issue_version have had incidents
- The list of trees is also used to add specific tags to the issues

## How to test
Acquire a list of issues that you want to get more details from, then go to `http://localhost:5173/issues/extras/` and in the swagger UI you can place a body for the request, such as:
```
{
    "issues": [
        ["maestro:e602fca280d85d8e603f7c0aff68363bb0cd7993", 1],
        ["maestro:da694c56147298d223ee432ad8d6a8ee311b773a", 1]
    ]
}
```

You can verify if the trees are coming correctly for an issue by running the following query (change the issue id and version at the end):
```
SELECT DISTINCT
	ON (
		C.TREE_NAME,
		C.GIT_REPOSITORY_URL,
		C.GIT_REPOSITORY_BRANCH
	) C.ID,
	C.TREE_NAME,
	C.GIT_REPOSITORY_URL,
	C.GIT_REPOSITORY_BRANCH,
	IC.ISSUE_ID,
	IC.ISSUE_VERSION
FROM
	INCIDENTS IC
	LEFT JOIN TESTS T ON IC.TEST_ID = T.ID
	JOIN BUILDS B ON (
		IC.BUILD_ID = B.ID
		OR T.BUILD_ID = B.ID
	)
	JOIN CHECKOUTS C ON B.CHECKOUT_ID = C.ID
WHERE
	IC.ISSUE_ID = 'redhat:issue_3332'
	AND IC.ISSUE_VERSION = 1734005602
```

The return of the new endpoint is the primary key for the issues (id and version) and the extra information only.

Closes #869