### PR TITLE
fix:extra queries

### DIFF
--- a/backend/kernelCI_app/views/treeView.py
+++ b/backend/kernelCI_app/views/treeView.py
@@ -121,9 +121,8 @@ class TreeView(APIView):
                     AND tests.status = 'DONE' THEN 1 END) AS done_tests,
                 COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
                     AND tests.status = 'SKIP' THEN 1 END) AS skip_tests,
-                SUM(CASE WHEN tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END)
-                    AS null_tests,
-
+                SUM(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
+                    AND tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END) AS null_tests,
                 COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
                     AND tests.status = 'FAIL' THEN 1 END) AS fail_boots,
                 COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
@@ -136,7 +135,7 @@ class TreeView(APIView):
                     AND tests.status = 'DONE' THEN 1 END) AS done_boots,
                 COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
                     AND tests.status = 'SKIP' THEN 1 END) AS skip_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
+                SUM(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
                     AND tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END) AS null_boots,
                 COALESCE(
                     ARRAY_AGG(DISTINCT tree_name) FILTER (

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -112,6 +112,7 @@ const getLinkProps = (
           ERROR: row.original.testStatus?.error,
           MISS: row.original.testStatus?.miss,
           SKIP: row.original.testStatus?.skip,
+          NULL: row.original.testStatus?.null,
         }),
         boots: statusCountToRequiredStatusCount({
           DONE: row.original.bootStatus?.done,
@@ -120,6 +121,7 @@ const getLinkProps = (
           ERROR: row.original.bootStatus?.error,
           MISS: row.original.bootStatus?.miss,
           SKIP: row.original.bootStatus?.skip,
+          NULL: row.original.bootStatus?.null,
         }),
       },
     }),
@@ -246,6 +248,7 @@ const getColumns = (origin: TOrigins): ColumnDef<TreeTableBody>[] => {
             miss={row.original.bootStatus.miss}
             done={row.original.bootStatus.done}
             error={row.original.bootStatus.error}
+            nullStatus={row.original.bootStatus.null}
             passLinkProps={getLinkProps(row, origin, tabTarget, {
               bootStatus: { PASS: true },
             })}
@@ -290,6 +293,7 @@ const getColumns = (origin: TOrigins): ColumnDef<TreeTableBody>[] => {
             miss={row.original.testStatus.miss}
             done={row.original.testStatus.done}
             error={row.original.testStatus.error}
+            nullStatus={row.original.testStatus.null}
             passLinkProps={getLinkProps(row, origin, tabTarget, {
               testStatus: { PASS: true },
             })}


### PR DESCRIPTION
# Description

Tree listing was receiving wrong null counts for its trees, this fix
it and by consequence fix the cache invalidation

## How to test
Keep alternating between tree listing and tree details and see that there are no extra queries

Closes #886 