### PR TITLE
Feat: show issueExtraDetails data on treeDetails

### DIFF
--- a/dashboard/src/api/buildDetails.ts
+++ b/dashboard/src/api/buildDetails.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import type { TBuildDetails } from '@/types/tree/BuildDetails';
 
-import type { TIssue } from '@/types/general';
+import type { TIssue } from '@/types/issues';
 
 import { RequestData } from './commonRequest';
 

--- a/dashboard/src/api/issueDetails.ts
+++ b/dashboard/src/api/issueDetails.ts
@@ -1,9 +1,13 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
-import type { TErrorWithStatus, TIssueDetails } from '@/types/issueDetails';
+import type { TIssueDetails } from '@/types/issueDetails';
 
-import type { BuildsTableBuild, TestHistory } from '@/types/general';
+import type {
+  BuildsTableBuild,
+  TErrorWithStatus,
+  TestHistory,
+} from '@/types/general';
 
 import { RequestData } from './commonRequest';
 

--- a/dashboard/src/api/issueExtras.ts
+++ b/dashboard/src/api/issueExtras.ts
@@ -1,0 +1,72 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type {
+  IssueExtraDetailsResponse,
+  IssueKeyList,
+} from '@/types/issueExtras';
+
+import type { TIssue } from '@/types/issues';
+
+import { RequestData } from './commonRequest';
+
+const fetchIssueExtraDetailsData = async (
+  issueKeyList?: IssueKeyList,
+): Promise<IssueExtraDetailsResponse> => {
+  const body = {
+    issues: issueKeyList,
+  };
+
+  const data = await RequestData.post<IssueExtraDetailsResponse>(
+    `/api/issue/extras/`,
+    body,
+  );
+
+  return data;
+};
+
+export interface ITabsIssues {
+  buildIssues?: TIssue[];
+  bootIssues?: TIssue[];
+  testIssues?: TIssue[];
+}
+
+const makeIssueKeyList = ({
+  buildIssues,
+  bootIssues,
+  testIssues,
+}: ITabsIssues): IssueKeyList => {
+  const result: IssueKeyList = [];
+
+  buildIssues?.forEach(issue => {
+    result.push([issue.id, issue.version]);
+  });
+  bootIssues?.forEach(issue => {
+    result.push([issue.id, issue.version]);
+  });
+  testIssues?.forEach(issue => {
+    result.push([issue.id, issue.version]);
+  });
+
+  return result;
+};
+
+export const useIssueExtraDetails = ({
+  buildIssues,
+  bootIssues,
+  testIssues,
+  enabled = true,
+}: ITabsIssues & {
+  enabled: boolean;
+}): UseQueryResult<IssueExtraDetailsResponse> => {
+  const issueKeyList = makeIssueKeyList({
+    buildIssues,
+    bootIssues,
+    testIssues,
+  });
+
+  return useQuery({
+    queryKey: ['issueExtraData', issueKeyList],
+    queryFn: () => fetchIssueExtraDetailsData(issueKeyList),
+    enabled,
+  });
+};

--- a/dashboard/src/api/testDetails.ts
+++ b/dashboard/src/api/testDetails.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import type { TTestDetails } from '@/types/tree/TestDetails';
 
-import type { TIssue } from '@/types/general';
+import type { TIssue } from '@/types/issues';
 
 import { RequestData } from './commonRequest';
 

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -15,7 +15,6 @@ import type {
   RedirectFrom,
   TFilter,
   TFilterObjectsKeys,
-  TIssue,
 } from '@/types/general';
 
 import FilterLink from '@/components/Tabs/FilterLink';
@@ -29,6 +28,7 @@ import { IssueTooltip } from '@/components/Issue/IssueTooltip';
 
 import { LinkIcon } from '@/components/Icons/Link';
 import { getIssueFilterLabel } from '@/utils/utils';
+import type { TIssue } from '@/types/issues';
 
 interface IIssuesList {
   issues: TIssue[];

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -147,7 +147,13 @@ const IssuesList = ({
     </DumbListingContent>
   );
 
-  return <BaseCard title={titleElement} content={contentElement} />;
+  return (
+    <BaseCard
+      title={titleElement}
+      content={contentElement}
+      className="col-span-2"
+    />
+  );
 };
 
 const MemoizedIssuesList = memo(IssuesList);

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -9,13 +9,15 @@ import { Link } from '@tanstack/react-router';
 import { RiProhibited2Line } from 'react-icons/ri';
 
 import ListingItem from '@/components/ListingItem/ListingItem';
-import { zOrigin, type TIssue } from '@/types/general';
+import { zOrigin } from '@/types/general';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import type { TErrorVariant } from '@/components/DetailsPages/SectionError';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import { zTableFilterInfoValidator } from '@/types/tree/TreeDetails';
+
+import type { TIssue } from '@/types/issues';
 
 import { IssueTooltip } from './IssueTooltip';
 

--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -118,7 +118,7 @@ export const IssueDetails = ({
     }
     return [
       {
-        title: data.id,
+        title: data.comment ?? data.id,
         eyebrow: formatMessage({ id: 'issueDetails.issueDetails' }),
         subsections: [
           {
@@ -153,11 +153,11 @@ export const IssueDetails = ({
                 linkText: getCulpritValue(data),
               },
               {
-                title: 'issueDetails.comment',
-                linkText: shouldTruncate(valueOrEmpty(data.comment)) ? (
-                  <TruncatedValueTooltip value={data.comment} />
+                title: 'issueDetails.id',
+                linkText: shouldTruncate(valueOrEmpty(data.id)) ? (
+                  <TruncatedValueTooltip value={data.id} />
                 ) : (
-                  valueOrEmpty(data.comment)
+                  data.id
                 ),
               },
             ],

--- a/dashboard/src/components/ListingItem/ListingItem.tsx
+++ b/dashboard/src/components/ListingItem/ListingItem.tsx
@@ -4,8 +4,9 @@ import { useCallback, Fragment, memo } from 'react';
 
 import type { PropsWithChildren } from 'react';
 
-import ColoredCircle from '../ColoredCircle/ColoredCircle';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip';
+import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 
 export interface IListingItem {
   leftIcon?: React.ReactNode;
@@ -98,7 +99,7 @@ const ListingItem = ({
     return (
       <Tooltip>
         <div className="flex w-full">
-          <TooltipTrigger className="max-w-[200px] overflow-hidden sm:max-w-[300px] md:max-w-[500px] lg:max-w-[700px] xl:max-w-[1000px]">
+          <TooltipTrigger className="max-w-[200px] overflow-hidden md:max-w-[100px] lg:max-w-[325px] xl:max-w-[475px] 2xl:max-w-[700px]">
             {children}
           </TooltipTrigger>
 

--- a/dashboard/src/components/Sheet/LogOrJsonSheetContent.tsx
+++ b/dashboard/src/components/Sheet/LogOrJsonSheetContent.tsx
@@ -12,7 +12,7 @@ import { MemoizedMoreDetailsButton } from '@/components/Button/MoreDetailsButton
 import { LogViewerCard } from '@/components/Log/LogViewerCard';
 import { LogExcerpt } from '@/components/Log/LogExcerpt';
 import IssueSection from '@/components/Issue/IssueSection';
-import type { TIssue } from '@/types/general';
+import type { TIssue } from '@/types/issues';
 
 export type SheetType = 'log' | 'json';
 

--- a/dashboard/src/components/TooltipDateTime/TooltipDateTime.tsx
+++ b/dashboard/src/components/TooltipDateTime/TooltipDateTime.tsx
@@ -1,16 +1,20 @@
-import { format, isValid } from 'date-fns';
+import { format, formatDistanceToNow, isValid } from 'date-fns';
+
+import { FormattedMessage } from 'react-intl';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 import { getDateOffset } from '@/utils/utils';
 
 type TooltipDateTimeProps = {
-  dateTime: string;
+  dateTime: string | Date;
   dateFormat?: string;
   timeFormat?: string;
   lineBreak?: boolean;
   showLabelTime?: boolean;
   showLabelTZ?: boolean;
   showTooltip?: boolean;
+  showRelative?: boolean;
+  message?: string;
 };
 
 const TooltipDateTime = ({
@@ -21,8 +25,10 @@ const TooltipDateTime = ({
   showLabelTime,
   showLabelTZ = false,
   showTooltip = true,
+  showRelative = false,
+  message,
 }: TooltipDateTimeProps): JSX.Element => {
-  const dateObj = new Date(dateTime);
+  const dateObj = typeof dateTime === 'string' ? new Date(dateTime) : dateTime;
   if (!isValid(dateObj)) {
     return <div>-</div>;
   }
@@ -38,9 +44,19 @@ const TooltipDateTime = ({
   return (
     <Tooltip>
       <TooltipTrigger>
-        <div>
-          {date} {showLabelTime ? time : ''} {showLabelTZ ? tz : ''}
-        </div>
+        {showRelative ? (
+          <>
+            <span className="pl-2">{message}</span>
+            <FormattedMessage
+              id="global.timeAgo"
+              values={{ time: formatDistanceToNow(dateObj) }}
+            />
+          </>
+        ) : (
+          <span>
+            {date} {showLabelTime ? time : ''} {showLabelTZ ? tz : ''}
+          </span>
+        )}
       </TooltipTrigger>
       {showTooltip && (
         <TooltipContent>

--- a/dashboard/src/components/ui/badge.tsx
+++ b/dashboard/src/components/ui/badge.tsx
@@ -15,6 +15,7 @@ const badgeVariants = cva(
         destructive:
           'border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80',
         outline: 'text-slate-950 dark:text-slate-50',
+        blueTag: 'text-dark-blue outline-medium-light-blue border-none bg-light-blue font-medium capitalize outline-1',
       },
     },
     defaultVariants: {

--- a/dashboard/src/hooks/useTreeDetailsLazyLoadQuery.ts
+++ b/dashboard/src/hooks/useTreeDetailsLazyLoadQuery.ts
@@ -7,6 +7,8 @@ import type {
   TreeDetailsSummary,
 } from '@/types/tree/TreeDetails';
 import type { QuerySelectorStatus } from '@/components/QuerySwitcher/QuerySwitcher';
+import { useIssueExtraDetails } from '@/api/issueExtras';
+import type { IssueExtraDetailsResponse } from '@/types/issueExtras';
 
 export type TreeDetailsLazyLoaded = {
   summary: {
@@ -20,6 +22,12 @@ export type TreeDetailsLazyLoaded = {
     data?: TreeDetailsFullData;
     isLoading: boolean;
     status: QuerySelectorStatus;
+  };
+  issuesExtras: {
+    data?: IssueExtraDetailsResponse;
+    isLoading: boolean;
+    status: QuerySelectorStatus;
+    error: UseQueryResult['error'];
   };
   common: {
     isAllReady: boolean;
@@ -41,6 +49,13 @@ export const useTreeDetailsLazyLoadQuery = (
     enabled: !!summaryResult.data,
   });
 
+  const issuesExtrasResult = useIssueExtraDetails({
+    buildIssues: summaryResult.data?.summary.builds.issues,
+    bootIssues: summaryResult.data?.summary.boots.issues,
+    testIssues: summaryResult.data?.summary.tests.issues,
+    enabled: !!summaryResult.data,
+  });
+
   return {
     summary: {
       data: summaryResult.data,
@@ -54,9 +69,18 @@ export const useTreeDetailsLazyLoadQuery = (
       isLoading: fullResult.isLoading,
       status: fullResult.status,
     },
+    issuesExtras: {
+      data: issuesExtrasResult.data,
+      isLoading: issuesExtrasResult.isLoading,
+      status: issuesExtrasResult.status,
+      error: issuesExtrasResult.error,
+    },
     common: {
-      isAllReady: !!summaryResult && !!fullResult,
-      isAnyLoading: summaryResult.isLoading || fullResult.isLoading,
+      isAllReady: !!summaryResult && !!fullResult && !!issuesExtrasResult,
+      isAnyLoading:
+        summaryResult.isLoading ||
+        fullResult.isLoading ||
+        issuesExtrasResult.isLoading,
     },
   };
 };

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -26,6 +26,9 @@
   --color-green: #53d07c;
   --color-red: #e15739;
   --color-blue: #11b3e6;
+  --color-dark-blue: #1d4ed8;
+  --color-light-blue: #e7f7fc;
+  --color-medium-light-blue: #bfdbfe;
 
   @keyframes accordion-down {
     from {

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -206,6 +206,7 @@ export const messages = {
     'issueDetails.culpritTitle': 'Culprit',
     'issueDetails.culpritTool': 'Tool',
     'issueDetails.failedToFetch': 'Failed to fetch issue details',
+    'issueDetails.id': 'Issue Id',
     'issueDetails.issueDetails': 'Issue Details',
     'issueDetails.logspecData': 'Logspec Data',
     'issueDetails.notFound': 'Issue not found',

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -166,6 +166,7 @@ export const messages = {
     'global.successCount': 'Success: {count}',
     'global.summary': 'Summary',
     'global.tests': 'Tests',
+    'global.timeAgo': '{time} ago',
     'global.tree': 'Tree',
     'global.trees': 'Trees',
     'global.underDevelopment': 'Under Development',
@@ -193,6 +194,8 @@ export const messages = {
     'hardwareDetails.timeFrame':
       'Results from {startDate} and {startTime} to {endDate} {endTime}',
     'hardwareDetails.treeBranch': 'Tree / Branch',
+    'issue.alsoPresentTooltip': 'Issue also present in {tree}',
+    'issue.firstSeen': 'First seen',
     'issue.noIssueFound': 'No issue found.',
     'issue.tooltip':
       'Issues groups several builds or tests by matching result status and logs.{br}They may also be linked to an external issue tracker or mailing list discussion.',

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -180,6 +180,8 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
           issueFilterSection="bootIssue"
           detailsId={treeId}
           pageFrom={RedirectFrom.Tree}
+          issueExtraDetails={treeDetailsLazyLoaded.issuesExtras.data?.issues}
+          extraDetailsLoading={treeDetailsLazyLoaded.issuesExtras.isLoading}
         />
       </DesktopGrid>
       <MobileGrid>
@@ -216,6 +218,8 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
             issueFilterSection="bootIssue"
             detailsId={treeId}
             pageFrom={RedirectFrom.Tree}
+            issueExtraDetails={treeDetailsLazyLoaded.issuesExtras.data?.issues}
+            extraDetailsLoading={treeDetailsLazyLoaded.issuesExtras.isLoading}
           />
         </InnerMobileGrid>
       </MobileGrid>

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -163,15 +163,6 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
             archCompilerErrors={data.summary.boots.architectures}
             diffFilter={diffFilter}
           />
-          <MemoizedIssuesList
-            title={<FormattedMessage id="global.issues" />}
-            issues={data.summary.boots.issues}
-            failedWithUnknownIssues={data.summary.boots.unknown_issues}
-            diffFilter={diffFilter}
-            issueFilterSection="bootIssue"
-            detailsId={treeId}
-            pageFrom={RedirectFrom.Tree}
-          />
         </div>
         <div>
           <TreeCommitNavigationGraph />
@@ -181,6 +172,15 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
             diffFilter={diffFilter}
           />
         </div>
+        <MemoizedIssuesList
+          title={<FormattedMessage id="global.issues" />}
+          issues={data.summary.boots.issues}
+          failedWithUnknownIssues={data.summary.boots.unknown_issues}
+          diffFilter={diffFilter}
+          issueFilterSection="bootIssue"
+          detailsId={treeId}
+          pageFrom={RedirectFrom.Tree}
+        />
       </DesktopGrid>
       <MobileGrid>
         <MemoizedStatusCard
@@ -200,15 +200,6 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
               archCompilerErrors={data.summary.boots.architectures}
               diffFilter={diffFilter}
             />
-            <MemoizedIssuesList
-              title={<FormattedMessage id="global.issues" />}
-              issues={data.summary.boots.issues}
-              failedWithUnknownIssues={data.summary.boots.unknown_issues}
-              diffFilter={diffFilter}
-              issueFilterSection="bootIssue"
-              detailsId={treeId}
-              pageFrom={RedirectFrom.Tree}
-            />
           </div>
           <div>
             <MemoizedHardwareTested
@@ -217,6 +208,15 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
               diffFilter={diffFilter}
             />
           </div>
+          <MemoizedIssuesList
+            title={<FormattedMessage id="global.issues" />}
+            issues={data.summary.boots.issues}
+            failedWithUnknownIssues={data.summary.boots.unknown_issues}
+            diffFilter={diffFilter}
+            issueFilterSection="bootIssue"
+            detailsId={treeId}
+            pageFrom={RedirectFrom.Tree}
+          />
         </InnerMobileGrid>
       </MobileGrid>
       <QuerySwitcher data={bootsData} status={fullStatus}>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -38,10 +38,11 @@ import {
   RedirectFrom,
   type BuildStatus,
   type TFilterObjectsKeys,
-  type TIssue,
 } from '@/types/general';
 
 import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
+
+import type { TIssue } from '@/types/issues';
 
 import { TreeDetailsBuildsTable } from './TreeDetailsBuildsTable';
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -131,17 +131,6 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
             toggleFilterBySection={toggleFilterBySection}
             diffFilter={diffFilter}
           />
-          <MemoizedIssuesList
-            title={<FormattedMessage id="global.issues" />}
-            issues={treeDetailsData.buildsIssues || []}
-            failedWithUnknownIssues={
-              treeDetailsData.failedBuildsWithUnknownIssues
-            }
-            diffFilter={diffFilter}
-            issueFilterSection="buildIssue"
-            detailsId={treeId}
-            pageFrom={RedirectFrom.Tree}
-          />
         </div>
         <div>
           <TreeCommitNavigationGraph />
@@ -151,6 +140,17 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
             diffFilter={diffFilter}
           />
         </div>
+        <MemoizedIssuesList
+          title={<FormattedMessage id="global.issues" />}
+          issues={treeDetailsData.buildsIssues}
+          failedWithUnknownIssues={
+            treeDetailsData.failedBuildsWithUnknownIssues
+          }
+          diffFilter={diffFilter}
+          issueFilterSection="buildIssue"
+          detailsId={treeId}
+          pageFrom={RedirectFrom.Tree}
+        />
       </DesktopGrid>
       <MobileGrid>
         <TreeCommitNavigationGraph />

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -150,6 +150,8 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
           issueFilterSection="buildIssue"
           detailsId={treeId}
           pageFrom={RedirectFrom.Tree}
+          issueExtraDetails={treeDetailsLazyLoaded.issuesExtras.data?.issues}
+          extraDetailsLoading={treeDetailsLazyLoaded.issuesExtras.isLoading}
         />
       </DesktopGrid>
       <MobileGrid>
@@ -180,6 +182,8 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
           issueFilterSection="buildIssue"
           detailsId={treeId}
           pageFrom={RedirectFrom.Tree}
+          issueExtraDetails={treeDetailsLazyLoaded.issuesExtras.data?.issues}
+          extraDetailsLoading={treeDetailsLazyLoaded.issuesExtras.isLoading}
         />
       </MobileGrid>
 

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -16,13 +16,14 @@ import StatusChartMemoized, {
 } from '@/components/StatusChart/StatusCharts';
 import { groupStatus } from '@/utils/status';
 import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
-import type { ArchCompilerStatus, TIssue } from '@/types/general';
+import type { ArchCompilerStatus } from '@/types/general';
 import { NoIssueFound } from '@/components/Issue/IssueSection';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
 import { Badge } from '@/components/ui/badge';
 import FilterLink from '@/components/Tabs/FilterLink';
 import { DumbSummary, MemoizedSummaryItem } from '@/components/Tabs/Summary';
+import type { TIssue } from '@/types/issues';
 
 interface IConfigList extends Pick<TTreeTestsData, 'configStatusCounts'> {
   title: IBaseCard['title'];

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -161,15 +161,6 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
             archCompilerErrors={summaryData.architectures}
             diffFilter={diffFilter}
           />
-          <MemoizedIssuesList
-            title={<FormattedMessage id="global.issues" />}
-            issues={summaryData.issues}
-            failedWithUnknownIssues={summaryData.unknown_issues}
-            diffFilter={diffFilter}
-            issueFilterSection="testIssue"
-            detailsId={treeId}
-            pageFrom={RedirectFrom.Tree}
-          />
         </div>
         <div>
           <TreeCommitNavigationGraph />
@@ -179,6 +170,15 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
             diffFilter={diffFilter}
           />
         </div>
+        <MemoizedIssuesList
+          title={<FormattedMessage id="global.issues" />}
+          issues={summaryData.issues}
+          failedWithUnknownIssues={summaryData.unknown_issues}
+          diffFilter={diffFilter}
+          issueFilterSection="testIssue"
+          detailsId={treeId}
+          pageFrom={RedirectFrom.Tree}
+        />
       </DesktopGrid>
       <MobileGrid>
         <MemoizedStatusCard
@@ -198,15 +198,6 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
               archCompilerErrors={summaryData.architectures}
               diffFilter={diffFilter}
             />
-            <MemoizedIssuesList
-              title={<FormattedMessage id="global.issues" />}
-              issues={summaryData.issues}
-              failedWithUnknownIssues={summaryData.unknown_issues}
-              diffFilter={diffFilter}
-              issueFilterSection="testIssue"
-              detailsId={treeId}
-              pageFrom={RedirectFrom.Tree}
-            />
           </div>
           <div>
             <MemoizedHardwareTested
@@ -215,6 +206,15 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
               diffFilter={diffFilter}
             />
           </div>
+          <MemoizedIssuesList
+            title={<FormattedMessage id="global.issues" />}
+            issues={summaryData.issues}
+            failedWithUnknownIssues={summaryData.unknown_issues}
+            diffFilter={diffFilter}
+            issueFilterSection="testIssue"
+            detailsId={treeId}
+            pageFrom={RedirectFrom.Tree}
+          />
         </InnerMobileGrid>
       </MobileGrid>
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -178,6 +178,8 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
           issueFilterSection="testIssue"
           detailsId={treeId}
           pageFrom={RedirectFrom.Tree}
+          issueExtraDetails={treeDetailsLazyLoaded.issuesExtras.data?.issues}
+          extraDetailsLoading={treeDetailsLazyLoaded.issuesExtras.isLoading}
         />
       </DesktopGrid>
       <MobileGrid>
@@ -214,6 +216,8 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
             issueFilterSection="testIssue"
             detailsId={treeId}
             pageFrom={RedirectFrom.Tree}
+            issueExtraDetails={treeDetailsLazyLoaded.issuesExtras.data?.issues}
+            extraDetailsLoading={treeDetailsLazyLoaded.issuesExtras.isLoading}
           />
         </InnerMobileGrid>
       </MobileGrid>

--- a/dashboard/src/pages/TreeDetails/Tabs/WrapperTableWithLogSheet.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/WrapperTableWithLogSheet.tsx
@@ -8,8 +8,8 @@ import { Sheet } from '@/components/Sheet';
 
 import { LogOrJsonSheetContent } from '@/components/Sheet/LogOrJsonSheetContent';
 import type { TNavigationLogActions } from '@/components/Sheet/WrapperSheetContent';
-import type { TIssue } from '@/types/general';
 import { cn } from '@/lib/utils';
+import type { TIssue } from '@/types/issues';
 
 interface TableWithLogSheetProps {
   currentLog?: number;

--- a/dashboard/src/types/commonDetails.ts
+++ b/dashboard/src/types/commonDetails.ts
@@ -4,8 +4,8 @@ import type {
   BuildStatus,
   PropertyStatusCounts,
   StatusCounts,
-  TIssue,
 } from './general';
+import type { TIssue } from './issues';
 
 type TestSummary = {
   status: StatusCounts;

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -37,7 +37,12 @@ interface IEnvironmentMisc {
   platform?: string;
 }
 
-export type TestHistory = {
+export type TreeBranchItem = {
+  tree_name?: string;
+  git_repository_branch?: string;
+};
+
+export type TestHistory = TreeBranchItem & {
   start_time: string;
   status: Status;
   path: string;
@@ -45,10 +50,11 @@ export type TestHistory = {
   duration?: number;
   environment_compatible?: string[];
   environment_misc?: IEnvironmentMisc;
-  tree_name?: string;
-  git_repository_branch?: string;
 };
 
+/**
+ * @deprecated Use a more generic approach to the misc field.
+ */
 interface ITreeDetailsMisc {
   kernel_type?: string;
   dtb?: string;

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -5,7 +5,11 @@ import { DEFAULT_LISTING_ITEMS } from '@/utils/constants/general';
 import type { Status } from './database';
 import type { TTreeDetailsFilter } from './tree/TreeDetails';
 import type { THardwareDetailsFilter } from './hardware/hardwareDetails';
-type IncidentsInfo = { incidentsCount: number };
+
+export type TErrorWithStatus = Error & {
+  status: number;
+};
+
 export type TPathTests = {
   path_group: string;
   fail_tests: number;
@@ -27,14 +31,6 @@ export type TIndividualTest = {
   duration: string;
   hardware?: string[];
   treeBranch?: string;
-};
-
-export type TIssue = {
-  id: string;
-  version: number;
-  comment?: string;
-  report_url?: string;
-  incidents_info: IncidentsInfo;
 };
 
 interface IEnvironmentMisc {

--- a/dashboard/src/types/issueDetails.ts
+++ b/dashboard/src/types/issueDetails.ts
@@ -1,14 +1,7 @@
-// TODO move this const
-export const NOT_FOUND_STATUS = 404;
+import type { IssueKeys } from './issues';
 
-export type TErrorWithStatus = Error & {
-  status: number;
-};
-
-export type TIssueDetails = {
+export type TIssueDetails = IssueKeys & {
   timestamp: string;
-  id: string;
-  version: number;
   origin: string;
   report_url?: string;
   report_subject?: string;

--- a/dashboard/src/types/issueExtras.ts
+++ b/dashboard/src/types/issueExtras.ts
@@ -1,0 +1,21 @@
+import type { TreeBranchItem } from './general';
+import type { IssueKeys } from './issues';
+
+type PossibleIssueTags = 'mainline' | 'stable' | 'linux-next';
+
+type TIssueExtraDetails = IssueKeys & {
+  first_seen?: Date;
+  trees?: TreeBranchItem[];
+  tags?: PossibleIssueTags[];
+};
+
+export type IssueKeyList = [string, number][];
+
+export type IssueExtraDetailsDict = Record<
+  string,
+  Record<number, TIssueExtraDetails>
+>;
+
+export type IssueExtraDetailsResponse = {
+  issues: IssueExtraDetailsDict;
+};

--- a/dashboard/src/types/issues.ts
+++ b/dashboard/src/types/issues.ts
@@ -1,0 +1,12 @@
+type IncidentsInfo = { incidentsCount: number };
+
+export type IssueKeys = {
+  id: string;
+  version: number;
+};
+
+export type TIssue = IssueKeys & {
+  comment?: string;
+  report_url?: string;
+  incidents_info: IncidentsInfo;
+};


### PR DESCRIPTION
- Adds functions to fetch extra issue details
- Use these functions in treeDetailsLazyLoaded (requires summaryData for the request)
- Changes Issue List to occupy 2 columns and changes how it's truncated
- Adds text for first_seen and badges for the tags

## How to test
Go to any treeDetails that have issues; all of them should have at least the first_seen information, the tags are optional and depend on each issue in particular.

Examples are [sashal-next/linus-next](http://localhost:5173/tree/133cb6f592c89e07f15c93d41f1c410e0bfb93d1?p=bt&ti%7Cc=v6.14-rc2-76-g133cb6f592c8&ti%7Cch=133cb6f592c89e07f15c93d41f1c410e0bfb93d1&ti%7Cgb=linus-next&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fsashal%2Flinus-next.git&ti%7Ct=sashal-next), [stable/linux-6.6.y](http://localhost:5173/tree/c719455843a8bc3e969ba58ec92335ed7510e9fc?p=t&ti%7Cc=v6.6.77&ti%7Cch=c719455843a8bc3e969ba58ec92335ed7510e9fc&ti%7Cgb=linux-6.6.y&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fstable%2Flinux.git&ti%7Ct=stable) and [android/android12-5.10-lts](http://localhost:5173/tree/1caf81977768719085dd3135691bb4a134e79f9f?ti%7Cc=android12-5.10.233_r00-178-g1caf819777687&ti%7Cch=1caf81977768719085dd3135691bb4a134e79f9f&ti%7Cgb=android12-5.10-lts&ti%7Cgu=https%3A%2F%2Fandroid.googlesource.com%2Fkernel%2Fcommon&ti%7Ct=android).

You can check every tree that the issues are present by looking in the network tab of dev tools and see the response for the /issue/extras/ request.

Reference (from stabe/linux-6.6.y):
![image](https://github.com/user-attachments/assets/16545de2-e75e-44aa-99fc-7b4eee5461c1)

Closes #870 