### PR TITLE
Refactor: Change issues from unknown to uncategorized

### DIFF
--- a/backend/kernelCI_app/constants/general.py
+++ b/backend/kernelCI_app/constants/general.py
@@ -1,3 +1,4 @@
 DEFAULT_ORIGIN = 'maestro'
 
 UNKNOWN_STRING = 'Unknown'
+UNCATEGORIZED_STRING = "Uncategorized"

--- a/backend/kernelCI_app/helpers/commonDetails.py
+++ b/backend/kernelCI_app/helpers/commonDetails.py
@@ -1,5 +1,6 @@
-from kernelCI_app.constants.general import UNKNOWN_STRING
-from typing import Set
+from typing import Dict, Literal, Set
+
+type PossibleTabs = Literal["build", "boot", "test"]
 
 
 def add_unfiltered_issue(
@@ -8,9 +9,11 @@ def add_unfiltered_issue(
     issue_version: int,
     should_increment: bool,
     issue_set: Set,
-    is_invalid: bool
+    is_invalid: bool,
+    unknown_issue_flag_dict: Dict[PossibleTabs, bool],
+    unknown_issue_flag_tab: PossibleTabs,
 ) -> None:
     if issue_id is not None and issue_version is not None and should_increment:
         issue_set.add((issue_id, issue_version))
     elif is_invalid is True:
-        issue_set.add((UNKNOWN_STRING, None))
+        unknown_issue_flag_dict[unknown_issue_flag_tab] = True

--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -4,12 +4,13 @@ import json
 from typing import Dict, List, Literal, Optional, Set
 
 from kernelCI_app.cache import getQueryCache, setQueryCache
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING
 from kernelCI_app.constants.hardwareDetails import (
     SELECTED_HEAD_TREE_VALUE,
 )
 from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.helpers.build import build_status_map
-from kernelCI_app.helpers.commonDetails import add_unfiltered_issue
+from kernelCI_app.helpers.commonDetails import PossibleTabs, add_unfiltered_issue
 from kernelCI_app.helpers.filters import (
     FilterParams,
     is_test_failure,
@@ -892,15 +893,19 @@ def process_filters(*, instance, record: Dict) -> None:
             should_increment=is_build_issue,
             issue_set=instance.unfiltered_build_issues,
             is_invalid=is_invalid,
+            unknown_issue_flag_dict=instance.unfiltered_uncategorized_issue_flags,
+            unknown_issue_flag_tab="build",
         )
 
     if record["id"] is not None:
         if is_boot(record["path"]):
             issue_set = instance.unfiltered_boot_issues
             platform_set = instance.unfiltered_boot_platforms
+            flag_tab: PossibleTabs = "boot"
         else:
             issue_set = instance.unfiltered_test_issues
             platform_set = instance.unfiltered_test_platforms
+            flag_tab: PossibleTabs = "test"
 
         test_issue_id = record["incidents__issue__id"]
         test_issue_version = record["incidents__issue__version"]
@@ -917,6 +922,8 @@ def process_filters(*, instance, record: Dict) -> None:
             should_increment=is_test_issue,
             issue_set=issue_set,
             is_invalid=is_invalid,
+            unknown_issue_flag_dict=instance.unfiltered_uncategorized_issue_flags,
+            unknown_issue_flag_tab=flag_tab,
         )
 
         environment_misc = handle_environment_misc(record["environment_misc"])
@@ -954,9 +961,9 @@ def assign_default_record_values(record: Dict) -> None:
         record["build__incidents__issue__id"] is None
         and record["build__valid"] is not True
     ):
-        record["build__incidents__issue__id"] = UNKNOWN_STRING
+        record["build__incidents__issue__id"] = UNCATEGORIZED_STRING
     if record["incidents__issue__id"] is None and record["status"] == FAIL_STATUS:
-        record["incidents__issue__id"] = UNKNOWN_STRING
+        record["incidents__issue__id"] = UNCATEGORIZED_STRING
 
 
 def format_issue_summary_for_response(

--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import Any, Optional, TypedDict
-from kernelCI_app.helpers.commonDetails import add_unfiltered_issue
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING
+from kernelCI_app.helpers.commonDetails import PossibleTabs, add_unfiltered_issue
 from kernelCI_app.helpers.filters import (
     is_test_failure,
     should_increment_build_issue,
@@ -218,7 +219,7 @@ def get_current_row_data(current_row: dict) -> dict:
         or current_row_data["build_valid"] is None
         or current_row_data["test_status"] == FAIL_STATUS
     ):
-        current_row_data["issue_id"] = UNKNOWN_STRING
+        current_row_data["issue_id"] = UNCATEGORIZED_STRING
     current_row_data["build_misc"] = handle_build_misc(current_row_data["build_misc"])
     if current_row_data["test_path"] is None:
         current_row_data["test_path"] = UNKNOWN_STRING
@@ -545,6 +546,8 @@ def process_filters(instance, row_data: dict) -> None:
             issue_version=build_issue_version,
             should_increment=is_build_issue,
             issue_set=instance.unfiltered_build_issues,
+            unknown_issue_flag_dict=instance.unfiltered_uncategorized_issue_flags,
+            unknown_issue_flag_tab="build",
             is_invalid=is_invalid,
         )
 
@@ -557,8 +560,10 @@ def process_filters(instance, row_data: dict) -> None:
 
         if is_boot(row_data["test_path"]):
             issue_set = instance.unfiltered_boot_issues
+            flag_tab: PossibleTabs = "boot"
         else:
             issue_set = instance.unfiltered_test_issues
+            flag_tab: PossibleTabs = "test"
 
         is_invalid = row_data["test_status"] == FAIL_STATUS
         add_unfiltered_issue(
@@ -567,4 +572,6 @@ def process_filters(instance, row_data: dict) -> None:
             should_increment=is_test_issue,
             issue_set=issue_set,
             is_invalid=is_invalid,
+            unknown_issue_flag_dict=instance.unfiltered_uncategorized_issue_flags,
+            unknown_issue_flag_tab=flag_tab,
         )

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -106,6 +106,7 @@ class GlobalFilters(BaseModel):
 
 class LocalFilters(BaseModel):
     issues: List[Tuple[str, Optional[int]]]
+    has_unknown_issue: bool
 
 
 class DetailsFilters(BaseModel):

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -5,6 +5,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.utils import extend_schema
 from http import HTTPStatus
+from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.helpers.filters import FilterParams
 from kernelCI_app.helpers.hardwareDetails import (
     assign_default_record_values,
@@ -256,6 +257,12 @@ class HardwareDetails(APIView):
         self.builds["summary"] = create_details_build_summary(self.builds["items"])
         self._format_processing_for_response()
 
+        self.unfiltered_uncategorized_issue_flags: Dict[PossibleTabs, bool] = {
+            "build": False,
+            "boot": False,
+            "test": False,
+        }
+
         get_filter_options(
             instance=self,
             records=records,
@@ -307,14 +314,25 @@ class HardwareDetails(APIView):
                         architectures=self.global_architectures,
                         compilers=self.global_compilers,
                     ),
-                    builds=LocalFilters(issues=list(self.unfiltered_build_issues)),
+                    builds=LocalFilters(
+                        issues=list(self.unfiltered_build_issues),
+                        has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
+                            "build"
+                        ],
+                    ),
                     boots=HardwareTestLocalFilters(
                         issues=list(self.unfiltered_boot_issues),
                         platforms=list(self.unfiltered_boot_platforms),
+                        has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
+                            "boot"
+                        ],
                     ),
                     tests=HardwareTestLocalFilters(
                         issues=list(self.unfiltered_test_issues),
                         platforms=list(self.unfiltered_test_platforms),
+                        has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
+                            "test"
+                        ],
                     ),
                 ),
                 common=HardwareCommon(

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -6,7 +6,7 @@ from kernelCI_app.helpers.filters import (
     FilterParams,
     InvalidComparisonOP,
 )
-from kernelCI_app.constants.general import UNKNOWN_STRING
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING, UNKNOWN_STRING
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.helpers.misc import (
     handle_build_misc,
@@ -250,7 +250,7 @@ class TreeCommitsHistory(APIView):
         if issue_id is None and (
             build_valid in [False, None] or test_status == FAIL_STATUS
         ):
-            issue_id = UNKNOWN_STRING
+            issue_id = UNCATEGORIZED_STRING
 
         if test_id is None:
             return

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -2029,6 +2029,9 @@ components:
             type: array
           title: Issues
           type: array
+        has_unknown_issue:
+          title: Has Unknown Issue
+          type: boolean
         platforms:
           items:
             type: string
@@ -2036,6 +2039,7 @@ components:
           type: array
       required:
       - issues
+      - has_unknown_issue
       - platforms
       title: HardwareTestLocalFilters
       type: object
@@ -2306,8 +2310,12 @@ components:
             type: array
           title: Issues
           type: array
+        has_unknown_issue:
+          title: Has Unknown Issue
+          type: boolean
       required:
       - issues
+      - has_unknown_issue
       title: LocalFilters
       type: object
     LogData:
@@ -2765,6 +2773,8 @@ components:
           $ref: '#/components/schemas/Checkout__GitCommitHash'
         git_commit_name:
           $ref: '#/components/schemas/Checkout__GitCommitName'
+        git_commit_tags:
+          $ref: '#/components/schemas/Checkout__GitCommitTags'
         earliest_start_time:
           format: date-time
           title: Earliest Start Time
@@ -2778,6 +2788,7 @@ components:
       required:
       - git_commit_hash
       - git_commit_name
+      - git_commit_tags
       - earliest_start_time
       - builds
       - boots

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -21,7 +21,7 @@ import FilterLink from '@/components/Tabs/FilterLink';
 
 import LinkWithIcon from '@/components/LinkWithIcon/LinkWithIcon';
 
-import { UNKNOWN_STRING } from '@/utils/constants/backend';
+import { UNCATEGORIZED_STRING } from '@/utils/constants/backend';
 
 import { MemoizedMoreDetailsIconLink } from '@/components/Button/MoreDetailsButton';
 import { IssueTooltip } from '@/components/Issue/IssueTooltip';
@@ -144,7 +144,8 @@ const IssuesList = ({
                       unknown={issue.incidents_info.incidentsCount}
                       hasBottomBorder
                       text={
-                        issue.comment ?? formatMessage({ id: 'global.unknown' })
+                        issue.comment ??
+                        formatMessage({ id: 'issue.uncategorized' })
                       }
                       tooltip={issue.comment}
                     />
@@ -176,7 +177,7 @@ const IssuesList = ({
                   icon={<LinkIcon className="h-4 w-4" />}
                 />
               )}
-              {issue.id !== UNKNOWN_STRING && (
+              {issue.id !== UNCATEGORIZED_STRING && (
                 <MemoizedMoreDetailsIconLink
                   linkProps={getIssueLink(issue.id, issue.version)}
                 />
@@ -188,12 +189,12 @@ const IssuesList = ({
       {failedWithUnknownIssues && (
         <FilterLink
           filterSection={issueFilterSection}
-          filterValue={'Unknown'}
+          filterValue={UNCATEGORIZED_STRING}
           diffFilter={diffFilter}
         >
           <ListingItem
             unknown={failedWithUnknownIssues}
-            text={formatMessage({ id: 'global.unknown' })}
+            text={formatMessage({ id: 'issue.uncategorized' })}
           />
         </FilterLink>
       )}

--- a/dashboard/src/components/Tabs/Filters.tsx
+++ b/dashboard/src/components/Tabs/Filters.tsx
@@ -19,7 +19,7 @@ import type {
   TFilterNumberKeys,
 } from '@/types/general';
 import { filterFieldMap, zFilterObjectsKeys } from '@/types/general';
-import { UNKNOWN_STRING } from '@/utils/constants/backend';
+import { UNCATEGORIZED_STRING } from '@/utils/constants/backend';
 import { version_prefix } from '@/utils/utils';
 
 export const NO_VALID_INDEX = -1;
@@ -55,10 +55,10 @@ export const mapFilterToReq = (filter: TFilter): TFilter => {
           }
 
           if (reqField.includes('issue')) {
-            let issue_id = UNKNOWN_STRING;
+            let issue_id = UNCATEGORIZED_STRING;
             let issue_version = null;
 
-            if (value !== UNKNOWN_STRING) {
+            if (value !== UNCATEGORIZED_STRING) {
               const split_issue_data = value.split(` ${version_prefix}`);
               issue_version = split_issue_data.pop();
               issue_id = split_issue_data.join(` ${version_prefix}`);

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -199,6 +199,7 @@ export const messages = {
     'issue.noIssueFound': 'No issue found.',
     'issue.tooltip':
       'Issues groups several builds or tests by matching result status and logs.{br}They may also be linked to an external issue tracker or mailing list discussion.',
+    'issue.uncategorized': 'Uncategorized',
     'issueDetails.buildValid': 'Build Valid',
     'issueDetails.comment': 'Comment',
     'issueDetails.culpritCode': 'Code',

--- a/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetailsFilter.tsx
@@ -16,6 +16,7 @@ import {
 import { isTFilterObjectKeys, type TFilter } from '@/types/general';
 import { cleanFalseFilters } from '@/components/Tabs/tabsUtils';
 import { getIssueFilterLabel } from '@/utils/utils';
+import { UNCATEGORIZED_STRING } from '@/utils/constants/backend';
 
 type TFilterValues = Record<string, boolean>;
 
@@ -54,18 +55,32 @@ export const createFilter = (data: TreeDetailsSummary | undefined): TFilter => {
 
     data.common.hardware.forEach(h => (hardware[h] = false));
 
-    data.filters.builds.issues.forEach(
+    const buildFilters = data.filters.builds;
+    buildFilters.issues.forEach(
       i =>
         (buildIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
     );
-    data.filters.boots.issues.forEach(
+    if (buildFilters.has_unknown_issue) {
+      buildIssue[UNCATEGORIZED_STRING] = false;
+    }
+
+    const bootFilters = data.filters.boots;
+    bootFilters.issues.forEach(
       i =>
         (bootIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
     );
-    data.filters.tests.issues.forEach(
+    if (bootFilters.has_unknown_issue) {
+      bootIssue[UNCATEGORIZED_STRING] = false;
+    }
+
+    const testFilters = data.filters.tests;
+    testFilters.issues.forEach(
       i =>
         (testIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
     );
+    if (testFilters.has_unknown_issue) {
+      testIssue[UNCATEGORIZED_STRING] = false;
+    }
   }
 
   return {

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -19,6 +19,7 @@ import { isTFilterObjectKeys, type TFilter } from '@/types/general';
 import { cleanFalseFilters } from '@/components/Tabs/tabsUtils';
 import type { HardwareDetailsSummary } from '@/types/hardware/hardwareDetails';
 import { getIssueFilterLabel } from '@/utils/utils';
+import { UNCATEGORIZED_STRING } from '@/utils/constants/backend';
 
 type TFilterValues = Record<string, boolean>;
 
@@ -83,18 +84,34 @@ export const createFilter = (
     data.filters.all.configs.forEach(config => {
       configs[config ?? 'Unknown'] = false;
     });
-    data.filters.builds.issues.forEach(
+
+    const buildFilters = data.filters.builds;
+    buildFilters.issues.forEach(
       i =>
         (buildIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
     );
-    data.filters.boots.issues.forEach(
+    if (buildFilters.has_unknown_issue) {
+      buildIssue[UNCATEGORIZED_STRING] = false;
+    }
+
+    const bootFilters = data.filters.boots;
+    bootFilters.issues.forEach(
       i =>
         (bootIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
     );
-    data.filters.tests.issues.forEach(
+    if (bootFilters.has_unknown_issue) {
+      bootIssue[UNCATEGORIZED_STRING] = false;
+    }
+
+    const testFilters = data.filters.tests;
+    testFilters.issues.forEach(
       i =>
         (testIssue[getIssueFilterLabel({ id: i[0], version: i[1] })] = false),
     );
+    if (testFilters.has_unknown_issue) {
+      testIssue[UNCATEGORIZED_STRING] = false;
+    }
+
     (data.filters.boots.platforms ?? []).forEach(
       p => (bootPlatform[p] = false),
     );

--- a/dashboard/src/types/commonDetails.ts
+++ b/dashboard/src/types/commonDetails.ts
@@ -44,6 +44,7 @@ export type IssueFilterItem = [string, number?];
 
 export type LocalFilters = {
   issues: IssueFilterItem[];
+  has_unknown_issue: boolean;
 };
 
 export type DetailsFilters = {

--- a/dashboard/src/utils/constants/backend.ts
+++ b/dashboard/src/utils/constants/backend.ts
@@ -1,1 +1,2 @@
 export const UNKNOWN_STRING = 'Unknown';
+export const UNCATEGORIZED_STRING = 'Uncategorized';


### PR DESCRIPTION
- Renames Unknown issues to Uncategorized issues
- Changes the behavior of the filters to return a flag for if it has uncategorized issues, instead of considering them as a normal issue
- Refactors TreeDetailsView and TreeDetailsSummaryView to use pydantic models directly

## How to test
Go to a tree or hardware details page where there are builds/boots/tests with uncategorized issues
Filter them through the issues list and through the filter modal
Check if everything is being filtered as intended

Closes #910