### PR TITLE
feat: add regex support to tree and hardware filters

### DIFF
--- a/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
@@ -15,6 +15,8 @@ import { Toaster } from '@/components/ui/toaster';
 
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
+import { matchesRegexOrIncludes } from '@/lib/string';
+
 import { TreeTable } from './TreeTable';
 
 interface ITreeListingPage {
@@ -52,12 +54,14 @@ const TreeListingPage = ({ inputFilter }: ITreeListingPage): JSX.Element => {
     return currentData
       .filter(tree => {
         return (
-          tree.git_commit_hash?.includes(inputFilter) ||
-          tree.git_repository_branch?.includes(inputFilter) ||
-          tree.git_repository_url?.includes(inputFilter) ||
+          matchesRegexOrIncludes(tree.git_commit_hash, inputFilter) ||
+          matchesRegexOrIncludes(tree.git_repository_branch, inputFilter) ||
+          matchesRegexOrIncludes(tree.git_repository_url, inputFilter) ||
           (isCompleteTree(tree)
-            ? tree.tree_names?.some(name => name.includes(inputFilter))
-            : tree.tree_name?.includes(inputFilter))
+            ? tree.tree_names?.some(name =>
+                matchesRegexOrIncludes(name, inputFilter),
+              )
+            : matchesRegexOrIncludes(tree.tree_name, inputFilter))
         );
       })
       .map((tree): TreeTableBody => {

--- a/dashboard/src/lib/string.ts
+++ b/dashboard/src/lib/string.ts
@@ -47,3 +47,31 @@ export const truncateUrl = (
   const lastPath = pathname ? pathname.slice(-endPathLength) : '';
   return `${domain}...${lastPath}`;
 };
+
+export const matchesRegexOrIncludes = (
+  text: string | undefined | null,
+  pattern: string,
+): boolean => {
+  if (!text) {
+    return false;
+  }
+  try {
+    const regex = new RegExp(pattern, 'i');
+    return regex.test(text);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e) {
+    return text.includes(pattern);
+  }
+};
+
+export const includesInAnStringOrStringArray = (
+  searched: string | string[],
+  inputFilter: string,
+): boolean => {
+  if (Array.isArray(searched)) {
+    return searched.some(element =>
+      matchesRegexOrIncludes(element, inputFilter),
+    );
+  }
+  return matchesRegexOrIncludes(searched, inputFilter);
+};

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -188,7 +188,8 @@ export const messages = {
     'hardware.details': 'Hardware Details',
     'hardware.multiplePlatforms': 'Multiple Platforms',
     'hardware.path': 'Hardware',
-    'hardware.searchPlaceholder': 'Search by hardware name or platform',
+    'hardware.searchPlaceholder':
+      'Search by hardware name or platform with a regex',
     'hardwareDetails.compatibles': 'Compatibles',
     'hardwareDetails.platforms': 'Platforms',
     'hardwareDetails.timeFrame':
@@ -260,7 +261,7 @@ export const messages = {
     'testsTab.testStatus': 'Test status',
     'tree.details': 'Trees Details',
     'tree.path': 'Trees',
-    'tree.searchPlaceholder': 'Search by tree, branch or tag',
+    'tree.searchPlaceholder': 'Search by tree, branch or tag with a regex',
     'treeDetails.bootsHistory': 'Boots History',
     'treeDetails.branch': 'Branch',
     'treeDetails.buildsHistory': 'Builds History',

--- a/dashboard/src/pages/Hardware/HardwareListingPage.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPage.tsx
@@ -17,6 +17,11 @@ import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import type { BuildStatus, StatusCount } from '@/types/general';
 
+import {
+  matchesRegexOrIncludes,
+  includesInAnStringOrStringArray,
+} from '@/lib/string';
+
 import { HardwareTable } from './HardwareTable';
 
 interface HardwareListingPageProps {
@@ -58,16 +63,6 @@ const useHardwareListingTime = (): {
   return { startTimestampInSeconds, endTimestampInSeconds };
 };
 
-const includesInAnStringOrArray = (
-  searched: string | string[],
-  inputFilter: string,
-): boolean => {
-  if (Array.isArray(searched)) {
-    return searched.some(element => element.includes(inputFilter));
-  }
-  return searched.includes(inputFilter);
-};
-
 const HardwareListingPage = ({
   inputFilter,
 }: HardwareListingPageProps): JSX.Element => {
@@ -89,8 +84,8 @@ const HardwareListingPage = ({
     return currentData
       .filter(hardware => {
         return (
-          hardware.hardware_name?.includes(inputFilter) ||
-          includesInAnStringOrArray(hardware.platform, inputFilter)
+          matchesRegexOrIncludes(hardware.hardware_name, inputFilter) ||
+          includesInAnStringOrStringArray(hardware.platform, inputFilter)
         );
       })
       .map((hardware): HardwareTableItem => {


### PR DESCRIPTION
- Updated TreeListingPage to use matchesRegexOrIncludes for filtering.
- Updated HardwareListingPage to use matchesRegexOrIncludes and
  includesInAnStringOrStringArray for filtering.
  functions to string utility library.

Closes #913


## How to test
Just use a regex on the search bars or click on the link below
http://localhost:5173/tree?ls=50&ts=android%7Cbroonie%7Cmainline