### PR TITLE
fix: swagger version

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -120,7 +120,7 @@ REST_FRAMEWORK = {
 SPECTACULAR_SETTINGS = {
     'TITLE': 'KernelCI Dashboard API',
     'DESCRIPTION': 'API for the KernelCI dashboard',
-    'VERSION': '1.0.0',
+    'VERSION': '0.9.0',
 }
 
 


### PR DESCRIPTION
The current API is not 1.0 yet, so it gives the users wrong impression

Closes #945
