### PR TITLE
Fix: issue list size on hardware details

### DIFF
--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -126,15 +126,6 @@ const BootsTab = ({
             archCompilerErrors={bootsSummary.architectures}
             diffFilter={diffFilter}
           />
-          <MemoizedIssuesList
-            title={<FormattedMessage id="global.issues" />}
-            issues={bootsSummary.issues}
-            failedWithUnknownIssues={bootsSummary.unknown_issues}
-            diffFilter={diffFilter}
-            issueFilterSection="bootIssue"
-            detailsId={hardwareId}
-            pageFrom={RedirectFrom.Hardware}
-          />
         </div>
         <div>
           <HardwareCommitNavigationGraph
@@ -152,6 +143,15 @@ const BootsTab = ({
             diffFilter={diffFilter}
           />
         </div>
+        <MemoizedIssuesList
+          title={<FormattedMessage id="global.issues" />}
+          issues={bootsSummary.issues}
+          failedWithUnknownIssues={bootsSummary.unknown_issues}
+          diffFilter={diffFilter}
+          issueFilterSection="bootIssue"
+          detailsId={hardwareId}
+          pageFrom={RedirectFrom.Hardware}
+        />
       </DesktopGrid>
       <MobileGrid>
         <MemoizedStatusCard
@@ -176,16 +176,16 @@ const BootsTab = ({
               archCompilerErrors={bootsSummary.architectures}
               diffFilter={diffFilter}
             />
-            <MemoizedIssuesList
-              title={<FormattedMessage id="global.issues" />}
-              issues={bootsSummary.issues}
-              failedWithUnknownIssues={bootsSummary.unknown_issues}
-              diffFilter={diffFilter}
-              issueFilterSection="bootIssue"
-              detailsId={hardwareId}
-              pageFrom={RedirectFrom.Hardware}
-            />
           </div>
+          <MemoizedIssuesList
+            title={<FormattedMessage id="global.issues" />}
+            issues={bootsSummary.issues}
+            failedWithUnknownIssues={bootsSummary.unknown_issues}
+            diffFilter={diffFilter}
+            issueFilterSection="bootIssue"
+            detailsId={hardwareId}
+            pageFrom={RedirectFrom.Hardware}
+          />
         </InnerMobileGrid>
       </MobileGrid>
       <HardwareDetailsTabsQuerySwitcher

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -102,15 +102,6 @@ const BuildTab = ({
             toggleFilterBySection={toggleFilterBySection}
             diffFilter={diffFilter}
           />
-          <MemoizedIssuesList
-            title={<FormattedMessage id="global.issues" />}
-            issues={buildsSummary.issues}
-            failedWithUnknownIssues={buildsSummary.unknown_issues}
-            diffFilter={diffFilter}
-            issueFilterSection="buildIssue"
-            detailsId={hardwareId}
-            pageFrom={RedirectFrom.Hardware}
-          />
         </div>
         <div>
           <HardwareCommitNavigationGraph
@@ -123,6 +114,15 @@ const BuildTab = ({
             diffFilter={diffFilter}
           />
         </div>
+        <MemoizedIssuesList
+          title={<FormattedMessage id="global.issues" />}
+          issues={buildsSummary.issues}
+          failedWithUnknownIssues={buildsSummary.unknown_issues}
+          diffFilter={diffFilter}
+          issueFilterSection="buildIssue"
+          detailsId={hardwareId}
+          pageFrom={RedirectFrom.Hardware}
+        />
       </DesktopGrid>
       <MobileGrid>
         <HardwareCommitNavigationGraph trees={trees} hardwareId={hardwareId} />
@@ -141,16 +141,16 @@ const BuildTab = ({
             toggleFilterBySection={toggleFilterBySection}
             diffFilter={diffFilter}
           />
+          <MemoizedIssuesList
+            title={<FormattedMessage id="global.issues" />}
+            issues={buildsSummary.issues}
+            failedWithUnknownIssues={buildsSummary.unknown_issues}
+            diffFilter={diffFilter}
+            issueFilterSection="buildIssue"
+            detailsId={hardwareId}
+            pageFrom={RedirectFrom.Hardware}
+          />
         </InnerMobileGrid>
-        <MemoizedIssuesList
-          title={<FormattedMessage id="global.issues" />}
-          issues={buildsSummary.issues}
-          failedWithUnknownIssues={buildsSummary.unknown_issues}
-          diffFilter={diffFilter}
-          issueFilterSection="buildIssue"
-          detailsId={hardwareId}
-          pageFrom={RedirectFrom.Hardware}
-        />
       </MobileGrid>
 
       <div className="flex flex-col gap-4">

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -113,15 +113,6 @@ const TestsTab = ({
             archCompilerErrors={testsSummary.architectures}
             diffFilter={diffFilter}
           />
-          <MemoizedIssuesList
-            title={<FormattedMessage id="global.issues" />}
-            issues={testsSummary.issues}
-            failedWithUnknownIssues={testsSummary.unknown_issues}
-            diffFilter={diffFilter}
-            issueFilterSection="testIssue"
-            detailsId={hardwareId}
-            pageFrom={RedirectFrom.Hardware}
-          />
         </div>
         <div>
           <HardwareCommitNavigationGraph
@@ -139,6 +130,15 @@ const TestsTab = ({
             diffFilter={diffFilter}
           />
         </div>
+        <MemoizedIssuesList
+          title={<FormattedMessage id="global.issues" />}
+          issues={testsSummary.issues}
+          failedWithUnknownIssues={testsSummary.unknown_issues}
+          diffFilter={diffFilter}
+          issueFilterSection="testIssue"
+          detailsId={hardwareId}
+          pageFrom={RedirectFrom.Hardware}
+        />
       </DesktopGrid>
       <MobileGrid>
         <MemoizedStatusCard
@@ -163,16 +163,16 @@ const TestsTab = ({
               archCompilerErrors={testsSummary.architectures}
               diffFilter={diffFilter}
             />
-            <MemoizedIssuesList
-              title={<FormattedMessage id="global.issues" />}
-              issues={testsSummary.issues}
-              failedWithUnknownIssues={testsSummary.unknown_issues}
-              diffFilter={diffFilter}
-              issueFilterSection="testIssue"
-              detailsId={hardwareId}
-              pageFrom={RedirectFrom.Hardware}
-            />
           </div>
+          <MemoizedIssuesList
+            title={<FormattedMessage id="global.issues" />}
+            issues={testsSummary.issues}
+            failedWithUnknownIssues={testsSummary.unknown_issues}
+            diffFilter={diffFilter}
+            issueFilterSection="testIssue"
+            detailsId={hardwareId}
+            pageFrom={RedirectFrom.Hardware}
+          />
         </InnerMobileGrid>
       </MobileGrid>
       <HardwareDetailsTabsQuerySwitcher


### PR DESCRIPTION
Moves the order of the issue list card so that it can occupy 2 columns on hardwareDetails, following the changes for the treeDetails

[Before](https://staging.dashboard.kernelci.org:9000/hardware/aaeon-UPN-EHLX4RE-A10-0864?et=1739556000&p=bt&st=1739124000):
![image](https://github.com/user-attachments/assets/00c66b1e-6b15-487f-b47f-f18fff94b5f1)

[After](http://localhost:5173/hardware/aaeon-UPN-EHLX4RE-A10-0864?et=1739556000&p=bt&st=1739124000):
![image](https://github.com/user-attachments/assets/1fc17fa0-4d64-49a1-ab85-7df0249895bc)


Closes #944