### PR TITLE
Refactor: rename build valid/invalid to pass/fail

### DIFF
--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -15,10 +15,10 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import type {
   TestByCommitHash,
-  TestsTableFilter,
+  PossibleTableFilters,
   TTestByCommitHashResponse,
 } from '@/types/tree/TreeDetails';
-import { possibleTestsTableFilter } from '@/types/tree/TreeDetails';
+import { possibleTableFilters } from '@/types/tree/TreeDetails';
 
 import { getStatusGroup } from '@/utils/status';
 
@@ -112,10 +112,10 @@ const defaultColumns: ColumnDef<TestByCommitHash>[] = [
 interface IBootsTable {
   tableKey: TableKeys;
   testHistory?: TestHistory[];
-  filter: TestsTableFilter;
+  filter: PossibleTableFilters;
   columns?: ColumnDef<TestByCommitHash>[];
   getRowLink: (testId: TestHistory['id']) => LinkProps;
-  onClickFilter: (newFilter: TestsTableFilter) => void;
+  onClickFilter: (newFilter: PossibleTableFilters) => void;
   updatePathFilter?: (pathFilter: string) => void;
   currentPathFilter?: string;
 }
@@ -177,29 +177,28 @@ export function BootsTable({
 
   const { globalFilter } = table.getState();
 
-  const filterCount: Record<(typeof possibleTestsTableFilter)[number], number> =
-    useMemo(() => {
-      const count = {
-        all: 0,
-        success: 0,
-        failed: 0,
-        inconclusive: 0,
-      };
+  const filterCount: Record<PossibleTableFilters, number> = useMemo(() => {
+    const count: Record<PossibleTableFilters, number> = {
+      all: 0,
+      success: 0,
+      failed: 0,
+      inconclusive: 0,
+    };
 
-      const rowsOriginal = table
-        .getPrePaginationRowModel()
-        .rows.map(row => row.original);
+    const rowsOriginal = table
+      .getPrePaginationRowModel()
+      .rows.map(row => row.original);
 
-      const dataFilter = globalFilter ? rowsOriginal : testsData;
+    const dataFilter = globalFilter ? rowsOriginal : testsData;
 
-      count.all = dataFilter.length;
-      dataFilter.forEach(test => count[getStatusGroup(test.status)]++);
+    count.all = dataFilter.length;
+    dataFilter.forEach(test => count[getStatusGroup(test.status)]++);
 
-      return count;
-    }, [testsData, globalFilter, table]);
+    return count;
+  }, [testsData, globalFilter, table]);
 
   const checkIfFilterIsSelected = useCallback(
-    (possibleFilter: TestsTableFilter): boolean => {
+    (possibleFilter: PossibleTableFilters): boolean => {
       return possibleFilter === filter;
     },
     [filter],
@@ -210,34 +209,34 @@ export function BootsTable({
       {
         label: intl.formatMessage(
           { id: 'global.allCount' },
-          { count: filterCount[possibleTestsTableFilter[0]] },
+          { count: filterCount[possibleTableFilters[0]] },
         ),
-        value: possibleTestsTableFilter[0],
-        isSelected: checkIfFilterIsSelected(possibleTestsTableFilter[0]),
+        value: possibleTableFilters[0],
+        isSelected: checkIfFilterIsSelected(possibleTableFilters[0]),
       },
       {
         label: intl.formatMessage(
           { id: 'global.successCount' },
-          { count: filterCount[possibleTestsTableFilter[1]] },
+          { count: filterCount[possibleTableFilters[1]] },
         ),
-        value: possibleTestsTableFilter[1],
-        isSelected: checkIfFilterIsSelected(possibleTestsTableFilter[1]),
+        value: possibleTableFilters[1],
+        isSelected: checkIfFilterIsSelected(possibleTableFilters[1]),
       },
       {
         label: intl.formatMessage(
           { id: 'global.failedCount' },
-          { count: filterCount[possibleTestsTableFilter[2]] },
+          { count: filterCount[possibleTableFilters[2]] },
         ),
-        value: possibleTestsTableFilter[2],
-        isSelected: checkIfFilterIsSelected(possibleTestsTableFilter[2]),
+        value: possibleTableFilters[2],
+        isSelected: checkIfFilterIsSelected(possibleTableFilters[2]),
       },
       {
         label: intl.formatMessage(
           { id: 'global.inconclusiveCount' },
-          { count: filterCount[possibleTestsTableFilter[3]] },
+          { count: filterCount[possibleTableFilters[3]] },
         ),
-        value: possibleTestsTableFilter[3],
-        isSelected: checkIfFilterIsSelected(possibleTestsTableFilter[3]),
+        value: possibleTableFilters[3],
+        isSelected: checkIfFilterIsSelected(possibleTableFilters[3]),
       },
     ],
     [intl, filterCount, checkIfFilterIsSelected],

--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -9,7 +9,7 @@ import type { ISection } from '@/components/Section/Section';
 import { useBuildDetails, useBuildIssues } from '@/api/buildDetails';
 import UnexpectedError from '@/components/UnexpectedError/UnexpectedError';
 
-import { formatDate } from '@/utils/utils';
+import { formatDate, getBuildStatus } from '@/utils/utils';
 
 import IssueSection from '@/components/Issue/IssueSection';
 
@@ -17,7 +17,10 @@ import { shouldTruncate, valueOrEmpty } from '@/lib/string';
 
 import { Sheet, SheetTrigger } from '@/components/Sheet';
 
-import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
+import type {
+  TableFilter,
+  PossibleTableFilters,
+} from '@/types/tree/TreeDetails';
 
 import type {
   IJsonContent,
@@ -40,7 +43,7 @@ import BuildDetailsTestSection from './BuildDetailsTestSection';
 interface BuildDetailsProps {
   breadcrumb?: JSX.Element;
   buildId?: string;
-  onClickFilter: (filter: TestsTableFilter) => void;
+  onClickFilter: (filter: PossibleTableFilters) => void;
   tableFilter: TableFilter;
   getTestTableRowLink: (testId: string) => LinkProps;
 }
@@ -153,11 +156,7 @@ const BuildDetails = ({
               },
               {
                 title: 'global.status',
-                linkText: data.valid
-                  ? 'VALID'
-                  : data.valid !== null
-                    ? 'INVALID'
-                    : 'NULL',
+                linkText: getBuildStatus(data.valid).toUpperCase(),
                 icon: <StatusIcon status={data?.valid} className="text-xl" />,
               },
               {

--- a/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
@@ -6,7 +6,10 @@ import { Separator } from '@/components/ui/separator';
 
 import { useBuildTests } from '@/api/buildTests';
 
-import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
+import type {
+  TableFilter,
+  PossibleTableFilters,
+} from '@/types/tree/TreeDetails';
 
 import { TestsTable } from '@/components/TestsTable/TestsTable';
 
@@ -14,7 +17,7 @@ import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 interface IBuildDetailsTestSection {
   buildId: string;
-  onClickFilter: (filter: TestsTableFilter) => void;
+  onClickFilter: (filter: PossibleTableFilters) => void;
   tableFilter: TableFilter;
   getRowLink: (testId: string) => LinkProps;
 }

--- a/dashboard/src/components/BuildsTable/DefaultBuildsColumns.tsx
+++ b/dashboard/src/components/BuildsTable/DefaultBuildsColumns.tsx
@@ -12,6 +12,7 @@ import {
   MoreDetailsIcon,
   MoreDetailsTableHeader,
 } from '@/components/Table/DetailsColumn';
+import { getBuildStatusGroup } from '@/utils/status';
 
 export const defaultBuildColumns: ColumnDef<AccordionItemBuilds>[] = [
   {
@@ -86,7 +87,8 @@ export const defaultBuildColumns: ColumnDef<AccordionItemBuilds>[] = [
         ? row.getValue('status')!.toString().toUpperCase()
         : 'NULL';
     },
-    filterFn: 'equals',
+    filterFn: (row, columnId, filterValue) =>
+      getBuildStatusGroup(row.getValue(columnId)) === filterValue,
   },
   {
     id: DETAILS_COLUMN_ID,

--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -17,9 +17,8 @@ import { getMiscSection } from '@/components/Section/MiscSection';
 import { useIssueDetails } from '@/api/issueDetails';
 
 import type {
-  BuildsTableFilter,
   TableFilter,
-  TestsTableFilter,
+  PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
@@ -44,9 +43,9 @@ interface IIssueDetails {
   issueId: string;
   versionNumber?: number;
   tableFilter: TableFilter;
-  onClickTestFilter: (filter: TestsTableFilter) => void;
+  onClickTestFilter: (filter: PossibleTableFilters) => void;
   getTestTableRowLink: (testId: string) => LinkProps;
-  onClickBuildFilter: (filter: BuildsTableFilter) => void;
+  onClickBuildFilter: (filter: PossibleTableFilters) => void;
   getBuildTableRowLink: (testId: string) => LinkProps;
   breadcrumb?: JSX.Element;
 }

--- a/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
@@ -10,7 +10,7 @@ import { Separator } from '@/components/ui/separator';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 import type {
   AccordionItemBuilds,
-  BuildsTableFilter,
+  PossibleTableFilters,
   TableFilter,
 } from '@/types/tree/TreeDetails';
 
@@ -26,7 +26,7 @@ interface IIssueDetailsBuildSection {
   issueId: string;
   versionNumber?: number;
   buildTableFilter: TableFilter['buildsTable'];
-  onClickFilter: (filter: BuildsTableFilter) => void;
+  onClickFilter: (filter: PossibleTableFilters) => void;
   getTableRowLink: (testId: string) => LinkProps;
 }
 

--- a/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
@@ -13,14 +13,17 @@ import { TableHeader } from '@/components/Table/TableHeader';
 import { Separator } from '@/components/ui/separator';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
-import type { TableFilter, TestsTableFilter } from '@/types/tree/TreeDetails';
+import type {
+  TableFilter,
+  PossibleTableFilters,
+} from '@/types/tree/TreeDetails';
 import type { TIndividualTest } from '@/types/general';
 
 interface IIssueDetailsTestSection {
   issueId: string;
   versionNumber?: number;
   testTableFilter: TableFilter['testsTable'];
-  onClickFilter: (filter: TestsTableFilter) => void;
+  onClickFilter: (filter: PossibleTableFilters) => void;
   getTableRowLink: (testId: string) => LinkProps;
 }
 

--- a/dashboard/src/components/Table/TableStatusFilter.tsx
+++ b/dashboard/src/components/Table/TableStatusFilter.tsx
@@ -3,17 +3,14 @@ import { useCallback, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@/components/ui/button';
-import type {
-  BuildsTableFilter,
-  TestsTableFilter,
-} from '@/types/tree/TreeDetails';
+import type { PossibleTableFilters } from '@/types/tree/TreeDetails';
 
 interface ITableStatusFilter {
-  onClickBuild?: (value: BuildsTableFilter) => void;
-  onClickTest?: (value: TestsTableFilter) => void;
+  onClickBuild?: (value: PossibleTableFilters) => void;
+  onClickTest?: (value: PossibleTableFilters) => void;
   filters: {
     label: string;
-    value: BuildsTableFilter | TestsTableFilter;
+    value: PossibleTableFilters;
     isSelected: boolean;
   }[];
 }
@@ -24,9 +21,9 @@ const TableStatusFilter = ({
   onClickTest,
 }: ITableStatusFilter): JSX.Element => {
   const onClickFilter = useCallback(
-    (filter: BuildsTableFilter | TestsTableFilter) => {
-      onClickBuild?.(filter as BuildsTableFilter);
-      onClickTest?.(filter as TestsTableFilter);
+    (filter: PossibleTableFilters) => {
+      onClickBuild?.(filter);
+      onClickTest?.(filter);
     },
     [onClickBuild, onClickTest],
   );

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -19,8 +19,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import type { LinkProps } from '@tanstack/react-router';
 
-import type { TestsTableFilter } from '@/types/tree/TreeDetails';
-import { possibleTestsTableFilter } from '@/types/tree/TreeDetails';
+import type { PossibleTableFilters } from '@/types/tree/TreeDetails';
+import { possibleTableFilters } from '@/types/tree/TreeDetails';
 
 import type { TestHistory, TIndividualTest, TPathTests } from '@/types/general';
 
@@ -47,8 +47,8 @@ import { defaultColumns, defaultInnerColumns } from './DefaultTestsColumns';
 export interface ITestsTable {
   tableKey: TableKeys;
   testHistory?: TestHistory[];
-  onClickFilter: (filter: TestsTableFilter) => void;
-  filter: TestsTableFilter;
+  onClickFilter: (filter: PossibleTableFilters) => void;
+  filter: PossibleTableFilters;
   columns?: ColumnDef<TPathTests>[];
   innerColumns?: ColumnDef<TIndividualTest>[];
   getRowLink: (testId: TestHistory['id']) => LinkProps;
@@ -273,53 +273,52 @@ export function TestsTable({
     },
   });
 
-  const filterCount: Record<(typeof possibleTestsTableFilter)[number], number> =
-    useMemo(
-      () => ({
-        all: globalStatusGroup.total_tests,
-        success: globalStatusGroup.pass_tests,
-        failed: globalStatusGroup.fail_tests,
-        inconclusive:
-          globalStatusGroup.total_tests -
-          globalStatusGroup.pass_tests -
-          globalStatusGroup.fail_tests,
-      }),
-      [globalStatusGroup],
-    );
+  const filterCount: Record<PossibleTableFilters, number> = useMemo(
+    () => ({
+      all: globalStatusGroup.total_tests,
+      success: globalStatusGroup.pass_tests,
+      failed: globalStatusGroup.fail_tests,
+      inconclusive:
+        globalStatusGroup.total_tests -
+        globalStatusGroup.pass_tests -
+        globalStatusGroup.fail_tests,
+    }),
+    [globalStatusGroup],
+  );
 
   const filters = useMemo(
     () => [
       {
         label: intl.formatMessage(
           { id: 'global.allCount' },
-          { count: filterCount[possibleTestsTableFilter[0]] },
+          { count: filterCount[possibleTableFilters[0]] },
         ),
-        value: possibleTestsTableFilter[0],
-        isSelected: filter === possibleTestsTableFilter[0],
+        value: possibleTableFilters[0],
+        isSelected: filter === possibleTableFilters[0],
       },
       {
         label: intl.formatMessage(
           { id: 'global.successCount' },
-          { count: filterCount[possibleTestsTableFilter[1]] },
+          { count: filterCount[possibleTableFilters[1]] },
         ),
-        value: possibleTestsTableFilter[1],
-        isSelected: filter === possibleTestsTableFilter[1],
+        value: possibleTableFilters[1],
+        isSelected: filter === possibleTableFilters[1],
       },
       {
         label: intl.formatMessage(
           { id: 'global.failedCount' },
-          { count: filterCount[possibleTestsTableFilter[2]] },
+          { count: filterCount[possibleTableFilters[2]] },
         ),
-        value: possibleTestsTableFilter[2],
-        isSelected: filter === possibleTestsTableFilter[2],
+        value: possibleTableFilters[2],
+        isSelected: filter === possibleTableFilters[2],
       },
       {
         label: intl.formatMessage(
           { id: 'global.inconclusiveCount' },
-          { count: filterCount[possibleTestsTableFilter[3]] },
+          { count: filterCount[possibleTableFilters[3]] },
         ),
-        value: possibleTestsTableFilter[3],
-        isSelected: filter === possibleTestsTableFilter[3],
+        value: possibleTableFilters[3],
+        isSelected: filter === possibleTableFilters[3],
       },
     ],
     [filterCount, intl, filter],

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -29,8 +29,7 @@ import type { TFilter, TOrigins, BuildStatus } from '@/types/general';
 import { formattedBreakLineValue } from '@/locales/messages';
 
 import {
-  possibleBuildsTableFilter,
-  possibleTestsTableFilter,
+  possibleTableFilters,
   zPossibleTabValidator,
 } from '@/types/tree/TreeDetails';
 
@@ -79,9 +78,9 @@ const getLinkProps = (
     params: { treeId: row.original.id },
     search: previousSearch => ({
       tableFilter: {
-        bootsTable: possibleTestsTableFilter[0],
-        buildsTable: possibleBuildsTableFilter[2],
-        testsTable: possibleTestsTableFilter[0],
+        bootsTable: possibleTableFilters[0],
+        buildsTable: possibleTableFilters[0],
+        testsTable: possibleTableFilters[0],
       },
       origin: origin,
       currentPageTab: zPossibleTabValidator.parse(tabTarget),

--- a/dashboard/src/pages/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetails.tsx
@@ -10,7 +10,7 @@ import {
 
 import {
   zTableFilterInfoDefault,
-  type TestsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
 
@@ -37,7 +37,7 @@ const BuildDetailsPage = (): JSX.Element => {
   );
 
   const onClickFilter = useCallback(
-    (filter: TestsTableFilter): void => {
+    (filter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
+++ b/dashboard/src/pages/HardwareBuildDetails/HardwareBuildDetails.tsx
@@ -11,7 +11,7 @@ import { useCallback } from 'react';
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
 import {
   zTableFilterInfoDefault,
-  type TestsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 import { RedirectFrom } from '@/types/general';
 import { MemoizedHardwareBreadcrumb } from '@/components/Breadcrumb/HardwareBreadcrumb';
@@ -39,7 +39,7 @@ const HardwareBuildDetails = (): JSX.Element => {
   );
 
   const onClickFilter = useCallback(
-    (filter: TestsTableFilter): void => {
+    (filter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/pages/IssueDetails/IssueDetails.tsx
@@ -9,10 +9,7 @@ import {
 import { useCallback, useMemo } from 'react';
 
 import { IssueDetails } from '@/components/IssueDetails/IssueDetails';
-import type {
-  BuildsTableFilter,
-  TestsTableFilter,
-} from '@/types/tree/TreeDetails';
+import type { PossibleTableFilters } from '@/types/tree/TreeDetails';
 import { zTableFilterInfoDefault } from '@/types/tree/TreeDetails';
 import { RedirectFrom } from '@/types/general';
 import { MemoizedTreeBreadcrumb } from '@/components/Breadcrumb/TreeBreadcrumb';
@@ -67,7 +64,7 @@ const IssueDetailsPage = (): JSX.Element => {
   }, [historyState.from, historyState.id, searchParams]);
 
   const onClickTestFilter = useCallback(
-    (filter: TestsTableFilter): void => {
+    (filter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {
@@ -85,7 +82,7 @@ const IssueDetailsPage = (): JSX.Element => {
   );
 
   const onClickBuildFilter = useCallback(
-    (filter: BuildsTableFilter): void => {
+    (filter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
+++ b/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
@@ -11,7 +11,7 @@ import { useCallback } from 'react';
 import BuildDetails from '@/components/BuildDetails/BuildDetails';
 import {
   zTableFilterInfoDefault,
-  type TestsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 import { RedirectFrom } from '@/types/general';
 import { MemoizedTreeBreadcrumb } from '@/components/Breadcrumb/TreeBreadcrumb';
@@ -37,7 +37,7 @@ const TreeBuildDetails = (): JSX.Element => {
   );
 
   const onClickFilter = useCallback(
-    (filter: TestsTableFilter): void => {
+    (filter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -13,7 +13,7 @@ import MemoizedIssuesList from '@/components/Cards/IssuesList';
 import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
 import {
   zTableFilterInfoDefault,
-  type TestsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 import {
   DesktopGrid,
@@ -68,7 +68,7 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
   );
 
   const onClickFilter = useCallback(
-    (newFilter: TestsTableFilter): void => {
+    (newFilter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -7,7 +7,7 @@ import { BuildsTable } from '@/components/BuildsTable/BuildsTable';
 import {
   zTableFilterInfoDefault,
   type AccordionItemBuilds,
-  type BuildsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 
 export interface TTreeDetailsBuildsTable {
@@ -34,7 +34,7 @@ export function TreeDetailsBuildsTable({
   );
 
   const onClickFilter = useCallback(
-    (newFilter: BuildsTableFilter): void => {
+    (newFilter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -11,7 +11,7 @@ import BaseCard from '@/components/Cards/BaseCard';
 
 import {
   zTableFilterInfoDefault,
-  type TestsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
@@ -86,7 +86,7 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
   );
 
   const onClickFilter = useCallback(
-    (filter: TestsTableFilter): void => {
+    (filter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -17,7 +17,7 @@ import type {
 
 import {
   zTableFilterInfoDefault,
-  type TestsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 
 import {
@@ -91,7 +91,7 @@ const BootsTab = ({
   );
 
   const onClickFilter = useCallback(
-    (newFilter: TestsTableFilter): void => {
+    (newFilter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/HardwareDetailsBootsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/HardwareDetailsBootsTable.tsx
@@ -15,7 +15,7 @@ import { getStatusGroup } from '@/utils/status';
 
 import type {
   TestByCommitHash,
-  TestsTableFilter,
+  PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 import type { TestHistory } from '@/types/general';
 
@@ -80,9 +80,9 @@ export const columns: ColumnDef<TestByCommitHash>[] = [
 interface IHardwareBootsTable {
   tableKey: TableKeys;
   testHistory?: TestHistory[];
-  filter: TestsTableFilter;
+  filter: PossibleTableFilters;
   getRowLink: (testId: TestHistory['id']) => LinkProps;
-  onClickFilter: (newFilter: TestsTableFilter) => void;
+  onClickFilter: (newFilter: PossibleTableFilters) => void;
   updatePathFilter?: (pathFilter: string) => void;
   currentPathFilter?: string;
 }

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -11,7 +11,7 @@ import { TableHeader } from '@/components/Table/TableHeader';
 import {
   zTableFilterInfoDefault,
   type AccordionItemBuilds,
-  type BuildsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 import { defaultBuildColumns } from '@/components/BuildsTable/DefaultBuildsColumns';
 import { sanitizeBuilds } from '@/utils/utils';
@@ -55,7 +55,7 @@ export function HardwareDetailsBuildsTable({
   );
 
   const onClickFilter = useCallback(
-    (filter: BuildsTableFilter) => {
+    (filter: PossibleTableFilters) => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -15,7 +15,7 @@ import type {
 
 import {
   zTableFilterInfoDefault,
-  type TestsTableFilter,
+  type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
 
 import {
@@ -78,7 +78,7 @@ const TestsTab = ({
   );
 
   const onClickFilter = useCallback(
-    (newFilter: TestsTableFilter): void => {
+    (newFilter: PossibleTableFilters): void => {
       navigate({
         search: previousParams => {
           return {

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -20,7 +20,7 @@ export type AccordionItemBuilds = {
   date?: string;
   buildErrors?: number;
   buildTime?: string | ReactNode;
-  status: 'valid' | 'invalid' | 'null';
+  status: 'pass' | 'fail' | 'null';
   kernelImage?: string;
   buildLogs?: string;
   kernelConfig?: string;
@@ -98,14 +98,7 @@ export const possibleTabs = [
   'global.tests',
 ] as const;
 
-export const possibleBuildsTableFilter = [
-  'invalid',
-  'valid',
-  'all',
-  'null',
-] as const;
-
-export const possibleTestsTableFilter = [
+export const possibleTableFilters = [
   'all',
   'success',
   'failed',
@@ -114,12 +107,10 @@ export const possibleTestsTableFilter = [
 
 export const defaultValidadorValues: {
   tab: (typeof possibleTabs)[number];
-  buildsTableFilter: (typeof possibleBuildsTableFilter)[number];
-  testsTableFilter: (typeof possibleTestsTableFilter)[number];
+  tableFilter: (typeof possibleTableFilters)[number];
 } = {
   tab: 'global.builds',
-  buildsTableFilter: 'all',
-  testsTableFilter: 'all',
+  tableFilter: 'all',
 };
 
 export const zPossibleTabValidator = z
@@ -129,27 +120,22 @@ export const zPossibleTabValidator = z
 
 export type PossibleTabs = z.infer<typeof zPossibleTabValidator>;
 
-export const zBuildsTableFilterValidator = z
-  .enum(possibleBuildsTableFilter)
-  .catch(defaultValidadorValues.buildsTableFilter);
+export const zTableFilterValidator = z
+  .enum(possibleTableFilters)
+  .catch(defaultValidadorValues.tableFilter);
 
-export const zTestsTableFilterValidator = z
-  .enum(possibleTestsTableFilter)
-  .catch(defaultValidadorValues.testsTableFilter);
-
-export type BuildsTableFilter = z.infer<typeof zBuildsTableFilterValidator>;
-export type TestsTableFilter = z.infer<typeof zTestsTableFilterValidator>;
+export type PossibleTableFilters = z.infer<typeof zTableFilterValidator>;
 
 export const zTableFilterInfo = object({
-  buildsTable: zBuildsTableFilterValidator,
-  bootsTable: zTestsTableFilterValidator,
-  testsTable: zTestsTableFilterValidator,
+  buildsTable: zTableFilterValidator,
+  bootsTable: zTableFilterValidator,
+  testsTable: zTableFilterValidator,
 });
 
 export const zTableFilterInfoDefault = {
-  buildsTable: zBuildsTableFilterValidator.parse(''),
-  bootsTable: zTestsTableFilterValidator.parse(''),
-  testsTable: zTestsTableFilterValidator.parse(''),
+  buildsTable: zTableFilterValidator.parse(''),
+  bootsTable: zTableFilterValidator.parse(''),
+  testsTable: zTableFilterValidator.parse(''),
 };
 
 export const zTableFilterInfoValidator = zTableFilterInfo

--- a/dashboard/src/utils/search.ts
+++ b/dashboard/src/utils/search.ts
@@ -4,9 +4,8 @@ import { type AnySchema, parseSearchWith } from '@tanstack/react-router';
 
 import { type SearchParamsKeys, type TFilterKeys } from '@/types/general';
 import type {
-  possibleBuildsTableFilter,
   possibleTabs,
-  possibleTestsTableFilter,
+  possibleTableFilters,
   TableFilter,
   TTreeInformation,
 } from '@/types/tree/TreeDetails';
@@ -203,9 +202,7 @@ const minifiedParams: MinifiedParams = {
 } as const;
 
 type MinifiedValues = Record<
-  | (typeof possibleTabs)[number]
-  | (typeof possibleBuildsTableFilter)[number]
-  | (typeof possibleTestsTableFilter)[number],
+  (typeof possibleTabs)[number] | (typeof possibleTableFilters)[number],
   string
 >;
 type MinifiedValuesKeys = keyof MinifiedValues;
@@ -215,9 +212,6 @@ const minifiedValues: MinifiedValues = {
   success: 's',
   failed: 'f',
   inconclusive: 'i',
-  valid: 'v',
-  invalid: 'iv',
-  null: 'n',
 
   // CurrentPageTab values
   'global.builds': 'b',

--- a/dashboard/src/utils/status.ts
+++ b/dashboard/src/utils/status.ts
@@ -4,6 +4,7 @@ import type {
   BuildStatus,
   RequiredStatusCount,
 } from '@/types/general';
+import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
 
 type StatusGroups = 'success' | 'failed' | 'inconclusive';
 
@@ -35,6 +36,19 @@ export function groupStatus(counts: GroupStatusCount): GroupedStatus {
       (counts.nullCount ?? 0),
   };
 }
+
+export const getBuildStatusGroup = (
+  buildStatus: AccordionItemBuilds['status'],
+): StatusGroups => {
+  switch (buildStatus) {
+    case 'pass':
+      return 'success';
+    case 'fail':
+      return 'failed';
+    default:
+      return 'inconclusive';
+  }
+};
 
 export const getStatusGroup = (status: Status): StatusGroups => {
   if (status === 'PASS') {

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -128,10 +128,16 @@ const isBuildError = (build_valid: boolean | null): number => {
   return build_valid || build_valid === null ? 0 : 1;
 };
 
-const getBuildStatus = (
-  build_valid: boolean | null,
+export const getBuildStatus = (
+  build_valid?: boolean | null,
 ): AccordionItemBuilds['status'] => {
-  return build_valid === null ? 'null' : build_valid ? 'valid' : 'invalid';
+  if (build_valid === true) {
+    return 'pass';
+  }
+  if (build_valid === false) {
+    return 'fail';
+  }
+  return 'null';
 };
 
 export const sanitizeBuilds = (


### PR DESCRIPTION
This change is only for the status display in the builds table and build details, the variables are still called valid since that is how it is called in the backend.
The name in the diffFilter was left unchanged, but the table filter was unified with the way it is being done in the other tables

## How to test
Go to a buildDetails page and check the change in the "status" field.
Go to a page with a build table (such as treeDetails, hardwareDetails or issueDetails) and check the table to see if it is behaving correctly, also check the status filters.
Try to filter by build status and check if it is behaving correctly, also check the url to see if it is called by the correct name.


Closes #922