### PR TITLE
feat(issues-list): sort by first_seen

### DIFF
--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -298,6 +298,8 @@ def query_records(
                 AND tests.start_time >= %s
                 AND tests.start_time <= %s
                 AND checkouts.git_commit_hash IN ({0})
+            ORDER BY
+                issues."_timestamp" DESC
             """.format(",".join(['%s'] * len(commit_hashes))),
             [hardware_id, hardware_id, origin, start_date, end_date] + commit_hashes
         )

--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -140,6 +140,8 @@ def get_tree_details_data(request, commit_hash):
         WHERE
             tests.origin = %(origin_param)s OR
             tests.origin IS NULL
+        ORDER BY
+            issues."_timestamp" DESC
         """
         with connection.cursor() as cursor:
             cursor.execute(query, params)


### PR DESCRIPTION
Sort the issues list card by the first_seen value of each issue in descending order, in other words, the newest versions (that have the "greatest" timestamp) will appear first in the list

Closes #940

## Visual Reference
### `mainline/master`

[localhost](http://localhost:5173/tree/0ad2507d5d93f39619fc42372c347d6006b64319?p=bt&ti%7Cc=v6.14-rc3&ti%7Cch=0ad2507d5d93f39619fc42372c347d6006b64319&ti%7Cgb=master&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Ftorvalds%2Flinux.git&ti%7Ct=mainline)
![image](https://github.com/user-attachments/assets/5eec60b1-f775-4034-8035-d14b318123f1)


[staging](https://staging.dashboard.kernelci.org:9000/tree/0ad2507d5d93f39619fc42372c347d6006b64319?p=bt&ti%7Cc=v6.14-rc3&ti%7Cch=0ad2507d5d93f39619fc42372c347d6006b64319&ti%7Cgb=master&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Ftorvalds%2Flinux.git&ti%7Ct=mainline)
![image](https://github.com/user-attachments/assets/e0812914-57fa-43c7-a384-99e19484c2dd)

### `aaptel/nvme-rx-offload-v25`

[localhost](http://localhost:5173/tree/f5d74f9f7c3b2495596b43c01f5747b66c8ef70d?ti%7Cc=v6.9-12136-gf5d74f9f7c3b&ti%7Cch=f5d74f9f7c3b2495596b43c01f5747b66c8ef70d&ti%7Cgb=nvme-rx-offload-v25&ti%7Cgu=https%3A%2F%2Fgithub.com%2Faaptel%2Flinux.git&ti%7Ct=aaptel)
![image](https://github.com/user-attachments/assets/603fb95a-663b-4a1b-8a8c-dddbd945239e)


[staging](https://staging.dashboard.kernelci.org:9000/tree/f5d74f9f7c3b2495596b43c01f5747b66c8ef70d?p=bt&ti%7Cc=v6.9-12136-gf5d74f9f7c3b&ti%7Cch=f5d74f9f7c3b2495596b43c01f5747b66c8ef70d&ti%7Cgb=nvme-rx-offload-v25&ti%7Cgu=https%3A%2F%2Fgithub.com%2Faaptel%2Flinux.git&ti%7Ct=aaptel)
![image](https://github.com/user-attachments/assets/ddd215c5-2078-456b-af6c-f91f15511f21)


### `cip/linux-5.10.y-cip`
[localhost](http://localhost:5173/tree/f9ff2e9e3f65a5e6d7480becf629532229ef463d?p=bt&ti%7Cc=v5.10.234-cip57&ti%7Cch=f9ff2e9e3f65a5e6d7480becf629532229ef463d&ti%7Cgb=linux-5.10.y-cip&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fcip%2Flinux-cip.git&ti%7Ct=cip)
![image](https://github.com/user-attachments/assets/6a0eab85-3cb1-4150-b7c6-b779e9653bd1)


[staging](https://staging.dashboard.kernelci.org:9000/tree/f9ff2e9e3f65a5e6d7480becf629532229ef463d?p=bt&ti%7Cc=v5.10.234-cip57&ti%7Cch=f9ff2e9e3f65a5e6d7480becf629532229ef463d&ti%7Cgb=linux-5.10.y-cip&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fcip%2Flinux-cip.git&ti%7Ct=cip)
![image](https://github.com/user-attachments/assets/193417bd-2b24-4995-bda8-c746c762d732)

