### PR TITLE
Fix: colored circle opacity

### DIFF
--- a/dashboard/src/components/ColoredCircle/ColoredCircle.tsx
+++ b/dashboard/src/components/ColoredCircle/ColoredCircle.tsx
@@ -48,10 +48,7 @@ const ColoredCircle = ({
           className,
           backgroundClassName,
           {
-            ['bg-opacity-20']:
-              quantity === 0 &&
-              (tooltipText === 'global.failed' ||
-                tooltipText === 'global.inconclusive'),
+            'opacity-20': quantity === 0,
           },
         )}
       >

--- a/dashboard/src/components/Status/Status.tsx
+++ b/dashboard/src/components/Status/Status.tsx
@@ -36,20 +36,16 @@ export const GroupedTestStatus = ({
   });
   return (
     <div className="flex flex-row gap-1">
-      {
-        <ColoredCircle
-          quantity={successCount ?? 0}
-          tooltipText="global.success"
-          backgroundClassName="bg-light-green"
-        />
-      }
-      {
-        <ColoredCircle
-          quantity={failedCount}
-          tooltipText="global.failed"
-          backgroundClassName="bg-light-red"
-        />
-      }
+      <ColoredCircle
+        quantity={successCount ?? 0}
+        tooltipText="global.success"
+        backgroundClassName="bg-light-green"
+      />
+      <ColoredCircle
+        quantity={failedCount}
+        tooltipText="global.failed"
+        backgroundClassName="bg-light-red"
+      />
       {!hideInconclusive && (
         <ColoredCircle
           quantity={inconclusiveCount ?? 0}


### PR DESCRIPTION
Colored circles should have a lower opacity when the count is 0, even for successful circles.
This makes it easier to see when there are many 0s in a page while also knowing that there are 0s in that page

Before:
![image](https://github.com/user-attachments/assets/4fe89022-71ad-4bc0-bf5a-d8b65ab88184)

After:
![image](https://github.com/user-attachments/assets/d1363bc6-167c-4980-bdc2-2b7706e37203)

 
Closes #954