### PR TITLE
fix(api): excludes dummy builds from results

### DIFF
--- a/backend/kernelCI_app/constants/general.py
+++ b/backend/kernelCI_app/constants/general.py
@@ -1,4 +1,6 @@
-DEFAULT_ORIGIN = 'maestro'
+DEFAULT_ORIGIN = "maestro"
 
-UNKNOWN_STRING = 'Unknown'
+UNKNOWN_STRING = "Unknown"
 UNCATEGORIZED_STRING = "Uncategorized"
+
+MAESTRO_DUMMY_BUILD_PREFIX = "maestro:dummy_"

--- a/backend/kernelCI_app/views/hardwareView.py
+++ b/backend/kernelCI_app/views/hardwareView.py
@@ -14,7 +14,7 @@ from kernelCI_app.helpers.build import build_status_map
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
-from kernelCI_app.constants.general import UNKNOWN_STRING
+from kernelCI_app.constants.general import UNKNOWN_STRING, MAESTRO_DUMMY_BUILD_PREFIX
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.helpers.misc import env_misc_value_or_default, handle_environment_misc
 from kernelCI_app.helpers.trees import get_tree_heads
@@ -112,7 +112,9 @@ class HardwareView(APIView):
         self.hardware[current_hardware][status_count][test_status] += 1
 
         build_key = test["build__id"] + current_hardware
-        if build_key in self.processed_builds:
+        if build_key in self.processed_builds or test["build__id"].startswith(
+            MAESTRO_DUMMY_BUILD_PREFIX
+        ):
             return
 
         self.processed_builds.add(build_key)
@@ -122,7 +124,9 @@ class HardwareView(APIView):
         if build_status is not None:
             self.hardware[current_hardware]["build_status_summary"][build_status] += 1
         else:
-            log_message(f"Hardware Listing -> Unknown Build status: {test["build__valid"]}")
+            log_message(
+                f"Hardware Listing -> Unknown Build status: {test["build__valid"]}"
+            )
 
     def _get_results(
         self, start_date: datetime, end_date: datetime, origin: str

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -26,6 +26,7 @@ from kernelCI_app.typeModels.treeCommits import (
     TreeCommitsResponse,
 )
 from pydantic import ValidationError
+from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 
 
 # TODO Move this endpoint to a function so it doesn't
@@ -284,7 +285,11 @@ class TreeCommitsHistory(APIView):
 
         key = f"{build_id}_{commit_hash}"
 
-        if build_id is not None and key not in self.processed_builds:
+        if (
+            build_id is not None
+            and key not in self.processed_builds
+            and not build_id.startswith(MAESTRO_DUMMY_BUILD_PREFIX)
+        ):
             self._process_builds_count(
                 build_valid=row["build_valid"],
                 duration=row["build_duration"],

--- a/backend/kernelCI_app/views/treeDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBuildsView.py
@@ -19,6 +19,7 @@ from kernelCI_app.typeModels.treeDetails import (
     TreeDetailsBuildsResponse,
     TreeQueryParameters,
 )
+from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 
 
 class TreeDetailsBuilds(APIView):
@@ -53,7 +54,9 @@ class TreeDetailsBuilds(APIView):
             if is_record_filter_out:
                 continue
 
-            if row_data["build_id"] is not None:
+            if row_data["build_id"] is not None and not row_data["build_id"].startswith(
+                MAESTRO_DUMMY_BUILD_PREFIX
+            ):
                 self._process_builds(row_data)
 
     @extend_schema(

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -45,6 +45,7 @@ from rest_framework.views import APIView
 from kernelCI_app.viewCommon import create_details_build_summary
 from kernelCI_app.helpers.errorHandling import create_error_response
 from http import HTTPStatus
+from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 
 
 class TreeDetailsSummary(APIView):
@@ -154,7 +155,9 @@ class TreeDetailsSummary(APIView):
             if is_record_filter_out:
                 continue
 
-            if row_data["build_id"] is not None:
+            if row_data["build_id"] is not None and not row_data["build_id"].startswith(
+                MAESTRO_DUMMY_BUILD_PREFIX
+            ):
                 self._process_builds(row_data)
 
             if row_data["test_id"] is None:

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -49,6 +49,7 @@ from kernelCI_app.typeModels.treeDetails import (
     TreeDetailsFullResponse,
     TreeQueryParameters,
 )
+from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 
 
 class TreeDetails(APIView):
@@ -164,7 +165,9 @@ class TreeDetails(APIView):
             if is_record_filter_out:
                 continue
 
-            if row_data["build_id"] is not None:
+            if row_data["build_id"] is not None and not row_data["build_id"].startswith(
+                MAESTRO_DUMMY_BUILD_PREFIX
+            ):
                 self._process_builds(row_data)
 
             if row_data["test_id"] is None:

--- a/dashboard/src/components/BuildsTable/DefaultBuildsColumns.tsx
+++ b/dashboard/src/components/BuildsTable/DefaultBuildsColumns.tsx
@@ -20,7 +20,11 @@ export const defaultBuildColumns: ColumnDef<AccordionItemBuilds>[] = [
   {
     accessorKey: 'config',
     header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="global.config" />
+      <TableHeader
+        column={column}
+        intlKey="global.config"
+        tooltipId="build.dummyInfo"
+      />
     ),
   },
   {

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -22,6 +22,7 @@ export const messages = {
     'bootsTab.info.description':
       'ℹ️ There is no boot test data available for this tree',
     'bootsTab.success': 'Success',
+    'build.dummyInfo': 'Dummy builds are hidden from this table',
     'build.statusTooltip':
       'Success - builds completed successfully{br}' +
       'Failed - builds failed{br}' +


### PR DESCRIPTION
Modified the condition for processing builds to ignore dummy builds. This clause was not added to the query because this way it ensures that the tests related to dummy builds remain visible in the dashboard, even if the dummy build itself is filtered out

Closes #957

## How to test
- Any listing or details view should be showing builds with id starting `dummy:maestro_` but it shouldn't affect other tabs. Also make that other tests/boots/builds didn't disappear

## Example
### Tree details
[before (dashboard)](https://dashboard.kernelci.org/tree/4dbf08702466205b2e1d3cff0e12bfd1b067da14?ti%7Cc=v5.15.178-23959-g4dbf087024662&ti%7Cch=4dbf08702466205b2e1d3cff0e12bfd1b067da14&ti%7Cgb=chromeos-5.15&ti%7Cgu=https%3A%2F%2Fchromium.googlesource.com%2Fchromiumos%2Fthird_party%2Fkernel&ti%7Ct=chromiumos)
![image](https://github.com/user-attachments/assets/2c9e9df6-02dc-447d-b44d-ceba9fcce38e)


[after (localhost)](http://localhost:5173/tree/4dbf08702466205b2e1d3cff0e12bfd1b067da14?p=t&tf%7Cb=s&tf%7Cbt=a&tf%7Ct=a&ti%7Cc=v5.15.178-23959-g4dbf087024662&ti%7Cch=4dbf08702466205b2e1d3cff0e12bfd1b067da14&ti%7Cgb=chromeos-5.15&ti%7Cgu=https%3A%2F%2Fchromium.googlesource.com%2Fchromiumos%2Fthird_party%2Fkernel&ti%7Ct=chromiumos)
![image](https://github.com/user-attachments/assets/75e6f784-5c2b-48b2-9b42-69f49b766ba1)

### Tree Listing
[before (dashboard)](https://dashboard.kernelci.org/tree?ts=chromeos-5.15)
![image](https://github.com/user-attachments/assets/7023f7d4-a133-43f2-bf6d-dd1fc33c994b)


[after (localhost)](http://localhost:5173/tree?ts=chromeos-5.15)
![image](https://github.com/user-attachments/assets/0241f432-af9c-4f43-9182-89ce338b9bb5)
