### PR TITLE
feat: new hardware listing query

### DIFF
--- a/backend/kernelCI_app/helpers/database.py
+++ b/backend/kernelCI_app/helpers/database.py
@@ -1,0 +1,8 @@
+def dict_fetchall(cursor) -> list[dict]:
+    """
+    Return all rows from a cursor as a dict.
+    Assume the column names are unique.
+    This has a performance cost so avoid using it in large unprocessed data.
+    """
+    columns = [col[0] for col in cursor.description]
+    return [dict(zip(columns, row)) for row in cursor.fetchall()]

--- a/backend/kernelCI_app/typeModels/hardwareListing.py
+++ b/backend/kernelCI_app/typeModels/hardwareListing.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from pydantic import BaseModel
-from typing import List, TypedDict, Union, Set
+from typing import TypedDict
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
+from kernelCI_app.typeModels.databases import StatusValues
 
 
 class BuildStatusCountDict(TypedDict):
@@ -11,16 +12,16 @@ class BuildStatusCountDict(TypedDict):
     null: int
 
 
-class HardwareItem(TypedDict):
+class HardwareItem(BaseModel):
     hardware_name: str
-    platform: Union[str, Set[str]]
-    test_status_summary: dict[str, int]
-    boot_status_summary: dict[str, int]
+    platform: str | set[str]
+    test_status_summary: dict[StatusValues, int]
+    boot_status_summary: dict[StatusValues, int]
     build_status_summary: BuildStatusCountDict
 
 
 class HardwareResponse(BaseModel):
-    hardware: List[HardwareItem]
+    hardware: list[HardwareItem]
 
 
 # Since OpenAPI does not support timestamp as datetime we add an extra model just for

--- a/backend/kernelCI_app/views/hardwareView.py
+++ b/backend/kernelCI_app/views/hardwareView.py
@@ -1,8 +1,5 @@
-from collections import defaultdict
+from django.db import connection
 from datetime import datetime
-from typing import Dict, List, Set
-from django.db import models
-from django.db.models import Subquery
 from http import HTTPStatus
 
 from drf_spectacular.utils import extend_schema
@@ -10,159 +7,193 @@ from pydantic import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from kernelCI_app.helpers.build import build_status_map
+from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
-from kernelCI_app.constants.general import UNKNOWN_STRING, MAESTRO_DUMMY_BUILD_PREFIX
-from kernelCI_app.helpers.logger import log_message
-from kernelCI_app.helpers.misc import env_misc_value_or_default, handle_environment_misc
-from kernelCI_app.helpers.trees import get_tree_heads
-from kernelCI_app.models import Tests
+from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.typeModels.hardwareListing import (
     HardwareItem,
     HardwareQueryParams,
     HardwareQueryParamsDocumentationOnly,
     HardwareResponse,
 )
-from kernelCI_app.utils import is_boot
 
 
 class HardwareView(APIView):
-    def _make_hardware_item(self, *, compatible: str, platform: str) -> HardwareItem:
-        return {
-            "hardware_name": compatible,
-            "platform": platform,
-            "test_status_summary": defaultdict(int),
-            "boot_status_summary": defaultdict(int),
-            "build_status_summary": {"valid": 0, "invalid": 0, "null": 0},
-        }
-
     def _get_tests_from_database(
         self, start_date: datetime, end_date: datetime, origin: str
-    ):
-        checkouts_subquery = get_tree_heads(origin, start_date, end_date)
+    ) -> list[HardwareItem]:
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "origin": origin,
+        }
 
-        return Tests.objects.filter(
-            models.Q(environment_compatible__isnull=False)
-            | models.Q(environment_misc__platform__isnull=False),
-            start_time__gte=start_date,
-            start_time__lte=end_date,
-            build__checkout__origin=origin,
-            build__checkout__git_commit_hash__in=Subquery(checkouts_subquery),
-        ).values(
-            "environment_compatible",
-            "environment_misc",
-            "status",
-            "build__valid",
-            "path",
-            "build__id",
-            "id",
-        )
+        query = """
+            WITH relevant_tests AS (
+                SELECT
+                    "tests"."environment_compatible",
+                    "tests"."environment_misc",
+                    "tests"."status",
+                    "builds"."valid",
+                    "tests"."path",
+                    "tests"."build_id",
+                    "tests"."id"
+                FROM
+                    "tests"
+                INNER JOIN "builds" ON
+                    ("tests"."build_id" = "builds"."id")
+                INNER JOIN "checkouts" ON
+                    ("builds"."checkout_id" = "checkouts"."id")
+                WHERE
+                    (("tests"."environment_compatible" IS NOT NULL
+                        OR ("tests"."environment_misc" -> 'platform') IS NOT NULL)
+                        AND "checkouts"."git_commit_hash" IN (
+                        SELECT
+                            DISTINCT ON
+                            (U0."tree_name",
+                            U0."git_repository_branch",
+                            U0."git_repository_url") U0."git_commit_hash"
+                        FROM
+                            "checkouts" U0
+                        WHERE
+                            (U0."origin" = %(origin)s
+                                AND U0."start_time" >= %(start_date)s
+                                AND U0."start_time" <= %(end_date)s)
+                        ORDER BY
+                            U0."tree_name" ASC,
+                            U0."git_repository_branch" ASC,
+                            U0."git_repository_url" ASC,
+                            U0."start_time" DESC)
+                        AND "checkouts"."origin" = %(origin)s
+                        AND "tests"."start_time" >= %(start_date)s
+                        AND "tests"."start_time" <= %(end_date)s)
+                )
+                SELECT
+                    hardware,
+                    ARRAY_AGG(DISTINCT platform) AS platform,
+                    COUNT(DISTINCT CASE WHEN "valid" = TRUE AND build_id
+                                    NOT LIKE 'maestro:dummy_%%' THEN build_id END) AS valid_builds,
+                    COUNT(DISTINCT CASE WHEN "valid" = FALSE AND build_id
+                                    NOT LIKE 'maestro:dummy_%%' THEN build_id END) AS invalid_builds,
+                    COUNT(DISTINCT CASE WHEN "valid" IS NULL AND build_id IS
+                                    NOT NULL AND build_id NOT LIKE 'maestro:dummy_%%' THEN build_id END)
+                                    AS null_builds,
+                    COUNT(CASE WHEN ("path" <> 'boot' AND "path" NOT LIKE 'boot.%%')
+                                    AND "status" = 'FAIL' THEN 1 END) AS fail_tests,
+                    COUNT(CASE WHEN ("path" <> 'boot' AND "path" NOT LIKE 'boot.%%')
+                                    AND "status" = 'ERROR' THEN 1 END) AS error_tests,
+                    COUNT(CASE WHEN ("path" <> 'boot' AND "path" NOT LIKE 'boot.%%')
+                                    AND "status" = 'MISS' THEN 1 END) AS miss_tests,
+                    COUNT(CASE WHEN ("path" <> 'boot' AND "path" NOT LIKE 'boot.%%')
+                                    AND "status" = 'PASS' THEN 1 END) AS pass_tests,
+                    COUNT(CASE WHEN ("path" <> 'boot' AND "path" NOT LIKE 'boot.%%')
+                                    AND "status" = 'DONE' THEN 1 END) AS done_tests,
+                    COUNT(CASE WHEN ("path" <> 'boot' AND "path" NOT LIKE 'boot.%%')
+                                    AND "status" = 'SKIP' THEN 1 END) AS skip_tests,
+                    SUM(CASE WHEN ("path" <> 'boot' AND "path" NOT LIKE 'boot.%%')
+                                    AND "status" IS NULL AND id IS NOT NULL THEN 1 ELSE 0 END) AS null_tests,
+                    COUNT(CASE WHEN ("path" = 'boot' OR "path" LIKE 'boot.%%')
+                                    AND "status" = 'FAIL' THEN 1 END) AS fail_boots,
+                    COUNT(CASE WHEN ("path" = 'boot' OR "path" LIKE 'boot.%%')
+                                    AND "status" = 'ERROR' THEN 1 END) AS error_boots,
+                    COUNT(CASE WHEN ("path" = 'boot' OR "path" LIKE 'boot.%%')
+                                    AND "status" = 'MISS' THEN 1 END) AS miss_boots,
+                    COUNT(CASE WHEN ("path" = 'boot' OR "path" LIKE 'boot.%%')
+                                    AND "status" = 'PASS' THEN 1 END) AS pass_boots,
+                    COUNT(CASE WHEN ("path" = 'boot' OR "path" LIKE 'boot.%%')
+                                    AND "status" = 'DONE' THEN 1 END) AS done_boots,
+                    COUNT(CASE WHEN ("path" = 'boot' OR "path" LIKE 'boot.%%')
+                                    AND "status" = 'SKIP' THEN 1 END) AS skip_boots,
+                    SUM(CASE WHEN ("path" = 'boot' OR "path" LIKE 'boot.%%')
+                                    AND "status" IS NULL AND id IS NOT NULL THEN 1 ELSE 0 END) AS null_boots
+                FROM
+                    (
+                    SELECT
+                        UNNEST("environment_compatible") AS hardware,
+                        "environment_misc" ->> 'platform' AS platform,
+                        build_id,
+                        "valid",
+                        "path",
+                        status,
+                        id
+                    FROM
+                        relevant_tests
+                    WHERE
+                        "environment_compatible" IS NOT NULL
+                UNION
+                    SELECT
+                        "environment_misc" ->> 'platform' AS hardware,
+                        "environment_misc" ->> 'platform' AS platform,
+                        build_id,
+                        "valid",
+                        "path",
+                        status,
+                        id
+                    FROM
+                        relevant_tests
+                    WHERE
+                        "environment_misc" ->> 'platform' IS NOT NULL
+                        AND environment_compatible IS NULL
+                ) AS combined_data
+            GROUP BY
+        hardware;
+        """
+        hardwares: list[HardwareItem] = []
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            hardwares_raw = dict_fetchall(cursor)
 
-    def _handle_hardware_with_multiple_platforms(
-        self, *, platform: str, current_hardware_name: str
-    ):
-        current_hardware = self.hardware[current_hardware_name]
+            # TODO Move this logic to the pydantic model
+            for hardware in hardwares_raw:
+                platform = ""
+                match len(hardware["platform"]):
+                    case 0:
+                        platform = UNKNOWN_STRING
+                    case 1:
+                        platform = hardware["platform"][0]
+                    case _:
+                        platform = hardware["platform"]
 
-        if current_hardware is None:
-            return
+                hardwares.append(
+                    HardwareItem(
+                        hardware_name=hardware["hardware"],
+                        platform=platform,
+                        test_status_summary={
+                            "FAIL": hardware["fail_tests"],
+                            "ERROR": hardware["error_tests"],
+                            "MISS": hardware["miss_tests"],
+                            "PASS": hardware["pass_tests"],
+                            "DONE": hardware["done_tests"],
+                            "SKIP": hardware["skip_tests"],
+                            "NULL": hardware["null_tests"],
+                        },
+                        boot_status_summary={
+                            "FAIL": hardware["fail_boots"],
+                            "ERROR": hardware["error_boots"],
+                            "MISS": hardware["miss_boots"],
+                            "PASS": hardware["pass_boots"],
+                            "DONE": hardware["done_boots"],
+                            "SKIP": hardware["skip_boots"],
+                            "NULL": hardware["null_boots"],
+                        },
+                        build_status_summary={
+                            "valid": hardware["valid_builds"],
+                            "invalid": hardware["invalid_builds"],
+                            "null": hardware["null_builds"],
+                        },
+                    )
+                )
 
-        # Platform is a possible updater, if it is unknown there is nothing to update.
-        if platform is UNKNOWN_STRING:
-            return
-
-        if current_hardware["platform"] is UNKNOWN_STRING:
-            current_hardware["platform"] = platform
-            return
-
-        if current_hardware["platform"] == platform:
-            return
-
-        if isinstance(current_hardware["platform"], str):
-            current_platform = current_hardware["platform"]
-            current_hardware["platform"] = {current_platform}
-
-        current_hardware["platform"].add(platform)
-
-    def _process_hardware(
-        self, *, test, current_hardware: str, current_platform: str
-    ) -> None:
-        test_key = test["id"] + current_hardware
-        if test_key in self.processed_tests:
-            return
-
-        self.processed_tests.add(test_key)
-
-        if self.hardware.get(current_hardware) is None:
-            self.hardware[current_hardware] = self._make_hardware_item(
-                compatible=current_hardware, platform=current_platform
-            )
-
-        self._handle_hardware_with_multiple_platforms(
-            platform=current_platform, current_hardware_name=current_hardware
-        )
-
-        status_count = "test_status_summary"
-
-        if is_boot(test["path"]):
-            status_count = "boot_status_summary"
-
-        test_status = "NULL" if test["status"] is None else test["status"]
-        self.hardware[current_hardware][status_count][test_status] += 1
-
-        build_key = test["build__id"] + current_hardware
-        if build_key in self.processed_builds or test["build__id"].startswith(
-            MAESTRO_DUMMY_BUILD_PREFIX
-        ):
-            return
-
-        self.processed_builds.add(build_key)
-
-        build_status = build_status_map.get(test["build__valid"])
-
-        if build_status is not None:
-            self.hardware[current_hardware]["build_status_summary"][build_status] += 1
-        else:
-            log_message(
-                f"Hardware Listing -> Unknown Build status: {test["build__valid"]}"
-            )
+        return hardwares
 
     def _get_results(
         self, start_date: datetime, end_date: datetime, origin: str
     ) -> HardwareResponse:
-        self.processed_builds: Set[str] = set()
-        self.processed_tests: Set[str] = set()
-        self.hardware: Dict[str, HardwareItem] = {}
+        hardware = self._get_tests_from_database(start_date, end_date, origin)
 
-        tests = self._get_tests_from_database(start_date, end_date, origin)
-
-        for test in tests:
-            environment_misc = env_misc_value_or_default(
-                handle_environment_misc(test["environment_misc"])
-            )
-            platform = environment_misc["platform"]
-            environment_compatible = test["environment_compatible"]
-
-            if environment_compatible is None and platform is UNKNOWN_STRING:
-                continue
-
-            if environment_compatible is None:
-                self._process_hardware(
-                    test=test, current_hardware=platform, current_platform=platform
-                )
-                continue
-
-            for compatible in environment_compatible:
-                self._process_hardware(
-                    test=test, current_hardware=compatible, current_platform=platform
-                )
-
-        other_result: List[HardwareItem] = list(self.hardware.values())
-
-        result: HardwareResponse = HardwareResponse(hardware=other_result)
-
-        return result
+        return HardwareResponse(hardware=hardware)
 
     @extend_schema(
         parameters=[HardwareQueryParamsDocumentationOnly], responses=HardwareResponse


### PR DESCRIPTION
# Description
Refactor the hardware view to use raw SQL queries for fetching test
data, replacing the ORM-based approach. This change improves
performance by reducing the number of database queries and leveraging
SQL's capabilities for complex data aggregation.

- Add `dict_fetchall` helper function to convert cursor results to dict
- Update `HardwareItem` and `HardwareResponse` models to use Pydantic
- Remove unused imports and functions from `hardwareView.py`

## How To Test

- Run the project
- Go to http://localhost:5173/hardware
- And see if the data is the same that is in https://staging.dashboard.kernelci.org:9000/hardware
- Also, check the loading tab in the network tab and see how it doesn't take more than 5 seconds now (sometimes even less than 3)

Closes #937