### PR TITLE
Feat: add test status history to test details

### DIFF
--- a/backend/kernelCI_app/queries/test.py
+++ b/backend/kernelCI_app/queries/test.py
@@ -1,0 +1,61 @@
+import datetime
+from kernelCI_app.models import Tests
+
+
+def get_test_details_data(*, test_id):
+    return (
+        Tests.objects.filter(id=test_id)
+        .values(
+            "id",
+            "build_id",
+            "status",
+            "path",
+            "log_excerpt",
+            "log_url",
+            "misc",
+            "environment_misc",
+            "start_time",
+            "environment_compatible",
+            "output_files",
+            "field_timestamp",
+            "build__compiler",
+            "build__architecture",
+            "build__config_name",
+            "build__checkout__git_commit_hash",
+            "build__checkout__git_repository_branch",
+            "build__checkout__git_repository_url",
+            "build__checkout__git_commit_tags",
+            "build__checkout__tree_name",
+            "build__checkout__origin",
+        )
+        .first()
+    )
+
+
+# TODO: combine with the test_details query
+def get_test_status_history(
+    *,
+    path: str,
+    origin: str,
+    git_repository_url: str,
+    git_repository_branch: str,
+    platform: str,
+    current_test_timestamp: datetime,
+):
+    return (
+        Tests.objects.values(
+            "field_timestamp",
+            "id",
+            "status",
+            "build__checkout__git_commit_hash",
+        )
+        .filter(
+            path=path,
+            build__checkout__origin=origin,
+            build__checkout__git_repository_url=git_repository_url,
+            build__checkout__git_repository_branch=git_repository_branch,
+            environment_misc__platform=platform,
+            field_timestamp__lte=current_test_timestamp,
+        )
+        .order_by("-field_timestamp")[:10]
+    )

--- a/backend/kernelCI_app/typeModels/testDetails.py
+++ b/backend/kernelCI_app/typeModels/testDetails.py
@@ -1,3 +1,4 @@
+from typing import Literal
 from pydantic import BaseModel, Field
 
 from kernelCI_app.typeModels.databases import (
@@ -20,7 +21,19 @@ from kernelCI_app.typeModels.databases import (
     Checkout__GitRepositoryUrl,
     Checkout__GitCommitTags,
     Checkout__TreeName,
+    Timestamp,
 )
+
+type PossibleRegressionType = Literal["regression", "fixed", "unstable", "pass", "fail"]
+
+
+class TestStatusHistoryItem(BaseModel):
+    field_timestamp: Timestamp
+    id: Test__Id
+    status: Test__Status
+    git_commit_hash: Checkout__GitCommitHash = Field(
+        validation_alias="build__checkout__git_commit_hash"
+    )
 
 
 class TestDetailsResponse(BaseModel):
@@ -51,3 +64,5 @@ class TestDetailsResponse(BaseModel):
         validation_alias="build__checkout__git_commit_tags"
     )
     tree_name: Checkout__TreeName = Field(validation_alias="build__checkout__tree_name")
+    status_history: list[TestStatusHistoryItem]
+    regression_type: PossibleRegressionType

--- a/backend/kernelCI_app/unitTests/issues_test.py
+++ b/backend/kernelCI_app/unitTests/issues_test.py
@@ -8,7 +8,7 @@ from kernelCI_app.unitTests.utils.fields.issues import (
     issues_expected_fields,
     issues_listing_fields,
 )
-from kernelCI_app.unitTests.utils.fields.tests import test_expected_fields
+from kernelCI_app.unitTests.utils.fields.tests import issue_tests_expected_fields
 from kernelCI_app.unitTests.utils.fields.builds import build_expected_fields
 from kernelCI_app.utils import string_to_json
 import pytest
@@ -139,7 +139,7 @@ def test_issue_tests(issue_id, issue_version, status_code, has_error_body):
 
     if not has_error_body:
         assert_has_fields_in_response_content(
-            fields=test_expected_fields, response_content=content[0]
+            fields=issue_tests_expected_fields, response_content=content[0]
         )
 
 

--- a/backend/kernelCI_app/unitTests/utils/fields/tests.py
+++ b/backend/kernelCI_app/unitTests/utils/fields/tests.py
@@ -1,3 +1,14 @@
+issue_tests_expected_fields = [
+    "id",
+    "status",
+    "path",
+    "start_time",
+    "environment_compatible",
+    "environment_misc",
+    "tree_name",
+    "git_repository_branch",
+]
+
 test_expected_fields = [
     "id",
     "status",
@@ -7,4 +18,6 @@ test_expected_fields = [
     "environment_misc",
     "tree_name",
     "git_repository_branch",
+    "status_history",
+    "regression_type",
 ]

--- a/backend/kernelCI_app/views/testDetailsView.py
+++ b/backend/kernelCI_app/views/testDetailsView.py
@@ -1,7 +1,11 @@
 from http import HTTPStatus
 from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.models import Tests
-from kernelCI_app.typeModels.testDetails import TestDetailsResponse
+from kernelCI_app.queries.test import get_test_details_data, get_test_status_history
+from kernelCI_app.typeModels.databases import FAIL_STATUS, PASS_STATUS
+from kernelCI_app.typeModels.testDetails import (
+    PossibleRegressionType,
+    TestDetailsResponse,
+)
 from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -9,41 +13,74 @@ from pydantic import ValidationError
 
 
 class TestDetails(APIView):
+    # TODO: create unit tests for this method
+    def process_test_status_history(
+        self, *, status_history: list[dict]
+    ) -> PossibleRegressionType:
+        history_task: PossibleRegressionType
+        first_test_flag = True
+        status_changed = False
+
+        for test in status_history:
+            test_status = test["status"]
+            if first_test_flag:
+                if test_status == PASS_STATUS:
+                    history_task = "pass"
+                    starting_status = PASS_STATUS
+                    opposite_status = FAIL_STATUS
+                elif test_status == FAIL_STATUS:
+                    history_task = "fail"
+                    starting_status = FAIL_STATUS
+                    opposite_status = PASS_STATUS
+                else:
+                    return "unstable"
+                first_test_flag = False
+                continue
+
+            is_inconclusive = test_status != PASS_STATUS and test_status != FAIL_STATUS
+
+            if test_status == opposite_status:
+                status_changed = True
+                if history_task == "pass":
+                    history_task = "fixed"
+                elif history_task == "fail":
+                    history_task = "regression"
+            if (status_changed and test_status == starting_status) or is_inconclusive:
+                return "unstable"
+
+        return history_task
+
     @extend_schema(
         responses=TestDetailsResponse,
     )
     def get(self, _request, test_id: str) -> Response:
-        fields = [
-            "id",
-            "build_id",
-            "status",
-            "path",
-            "log_excerpt",
-            "log_url",
-            "misc",
-            "environment_misc",
-            "start_time",
-            "environment_compatible",
-            "output_files",
-            "build__compiler",
-            "build__architecture",
-            "build__config_name",
-            "build__checkout__git_commit_hash",
-            "build__checkout__git_repository_branch",
-            "build__checkout__git_repository_url",
-            "build__checkout__git_commit_tags",
-            "build__checkout__tree_name",
-        ]
 
-        response = Tests.objects.filter(id=test_id).values(*fields).first()
+        response = get_test_details_data(test_id=test_id)
 
         if response is None:
             return create_api_error_response(
                 error_message="Test not found", status_code=HTTPStatus.OK
             )
 
+        status_history_response = get_test_status_history(
+            path=response["path"],
+            origin=response["build__checkout__origin"],
+            git_repository_url=response["build__checkout__git_repository_url"],
+            git_repository_branch=response["build__checkout__git_repository_branch"],
+            platform=response["environment_misc"]["platform"],
+            current_test_timestamp=response["field_timestamp"],
+        )
+
+        regression_type = self.process_test_status_history(
+            status_history=status_history_response
+        )
+
         try:
-            valid_response = TestDetailsResponse(**response)
+            valid_response = TestDetailsResponse(
+                **response,
+                status_history=status_history_response,
+                regression_type=regression_type,
+            )
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 

--- a/backend/requests/tree-details-get.sh
+++ b/backend/requests/tree-details-get.sh
@@ -1,1 +1,118 @@
-http 'http://localhost:8000/api/tree/b7bfaa761d760e72a969d116517eaa12e404c262/full' git_branch==for-kernelci git_url==https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git origin==maestro
+http 'http://localhost:8000/api/test/maestro%3A678ee7b046f65f378a18d33e'
+
+# HTTP/1.1 200 OK
+# Allow: GET, HEAD, OPTIONS
+# Cache-Control: max-age=0
+# Content-Length: 20004
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Fri, 28 Feb 2025 12:48:28 GMT
+# Expires: Fri, 28 Feb 2025 12:48:28 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "architecture": "arm64",
+#     "build_id": "maestro:678eddbf46f65f378a1850b3",
+#     "compiler": "gcc-12",
+#     "config_name": "defconfig",
+#     "environment_compatible": [
+#         "libretech,aml-a311d-cc",
+#         "amlogic,a311d",
+#         "amlogic,g12b"
+#     ],
+#     "environment_misc": {
+#         "platform": "meson-g12b-a311d-libretech-cc"
+#     },
+#     "git_commit_hash": "d73a4602e973e9e922f00c537a4643907a547ade",
+#     "git_commit_tags": [],
+#     "git_repository_branch": "main",
+#     "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git",
+#     "id": "maestro:678ee7b046f65f378a18d33e",
+#     "log_excerpt": "BL33 decompress pass\nERROR:   Error initializing runtime service opteed_fast\nU-Boot 2024.01-rc4+ (Dec 14 2023 - 01:31:33 -0500) Libre Computer AML-A311D-CC\nModel: Libre Computer AML-A311D-CC Alta\nSoC:   Amlogic Meson G12B (A311D) Revision 29:b (10:2)\nDRAM:  2 GiB (effective 3.8 GiB)\nCore:  408 devices, 31 uclasses, devicetree: separate\nWDT:   Not starting watchdog@f0d0\nMMC:   mmc@ffe05000: 1, mmc@ffe07000: 0\nLoading Environment from FAT... Card did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCard did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCouldn't find partition mmc 0\nCard did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCouldn't find partition mmc 0\nError: could not access storage.\nG12B:BL:6e7c85:2a3b91;FEAT:E0F83180:402000;POC:B;RCY:0;SPINOR:0;0.\nbl2_stage_init 0x01\nbl2_stage_init 0x81\nhw id: 0x0000 - pwm id 0x01\nbl2_stage_init 0xc1\nbl2_stage_init 0x02\nL0:00000000\nL1:20000703\nL2:00008067\nL3:14000000\nB2:00402000\nB1:e0f83180\nTE: 58159\nBL2 Built : 15:22:05, Aug 28 2019. g12b g1bf2b53 - luan.yuan@droid15-sz\nBoard ID = 1\nSet A53 clk to 24M\nSet A73 clk to 24M\nSet clk81 to 24M\nA53 clk: 1200 MHz\nA73 clk: 1200 MHz\nCLK81: 166.6M\nsmccc: 00012ab4\nDDR driver_vesion: LPDDR4_PHY_V_0_1_18 build time: Aug 28 2019 15:22:01\nboard id: 1\nLoad FIP HDR from SPI, src: 0x00010000, des: 0xfffd0000, size: 0x00004000, part: 0\nfw parse done\nLoad ddrfw from SPI, src: 0x00030000, des: 0xfffd0000, size: 0x0000c000, part: 0\nLoad ddrfw from SPI, src: 0x00014000, des: 0xfffd0000, size: 0x00004000, part: 0\nPIEI prepare done\nfastboot data load\nfastboot data verify\nverify result: 266\nCfg max: 1, cur: 1. Board id: 255. Force loop cfg\nLPDDR4 probe\nddr clk to 1584MHz\nLoad ddrfw from SPI, src: 0x00018000, des: 0xfffd0000, size: 0x0000c000, part: 0\ndmc_version 0001\nCheck phy result\nINFO : End of CA training\nINFO : End of initialization\nINFO : Training has run successfully!\nCheck phy result\nINFO : End of initialization\nINFO : End of read enable training\nINFO : End of fine write leveling\nINFO : End of Write leveling coarse delay\nINFO : Training has run successfully!\nCheck phy result\nINFO : End of initialization\nINFO : End of read dq deskew training\nINFO : End of MPR read delay center optimization\nINFO : End of write delay center optimization\nINFO : End of read delay center optimization\nINFO : End of max read latency training\nINFO : Training has run successfully!\n1D training succeed\nLoad ddrfw from SPI, src: 0x00024000, des: 0xfffd0000, size: 0x0000c000, part: 0\nCheck phy result\nINFO : End of initialization\nINFO : End of 2D read delay Voltage center optimization\nINFO : End of 2D read delay Voltage center optimization\nINFO : End of 2D write delay Voltage center optimization\nINFO : End of 2D write delay Voltage center optimization\nINFO : Training has run successfully!\nchannel==0\nRxClkDly_Margin_A0==88 ps 9\nTxDqDly_Margin_A0==98 ps 10\nRxClkDly_Margin_A1==88 ps 9\nTxDqDly_Margin_A1==98 ps 10\nTrainedVREFDQ_A0==74\nTrainedVREFDQ_A1==74\nVrefDac_Margin_A0==24\nDeviceVref_Margin_A0==40\nVrefDac_Margin_A1==25\nDeviceVref_Margin_A1==40\nchannel==1\nRxClkDly_Margin_A0==98 ps 10\nTxDqDly_Margin_A0==88 ps 9\nRxClkDly_Margin_A1==98 ps 10\nTxDqDly_Margin_A1==88 ps 9\nTrainedVREFDQ_A0==75\nTrainedVREFDQ_A1==77\nVrefDac_Margin_A0==23\nDeviceVref_Margin_A0==38\nVrefDac_Margin_A1==24\nDeviceVref_Margin_A1==37\ndwc_ddrphy_apb_wr((0<<20)|(2<<16)|(0<<12)|(0xb0):0004\nsoc_vref_reg_value 0x 00000019 0000001a 00000017 00000019 00000018 00000019 00000018 00000018 00000018 00000016 00000018 00000015 00000017 00000019 00000017 00000019 00000018 00000019 00000019 00000018 00000016 00000018 00000018 00000019 00000018 00000017 00000019 00000019 0000001a 00000017 00000019 00000017 dram_vref_reg_value 0x 00000060\n2D training succeed\naml_ddr_fw_vesion: LPDDR4_PHY_V_0_1_18 build time: Aug 28 2019 13:54:19\nauto size-- 65535DDR cs0 size: 2048MB\nDDR cs1 size: 2048MB\nDMC_DDR_CTRL: 00e00024DDR size: 3928MB\ncs0 DataBus test pass\ncs1 DataBus test pass\ncs0 AddrBus test pass\ncs1 AddrBus test pass\n100bdlr_step_size ps== 420\nresult report\nboot times 0Enable ddr reg access\nLoad FIP HDR from SPI, src: 0x00010000, des: 0x01700000, size: 0x00004000, part: 0\nLoad BL3X from SPI, src: 0x0003c000, des: 0x0172c000, size: 0x000c0000, part: 0\n0.0;M3 CHK:0;cm4_sp_mode 0\nMVN_1=0x00000000\nMVN_2=0x00000000\n[Image: g12b_v1.1.3390-6ac5299 2019-09-26 14:10:05 luan.yuan@droid15-sz]\nOPS=0x10\nring efuse init\nchipver efuse init\n29 0b 10 00 01 05 19 00 00 17 38 33 33 42 42 50\n[0.018960 Inits done]\nsecure task start!\nhigh task start!\nlow task start!\nrun into bl31\nNOTICE:  BL31: v1.3(release):4fc40b1\nNOTICE:  BL31: Built : 15:58:17, May 22 2019\nNOTICE:  BL31: G12A normal boot!\nNOTICE:  BL31: BL33 decompress pass\nERROR:   Error initializing runtime service opteed_fast\nU-Boot 2024.01-rc4+ (Dec 14 2023 - 01:31:33 -0500) Libre Computer AML-A311D-CC\nModel: Libre Computer AML-A311D-CC Alta\nSoC:   Amlogic Meson G12B (A311D) Revision 29:b (10:2)\nDRAM:  2 GiB (effective 3.8 GiB)\nCore:  408 devices, 31 uclasses, devicetree: separate\nWDT:   Not starting watchdog@f0d0\nMMC:   mmc@ffe05000: 1, mmc@ffe07000: 0\nLoading Environment from FAT... Card did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCard did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCouldn't find partition mmc 0\nCard did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCouldn't find partition mmc 0\nError: could not access storage.\nNet:   eth0: ethernet@ff3f0000\nstarting USB...\nBus usb@ff500000: Register 3000140 NbrPorts 3\nStarting the controller\nUSB XHCI 1.10\nscanning bus usb@ff500000 for devices... G12B:BL:6e7c85:2a3b91;FEAT:E0F83180:402000;POC:B;RCY:0;SPINOR:0;0.\nbl2_stage_init 0x01\nbl2_stage_init 0x81\nhw id: 0x0000 - pwm id 0x01\nbl2_stage_init 0xc1\nbl2_stage_init 0x02\nL0:00000000\nL1:20000703\nL2:00008067\nL3:14000000\nB2:00402000\nB1:e0f83180\nTE: 58167\nBL2 Built : 15:22:05, Aug 28 2019. g12b g1bf2b53 - luan.yuan@droid15-sz\nBoard ID = 1\nSet A53 clk to 24M\nSet A73 clk to 24M\nSet clk81 to 24M\nA53 clk: 1200 MHz\nA73 clk: 1200 MHz\nCLK81: 166.6M\nsmccc: 00012abd\nDDR driver_vesion: LPDDR4_PHY_V_0_1_18 build time: Aug 28 2019 15:22:01\nboard id: 1\nLoad FIP HDR from SPI, src: 0x00010000, des: 0xfffd0000, size: 0x00004000, part: 0\nfw parse done\nLoad ddrfw from SPI, src: 0x00030000, des: 0xfffd0000, size: 0x0000c000, part: 0\nLoad ddrfw from SPI, src: 0x00014000, des: 0xfffd0000, size: 0x00004000, part: 0\nPIEI prepare done\nfastboot data load\nfastboot data verify\nverify result: 266\nCfg max: 1, cur: 1. Board id: 255. Force loop cfg\nLPDDR4 probe\nddr clk to 1584MHz\nLoad ddrfw from SPI, src: 0x00018000, des: 0xfffd0000, size: 0x0000c000, part: 0\ndmc_version 0001\nCheck phy result\nINFO : End of CA training\nINFO : End of initialization\nINFO : Training has run successfully!\nCheck phy result\nINFO : End of initialization\nINFO : End of read enable training\nINFO : End of fine write leveling\nINFO : End of Write leveling coarse delay\nINFO : Training has run successfully!\nCheck phy result\nINFO : End of initialization\nINFO : End of read dq deskew training\nINFO : End of MPR read delay center optimization\nINFO : End of write delay center optimization\nINFO : End of read delay center optimization\nINFO : End of max read latency training\nINFO : Training has run successfully!\n1D training succeed\nLoad ddrfw from SPI, src: 0x00024000, des: 0xfffd0000, size: 0x0000c000, part: 0\nCheck phy result\nINFO : End of initialization\nINFO : End of 2D read delay Voltage center optimization\nINFO : End of 2D read delay Voltage center optimization\nINFO : End of 2D write delay Voltage center optimization\nINFO : End of 2D write delay Voltage center optimization\nINFO : Training has run successfully!\nchannel==0\nRxClkDly_Margin_A0==88 ps 9\nTxDqDly_Margin_A0==98 ps 10\nRxClkDly_Margin_A1==88 ps 9\nTxDqDly_Margin_A1==98 ps 10\nTrainedVREFDQ_A0==74\nTrainedVREFDQ_A1==75\nVrefDac_Margin_A0==24\nDeviceVref_Margin_A0==40\nVrefDac_Margin_A1==25\nDeviceVref_Margin_A1==39\nchannel==1\nRxClkDly_Margin_A0==98 ps 10\nTxDqDly_Margin_A0==98 ps 10\nRxClkDly_Margin_A1==88 ps 9\nTxDqDly_Margin_A1==88 ps 9\nTrainedVREFDQ_A0==77\nTrainedVREFDQ_A1==77\nVrefDac_Margin_A0==22\nDeviceVref_Margin_A0==37\nVrefDac_Margin_A1==24\nDeviceVref_Margin_A1==37\ndwc_ddrphy_apb_wr((0<<20)|(2<<16)|(0<<12)|(0xb0):0004\nsoc_vref_reg_value 0x 00000019 0000001a 00000017 00000019 00000018 00000019 00000018 00000018 00000018 00000016 00000018 00000015 00000017 00000019 00000017 00000019 00000018 0000001a 00000019 00000018 00000016 00000018 00000018 00000019 00000018 00000018 00000019 00000019 0000001a 00000017 00000018 00000017 dram_vref_reg_value 0x 00000060\n2D training succeed\naml_ddr_fw_vesion: LPDDR4_PHY_V_0_1_18 build time: Aug 28 2019 13:54:19\nauto size-- 65535DDR cs0 size: 2048MB\nDDR cs1 size: 2048MB\nDMC_DDR_CTRL: 00e00024DDR size: 3928MB\ncs0 DataBus test pass\ncs1 DataBus test pass\ncs0 AddrBus test pass\ncs1 AddrBus test pass\n100bdlr_step_size ps== 420\nresult report\nboot times 0Enable ddr reg access\nLoad FIP HDR from SPI, src: 0x00010000, des: 0x01700000, size: 0x00004000, part: 0\nLoad BL3X from SPI, src: 0x0003c000, des: 0x0172c000, size: 0x000c0000, part: 0\n0.0;M3 CHK:0;cm4_sp_mode 0\nMVN_1=0x00000000\nMVN_2=0x00000000\n[Image: g12b_v1.1.3390-6ac5299 2019-09-26 14:10:05 luan.yuan@droid15-sz]\nOPS=0x10\nring efuse init\nchipver efuse init\n29 0b 10 00 01 05 19 00 00 17 38 33 33 42 42 50\n[0.018961 Inits done]\nsecure task start!\nhigh task start!\nlow task start!\nrun into bl31\nNOTICE:  BL31: v1.3(release):4fc40b1\nNOTICE:  BL31: Built : 15:58:17, May 22 2019\nNOTICE:  BL31: G12A normal boot!\nNOTICE:  BL31: BL33 decompress pass\nERROR:   Error initializing runtime service opteed_fast\nU-Boot 2024.01-rc4+ (Dec 14 2023 - 01:31:33 -0500) Libre Computer AML-A311D-CC\nModel: Libre Computer AML-A311D-CC Alta\nSoC:   Amlogic Meson G12B (A311D) Revision 29:b (10:2)\nDRAM:  2 GiB (effective 3.8 GiB)\nCore:  408 devices, 31 uclasses, devicetree: separate\nWDT:   Not starting watchdog@f0d0\nMMC:   mmc@ffe05000: 1, mmc@ffe07000: 0\nLoading Environment from FAT... Card did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCard did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCouldn't find partition mmc 0\nCard did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCouldn't find partition mmc 0\nError: could not access storage.\nNet:   eth0: ethernet@ff3f0000\nstarting USB...\nBus usb@ff500000: Register 3000140 NbrPorts 3\nStarting the controller\nUSB XHCI 1.10\nscanning bus usb@ff500000 for devices... G12B:BL:6e7c85:2a3b91;FEAT:E0F83180:402000;POC:B;RCY:0;SPINOR:0;0.�!,K��х��}���с0x01\nbl2_stage_init 0x81\nhw id: 0x0000 - pwm id 0x01\nbl2_stage_init 0xc1\nbl2_stage_init 0x02\nL0:00000000\nL1:20000703\nL2:00008067\nL3:14000000\nB2:00402000\nB1:e0f83180\nTE: 58150\nBL2 Built : 15:22:05, Aug 28 2019. g12b g1bf2b53 - luan.yuan@droid15-sz\nBoard ID = 1\nSet A53 clk to 24M\nSet A73 clk to 24M\nSet clk81 to 24M\nA53 clk: 1200 MHz\nA73 clk: 1200 MHz\nCLK81: 166.6M\nsmccc: 00012aac\nDDR driver_vesion: LPDDR4_PHY_V_0_1_18 build time: Aug 28 2019 15:22:01\nboard id: 1\nLoad FIP HDR from SPI, src: 0x00010000, des: 0xfffd0000, size: 0x00004000, part: 0\nfw parse done\nLoad ddrfw from SPI, src: 0x00030000, des: 0xfffd0000, size: 0x0000c000, part: 0\nLoad ddrfw from SPI, src: 0x00014000, des: 0xfffd0000, size: 0x00004000, part: 0\nPIEI prepare done\nfastboot data load\nfastboot data verify\nverify result: 266\nCfg max: 1, cur: 1. Board id: 255. Force loop cfg\nLPDDR4 probe\nddr clk to 1584MHz\nLoad ddrfw from SPI, src: 0x00018000, des: 0xfffd0000, size: 0x0000c000, part: 0\ndmc_version 0001\nCheck phy result\nINFO : End of CA training\nINFO : End of initialization\nINFO : Training has run successfully!\nCheck phy result\nINFO : End of initialization\nINFO : End of read enable training\nINFO : End of fine write leveling\nINFO : End of Write leveling coarse delay\nINFO : Training has run successfully!\nCheck phy result\nINFO : End of initialization\nINFO : End of read dq deskew training\nINFO : End of MPR read delay center optimization\nINFO : End of write delay center optimization\nINFO : End of read delay center optimization\nINFO : End of max read latency training\nINFO : Training has run successfully!\n1D training succeed\nLoad ddrfw from SPI, src: 0x00024000, des: 0xfffd0000, size: 0x0000c000, part: 0\nCheck phy result\nINFO : End of initialization\nINFO : End of 2D read delay Voltage center optimization\nINFO : End of 2D read delay Voltage center optimization\nINFO : End of 2D write delay Voltage center optimization\nINFO : End of 2D write delay Voltage center optimization\nINFO : Training has run successfully!\nchannel==0\nRxClkDly_Margin_A0==88 ps 9\nTxDqDly_Margin_A0==98 ps 10\nRxClkDly_Margin_A1==88 ps 9\nTxDqDly_Margin_A1==98 ps 10\nTrainedVREFDQ_A0==74\nTrainedVREFDQ_A1==74\nVrefDac_Margin_A0==25\nDeviceVref_Margin_A0==40\nVrefDac_Margin_A1==25\nDeviceVref_Margin_A1==40\nchannel==1\nRxClkDly_Margin_A0==98 ps 10\nTxDqDly_Margin_A0==98 ps 10\nRxClkDly_Margin_A1==98 ps 10\nTxDqDly_Margin_A1==88 ps 9\nTrainedVREFDQ_A0==77\nTrainedVREFDQ_A1==77\nVrefDac_Margin_A0==23\nDeviceVref_Margin_A0==37\nVrefDac_Margin_A1==22\nDeviceVref_Margin_A1==37\ndwc_ddrphy_apb_wr((0<<20)|(2<<16)|(0<<12)|(0xb0):0004\nsoc_vref_reg_value 0x 00000019 0000001a 00000017 00000019 00000018 00000019 00000018 00000017 00000017 00000016 00000017 00000015 00000018 00000019 00000017 00000019 00000018 00000019 0000001a 00000018 00000016 00000018 00000018 00000019 00000018 00000018 00000019 00000019 0000001a 00000016 00000018 00000017 dram_vref_reg_value 0x 00000060\n2D training succeed\naml_ddr_fw_vesion: LPDDR4_PHY_V_0_1_18 build time: Aug 28 2019 13:54:19\nauto size-- 65535DDR cs0 size: 2048MB\nDDR cs1 size: 2048MB\nDMC_DDR_CTRL: 00e00024DDR size: 3928MB\ncs0 DataBus test pass\ncs1 DataBus test pass\ncs0 AddrBus test pass\ncs1 AddrBus test pass\n100bdlr_step_size ps== 420\nresult report\nboot times 0Enable ddr reg access\nLoad FIP HDR from SPI, src: 0x00010000, des: 0x01700000, size: 0x00004000, part: 0\nLoad BL3X from SPI, src: 0x0003c000, des: 0x0172c000, size: 0x000c0000, part: 0\n0.0;M3 CHK:0;cm4_sp_mode 0\nMVN_1=0x00000000\nMVN_2=0x00000000\n[Image: g12b_v1.1.3390-6ac5299 2019-09-26 14:10:05 luan.yuan@droid15-sz]\nOPS=0x10\nring efuse init\nchipver efuse init\n29 0b 10 00 01 05 19 00 00 17 38 33 33 42 42 50\n[0.018961 Inits done]\nsecure task start!\nhigh task start!\nlow task start!\nrun into bl31\nNOTICE:  BL31: v1.3(release):4fc40b1\nNOTICE:  BL31: Built : 15:58:17, May 22 2019\nNOTICE:  BL31: G12A normal boot!\nNOTICE:  BL31: BL33 decompress pass\nERROR:   Error initializing runtime service opteed_fast\nU-Boot 2024.01-rc4+ (Dec 14 2023 - 01:31:33 -0500) Libre Computer AML-A311D-CC\nModel: Libre Computer AML-A311D-CC Alta\nSoC:   Amlogic Meson G12B (A311D) Revision 29:b (10:2)\nDRAM:  2 GiB (effective 3.8 GiB)\nCore:  408 devices, 31 uclasses, devicetree: separate\nWDT:   Not starting watchdog@f0d0\nMMC:   mmc@ffe05000: 1, mmc@ffe07000: 0\nLoading Environment from FAT... Card did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCard did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCouldn't find partition mmc 0\nCard did not respond to voltage select! : -110\n** Bad device specification mmc 0 **\nCouldn't find partition mmc 0\nError: could not access storage.\nNet:   eth0: ethernet@ff3f0000\nstarting USB...\nBus usb@ff500000: Register 3000140 NbrPorts 3\nStarting the controller\nUSB XHCI 1.10\nscanning bus usb@ff500000 for devices... 3 USB Device(s) found\nscanning usb for storage devices... 0 Storage Device(s) found\nHit any key to stop autoboot:  1\n??? 0\n=> setenv autoload no\nsetenv autoload no\n=> setenv initrd_high 0xffffffff\nsetenv initrd_high 0xffffffff\n=> setenv fdt_high 0xffffffff\nsetenv fdt_high 0xffffffff\n=> dhcp\ndhcp\nSpeed: 1000, full duplex\nBOOTP broadcast 1\nDHCP client bound to address 192.168.7.181 (238 ms)\n=> setenv serverip 192.168.6.2\nsetenv serverip 192.168.6.2\n=> tftpboot 0x01080000 1072814/tftp-deploy-gc_l3wwh/kernel/uImage\ntftpboot 0x01080000 1072814/tftp-deploy-gc_l3wwh/kernel/uImage\nSpeed: 1000, full duplex\nUsing ethernet@ff3f0000 device\nTFTP from server 192.168.6.2; our IP address is 192.168.7.181\nFilename '1072814/tftp-deploy-gc_l3wwh/kernel/uImage'.\nLoad address: 0x1080000\nLoading: *?T T T T T T T T T T\nRetry count exceeded; starting again\n=>\n",
+#     "log_url": "https://kciapistagingstorage1.file.core.windows.net/production/baseline-arm64-broonie-678ee7b046f65f378a18d33e/log.txt.gz?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D",
+#     "misc": {
+#         "arch": "arm64",
+#         "compiler": "gcc-12",
+#         "error_code": "Infrastructure",
+#         "error_msg": "matched a bootloader error message: 'Retry count exceeded' (4)",
+#         "kernel_type": "image",
+#         "runtime": "lava-broonie"
+#     },
+#     "output_files": [
+#         {
+#             "name": "callback_data",
+#             "url": "https://kciapistagingstorage1.file.core.windows.net/production/baseline-arm64-broonie-678ee7b046f65f378a18d33e/lava_callback.json.gz?sv=2022-11-02&ss=f&srt=sco&sp=r&se=2026-10-18T13:36:18Z&st=2024-10-17T05:36:18Z&spr=https&sig=xFxYOOh5uXJWeN9I3YKAUvpGGQivo89HKZbD78gcxvc%3D"
+#         }
+#     ],
+#     "path": "boot",
+#     "regression_type": "unstable",
+#     "start_time": "2025-01-21T00:17:52.855000Z",
+#     "status": "MISS",
+#     "status_history": [
+#         {
+#             "field_timestamp": "2025-01-21T00:24:05.705873Z",
+#             "git_commit_hash": "d73a4602e973e9e922f00c537a4643907a547ade",
+#             "id": "maestro:678ee7b046f65f378a18d33e",
+#             "status": "MISS"
+#         },
+#         {
+#             "field_timestamp": "2025-01-20T15:22:05.948330Z",
+#             "git_commit_hash": "64ff63aeefb03139ae27454bd4208244579ae88e",
+#             "id": "maestro:678e592546f65f378a15d3c1",
+#             "status": "PASS"
+#         },
+#         {
+#             "field_timestamp": "2025-01-20T13:10:01.093219Z",
+#             "git_commit_hash": "5fe71fda89745fc3cd95f70d06e9162b595c3702",
+#             "id": "maestro:678e4a0946f65f378a158459",
+#             "status": "PASS"
+#         },
+#         {
+#             "field_timestamp": "2025-01-20T11:26:01.225745Z",
+#             "git_commit_hash": "45bd1c5ba7580f612e46f3c6cb430c64adfd0294",
+#             "id": "maestro:678e30f546f65f378a151e05",
+#             "status": "FAIL"
+#         },
+#         {
+#             "field_timestamp": "2025-01-19T03:10:05.623899Z",
+#             "git_commit_hash": "59372af69d4d71e6487614f1b35712cf241eadb4",
+#             "id": "maestro:678c6b447adb323264c66a80",
+#             "status": "PASS"
+#         },
+#         {
+#             "field_timestamp": "2025-01-18T05:40:01.280900Z",
+#             "git_commit_hash": "41c5d104f338b21b98aee5a207336c281325583f",
+#             "id": "maestro:678b3dd77adb323264c529af",
+#             "status": "PASS"
+#         },
+#         {
+#             "field_timestamp": "2025-01-18T04:36:00.846297Z",
+#             "git_commit_hash": "3df22e75102785bac1768f7eeabbc45c01a6e7f4",
+#             "id": "maestro:678b2de47adb323264c4e58f",
+#             "status": "FAIL"
+#         },
+#         {
+#             "field_timestamp": "2025-01-17T05:49:01.279497Z",
+#             "git_commit_hash": "7d2eba0f83a59d360ed1e77ed2778101a6e3c4a1",
+#             "id": "maestro:6789eea37adb323264c10476",
+#             "status": "PASS"
+#         },
+#         {
+#             "field_timestamp": "2025-01-17T03:09:01.100522Z",
+#             "git_commit_hash": "3030e3d57ba8d0f59bd8162b3b1f3f7ee273f280",
+#             "id": "maestro:6789c9027adb323264c0333f",
+#             "status": "PASS"
+#         },
+#         {
+#             "field_timestamp": "2025-01-16T21:42:01.164556Z",
+#             "git_commit_hash": "2ee738e90e80850582cbe10f34c6447965c1d87b",
+#             "id": "maestro:67897c4f7adb323264bef0b4",
+#             "status": "PASS"
+#         }
+#     ],
+#     "tree_name": "net-next"
+# }

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -2514,6 +2514,14 @@ components:
       - stable
       - linux-next
       type: string
+    PossibleRegressionType:
+      enum:
+      - regression
+      - fixed
+      - unstable
+      - pass
+      - fail
+      type: string
     ProcessedExtraDetailedIssues:
       additionalProperties:
         $ref: '#/components/schemas/ExtraIssuesData'
@@ -2612,6 +2620,13 @@ components:
           $ref: '#/components/schemas/Checkout__GitCommitTags'
         tree_name:
           $ref: '#/components/schemas/Checkout__TreeName'
+        status_history:
+          items:
+            $ref: '#/components/schemas/TestStatusHistoryItem'
+          title: Status History
+          type: array
+        regression_type:
+          $ref: '#/components/schemas/PossibleRegressionType'
       required:
       - id
       - build_id
@@ -2632,6 +2647,8 @@ components:
       - git_repository_url
       - git_commit_tags
       - tree_name
+      - status_history
+      - regression_type
       title: TestDetailsResponse
       type: object
     TestHistoryItem:
@@ -2747,6 +2764,23 @@ components:
           default: 0
           title: 'Null'
       title: TestStatusCount
+      type: object
+    TestStatusHistoryItem:
+      properties:
+        field_timestamp:
+          $ref: '#/components/schemas/Timestamp'
+        id:
+          $ref: '#/components/schemas/Test__Id'
+        status:
+          $ref: '#/components/schemas/Test__Status'
+        git_commit_hash:
+          $ref: '#/components/schemas/Checkout__GitCommitHash'
+      required:
+      - field_timestamp
+      - id
+      - status
+      - git_commit_hash
+      title: TestStatusHistoryItem
       type: object
     TestSummary:
       properties:

--- a/dashboard/src/components/Icons/TooltipIcon.tsx
+++ b/dashboard/src/components/Icons/TooltipIcon.tsx
@@ -1,0 +1,36 @@
+import type { JSX } from 'react';
+
+import { LiaQuestionCircle } from 'react-icons/lia';
+import { FormattedMessage } from 'react-intl';
+
+import { formattedBreakLineValue, type MessagesKey } from '@/locales/messages';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
+
+export const TooltipIcon = ({
+  triggerClassName,
+  iconClassName,
+  contentClassName,
+  tooltipId,
+  tooltipValues,
+}: {
+  triggerClassName?: string;
+  iconClassName?: string;
+  contentClassName?: string;
+  tooltipId: MessagesKey;
+  tooltipValues?: Record<string, unknown>;
+}): JSX.Element => {
+  return (
+    <Tooltip>
+      <TooltipTrigger className={triggerClassName}>
+        <LiaQuestionCircle className={iconClassName} />
+      </TooltipTrigger>
+      <TooltipContent className={contentClassName}>
+        <FormattedMessage
+          id={tooltipId}
+          values={{ ...formattedBreakLineValue, ...tooltipValues }}
+        />
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/dashboard/src/components/Issue/IssueTooltip.tsx
+++ b/dashboard/src/components/Issue/IssueTooltip.tsx
@@ -1,12 +1,7 @@
-import { LiaQuestionCircle } from 'react-icons/lia';
-
-import { FormattedMessage } from 'react-intl';
-
 import type { JSX } from 'react';
 
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
-import { formattedBreakLineValue } from '@/locales/messages';
 import { cn } from '@/lib/utils';
+import { TooltipIcon } from '@/components/Icons/TooltipIcon';
 
 export const IssueTooltip = ({
   iconClassName,
@@ -16,13 +11,10 @@ export const IssueTooltip = ({
   tooltipClassName?: string;
 }): JSX.Element => {
   return (
-    <Tooltip>
-      <TooltipTrigger>
-        <LiaQuestionCircle className={cn('h-5 w-5', iconClassName)} />
-      </TooltipTrigger>
-      <TooltipContent className={cn('font-normal', tooltipClassName)}>
-        <FormattedMessage id="issue.tooltip" values={formattedBreakLineValue} />
-      </TooltipContent>
-    </Tooltip>
+    <TooltipIcon
+      iconClassName={cn('h-5 w-5', iconClassName)}
+      contentClassName={cn('font-normal', tooltipClassName)}
+      tooltipId="issue.tooltip"
+    />
   );
 };

--- a/dashboard/src/components/Section/Section.tsx
+++ b/dashboard/src/components/Section/Section.tsx
@@ -30,12 +30,20 @@ export interface ISubsection {
 }
 
 export const Subsection = ({ infos, title }: ISubsection): JSX.Element => {
-  const children: JSX.Element[] = useMemo(() => [], []);
-  const items = useMemo(
-    () =>
-      infos.map(info => {
+  const [items, children] = useMemo(() => {
+    const childrenList: JSX.Element[] = [];
+    const itemList = infos
+      .map(info => {
         const WrapperComponent = info.wrapperComponent;
-        const LinkComponent = (
+        const shouldHaveLinkComponent =
+          info.title !== undefined ||
+          info.link !== undefined ||
+          info.linkComponent !== undefined ||
+          info.linkText !== undefined ||
+          info.unformattedTitle !== undefined ||
+          info.icon !== undefined ||
+          info.onClick !== undefined;
+        const LinkComponent = shouldHaveLinkComponent && (
           <LinkWithIcon
             key={info.title?.toString()}
             title={info.title}
@@ -55,29 +63,38 @@ export const Subsection = ({ infos, title }: ISubsection): JSX.Element => {
         );
 
         if (info.children !== undefined) {
-          children.push(info.children);
+          childrenList.push(info.children);
         } else {
-          return (
-            <div key={info.title} className="flex flex-row items-end">
-              {WrapperComponent ? (
-                <WrapperComponent asChild>{LinkComponent}</WrapperComponent>
-              ) : (
-                <>{LinkComponent}</>
-              )}
-              {info.copyValue && <CopyButton value={info.copyValue} />}
-            </div>
-          );
+          if (
+            WrapperComponent !== undefined ||
+            LinkComponent !== undefined ||
+            info.copyValue !== undefined
+          ) {
+            return (
+              <div key={info.title} className="flex flex-row items-end">
+                {WrapperComponent ? (
+                  <WrapperComponent asChild>{LinkComponent}</WrapperComponent>
+                ) : (
+                  <>{LinkComponent}</>
+                )}
+                {info.copyValue && <CopyButton value={info.copyValue} />}
+              </div>
+            );
+          }
         }
-      }),
-    [infos, children],
-  );
+      })
+      .filter(item => item !== undefined);
+
+    return [itemList, childrenList];
+  }, [infos]);
+
   return (
     <div>
-      <span className="text-xl">{title}</span>
-      <div className="border-dark-gray grid grid-cols-2 gap-8 border-t py-8">
-        {items}
-      </div>
-      <div className="w-[80vw]">{children}</div>
+      {title && <span className="text-xl">{title}</span>}
+      {items.length > 0 && (
+        <div className="border-dark-gray grid grid-cols-2 gap-8">{items}</div>
+      )}
+      {children.length > 0 && <div className="w-[80vw]">{children}</div>}
     </div>
   );
 };
@@ -101,13 +118,14 @@ const Section = ({
       )),
     [subsections],
   );
+
   return (
-    <div className="text-dim-gray flex flex-col gap-4">
-      <div className="flex flex-col gap-2">
-        <span className="text-sm">{eyebrow}</span>
+    <div className="text-dim-gray mb-10 flex flex-col gap-4">
+      <div className="border-dark-gray flex flex-col gap-2 border-b pb-4">
+        {eyebrow && <span className="text-sm">{eyebrow}</span>}
         <div className="flex flex-row items-center gap-2">
           {leftIcon}
-          <span className="text-2xl font-bold">{title}</span>
+          {title && <span className="text-2xl font-bold">{title}</span>}
           {rightIcon}
         </div>
         {subtitle}

--- a/dashboard/src/components/Table/TableHeader.tsx
+++ b/dashboard/src/components/Table/TableHeader.tsx
@@ -3,17 +3,16 @@ import type { Column } from '@tanstack/react-table';
 import { FormattedMessage } from 'react-intl';
 
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
-import { LiaQuestionCircle } from 'react-icons/lia';
 
 import { z } from 'zod';
 
 import { useCallback, type JSX } from 'react';
 
 import type { MessagesKey } from '@/locales/messages';
-import { formattedBreakLineValue } from '@/locales/messages';
 
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 import { Button } from '@/components/ui/button';
+
+import { TooltipIcon } from '@/components/Icons/TooltipIcon';
 
 export interface ITableHeader<T> {
   column: Column<T>;
@@ -64,14 +63,11 @@ export const TableHeader = <T,>({
         {sortable && sortedArrow[zSortingMethod.parse(column.getIsSorted())]}
       </Button>
       {tooltipId && (
-        <Tooltip>
-          <TooltipTrigger className="ml-2">
-            <LiaQuestionCircle />
-          </TooltipTrigger>
-          <TooltipContent className="font-normal whitespace-pre-line">
-            <FormattedMessage id={tooltipId} values={formattedBreakLineValue} />
-          </TooltipContent>
-        </Tooltip>
+        <TooltipIcon
+          triggerClassName="ml-2"
+          contentClassName="font-normal whitespace-pre-line"
+          tooltipId={tooltipId}
+        />
       )}
     </span>
   );

--- a/dashboard/src/components/TestDetails/StatusHistoryItem.tsx
+++ b/dashboard/src/components/TestDetails/StatusHistoryItem.tsx
@@ -1,0 +1,63 @@
+import { useMemo, type JSX } from 'react';
+
+import {
+  MdOutlineCancel,
+  MdOutlineCheckCircle,
+  MdOutlinePending,
+} from 'react-icons/md';
+
+import { Link } from '@tanstack/react-router';
+
+import type { TestStatusHistoryItem } from '@/types/tree/TestDetails';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
+import { cn } from '@/lib/utils';
+
+export const StatusHistoryItem = ({
+  historyItem,
+  iconsClassName,
+}: {
+  historyItem: TestStatusHistoryItem;
+  iconsClassName?: string;
+}): JSX.Element => {
+  const statusIcon = useMemo(() => {
+    const status = historyItem.status;
+    switch (status) {
+      case 'FAIL':
+        return (
+          <MdOutlineCancel
+            className={cn(iconsClassName, 'text-red text-2xl')}
+          />
+        );
+      case 'PASS':
+        return (
+          <MdOutlineCheckCircle
+            className={cn(iconsClassName, 'text-green text-2xl')}
+          />
+        );
+      default:
+        return (
+          <MdOutlinePending
+            className={cn(iconsClassName, 'text-2xl text-amber-500')}
+          />
+        );
+    }
+  }, [historyItem.status, iconsClassName]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <Link
+          to="/test/$testId"
+          params={{ testId: historyItem.id }}
+          from="/test/$testId/"
+          search={s => s}
+          state={s => s}
+        >
+          {statusIcon}
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent>{historyItem.id}</TooltipContent>
+    </Tooltip>
+  );
+};

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -267,6 +267,16 @@ export const messages = {
     'testDetails.buildInfo': 'Build Info',
     'testDetails.failedToFetch': 'Failed to fetch test details',
     'testDetails.notFound': 'Test not found',
+    'testDetails.regressionTypeTooltip':
+      'The regression type of the test.\n' +
+      'Pass - test passed in all previous tests\n' +
+      'Fail - test failed in all previous tests\n' +
+      'Fixed - test was failing but passed in the last iterations\n' +
+      'Regression - test was passing but failed in the last iterations\n' +
+      'Unstable - test has inconclusive results or is not consistent',
+    'testDetails.statusHistory': 'Status History',
+    'testDetails.statusHistoryTooltip':
+      'The {amount} previous tests before the current test.\nClick on an icon to see details of that specific test.',
     'testDetails.testId': 'Test Id',
     'testStatus.done': 'Done',
     'testStatus.error': 'Error',

--- a/dashboard/src/types/tree/TestDetails.tsx
+++ b/dashboard/src/types/tree/TestDetails.tsx
@@ -1,5 +1,19 @@
 import type { Status } from '@/types/database';
 
+export type TestStatusHistoryItem = {
+  field_timestamp: Date;
+  id: string;
+  status: Status;
+  git_commit_hash: string;
+};
+
+type PossibleRegressionType =
+  | 'regression'
+  | 'fixed'
+  | 'unstable'
+  | 'pass'
+  | 'fail';
+
 export type TTestDetails = {
   architecture: string;
   build_id: string;
@@ -20,4 +34,6 @@ export type TTestDetails = {
   misc?: Record<string, unknown>;
   output_files?: Record<string, unknown>;
   tree_name?: string;
+  status_history: TestStatusHistoryItem[];
+  regression_type: PossibleRegressionType;
 };


### PR DESCRIPTION
Adds a new query to get the history of a test
Adds a method to tell if a given test is a regression, is fixed, or is unstable

## How to test
Fetch test endpoints with `http 'localhost:8000/api/test/<test_id>` and check if the history is getting fetched and the classification is correct. You can also check the network tab when going to a test details page to check the response.

For the frontend, go to any testDetails page and check the Status History section, some examples:
[Test with 1 pass](http://localhost:5173/test/maestro%3A67c173ff3218f15c74bc5c79)
[Test with 1 fail](http://localhost:5173/test/maestro%3A67c074b57d9799de2b4ce46d)
[Test with 1 inconclusive](http://localhost:5173/test/maestro%3A67c17c8b3218f15c74bc68bd)
[Unstable test](http://localhost:5173/test/maestro%3A678ee7b046f65f378a18d33e)
[Test with many passes](http://localhost:5173/test/maestro%3A67c0c84f7d9799de2b4d805b)

Closes #898
Closes #899
Closes #258