### PR TITLE
fix: remove unused cache functions

### DIFF
--- a/backend/kernelCI_app/apps.py
+++ b/backend/kernelCI_app/apps.py
@@ -1,5 +1,4 @@
 from django.apps import AppConfig
-from kernelCI_app.cache import run_cache_invalidator
 
 
 class KernelciAppConfig(AppConfig):
@@ -7,5 +6,4 @@ class KernelciAppConfig(AppConfig):
     name = "kernelCI_app"
 
     def ready(self) -> None:
-        run_cache_invalidator()
         return super().ready()


### PR DESCRIPTION
Closes #999 
Closes #1025

## How to test
I think that currently the best way to test is to run our `generate-schema.sh` script and check that it exits correctly. Another option would be to create a new admin command (for example https://github.com/padovan/dashboard/commits/dev/), run it and check it's exiting correctly