### PR TITLE
Fix: test details without env misc

### DIFF
--- a/backend/kernelCI_app/queries/test.py
+++ b/backend/kernelCI_app/queries/test.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Optional
 from kernelCI_app.models import Tests
 
 
@@ -39,7 +40,7 @@ def get_test_status_history(
     origin: str,
     git_repository_url: str,
     git_repository_branch: str,
-    platform: str,
+    platform: Optional[str],
     current_test_timestamp: datetime,
 ):
     query = Tests.objects.values(

--- a/backend/kernelCI_app/views/testDetailsView.py
+++ b/backend/kernelCI_app/views/testDetailsView.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from typing import Optional
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.queries.test import get_test_details_data, get_test_status_history
 from kernelCI_app.typeModels.databases import FAIL_STATUS, PASS_STATUS
@@ -62,7 +63,10 @@ class TestDetails(APIView):
                 error_message="Test not found", status_code=HTTPStatus.OK
             )
 
-        platform = response["environment_misc"].get("platform")
+        environment_misc = response.get("environment_misc")
+        platform: Optional[str] = None
+        if environment_misc is not None:
+            platform = environment_misc.get("platform")
 
         status_history_response = get_test_status_history(
             path=response["path"],


### PR DESCRIPTION
Fixes test details pages where there is no environment misc to extract the platform, which were crashing because of the status history filter

Example: http://localhost:5173/test/redhat%3A1575003976-x86_64-kernel_upt_1
Compare it with the same page on staging: https://staging.dashboard.kernelci.org:9000/test/redhat%3A1575003976-x86_64-kernel_upt_1