### PR TITLE
Chore: logic to construct tree proof file

### DIFF
--- a/backend/data/trees-name.yaml
+++ b/backend/data/trees-name.yaml
@@ -1,0 +1,157 @@
+trees:
+  Rust-for-Linux:
+    url: https://github.com/Rust-for-Linux/linux.git
+  aaptel:
+    url: https://github.com/aaptel/linux.git
+  agross:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git
+  amlogic:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/amlogic/linux.git
+  android:
+    url: https://android.googlesource.com/kernel/common
+  ardb:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/ardb/linux.git
+  arm64:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
+  arnd:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/arnd/playground.git
+  block:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/axboe/linux-block.git
+  bpf:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git
+  bpf-next:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git
+  broonie-misc:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git
+  broonie-regmap:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/broonie/regmap.git
+  broonie-regulator:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/broonie/regulator.git
+  broonie-sound:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/broonie/sound.git
+  broonie-spi:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/broonie/spi.git
+  c10s:
+    url: https://gitlab.com/cki-project/kernel-ark.git
+  c10s-coverage:
+    url: https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-10.git
+  c9s:
+    url: https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9.git
+  chrome-platform:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/linux.git
+  chromiumos:
+    url: https://chromium.googlesource.com/chromiumos/third_party/kernel
+  cip:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git
+  cip-kernel-linux-cip:
+    url: https://gitlab.com/cip-project/cip-kernel/linux-cip.git
+  clk:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/clk/linux.git
+  collabora-chromeos-kernel:
+    url: https://gitlab.collabora.com/google/chromeos-kernel.git
+  collabora-next:
+    url: https://gitlab.collabora.com/kernel/collabora-next.git
+  davem-net:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/davem/net.git
+  davem-net-next:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git
+  efi:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/efi/efi.git
+  gfs2:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/gfs2/linux-gfs2.git
+  gregkh-usb:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/usb.git
+  hyperv:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/hyperv/linux.git
+  khilman:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux.git
+  krzysztof:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/krzk/linux.git
+  kselftest:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git
+  kvm:
+    url: https://git.kernel.org/pub/scm/virt/kvm/kvm.git
+  kvmarm:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/kvmarm/kvmarm.git
+  lee-backlight:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/lee/backlight.git
+  lee-mfd:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git
+  libfabric:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
+  linusw:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git
+  mainline:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+  media:
+    url: https://git.linuxtv.org/media.git
+  media-committers:
+    url: https://gitlab.freedesktop.org/linux-media/media-committers.git
+  mediatek:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/mediatek/linux.git
+  net-next:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git
+  netdev-testing:
+    url: https://github.com/linux-netdev/testing.git
+  next:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+  omap:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux-omap.git
+  padovan:
+    url: https://github.com/padovan/linux.git
+  pm:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git
+  printk:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/printk/linux.git
+  renesas:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git
+  riscv:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux.git
+  robh:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/robh/linux.git
+  rppt:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/rppt/memblock.git
+  sashal-next:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/sashal/linus-next.git
+  scsi:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/mkp/scsi.git
+  soc:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/soc/soc.git
+  stable:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+  stable-linux-stable:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+  stable-linux-stable-rc-queues:
+    url: https://gitlab.com/Linaro/lkft/mirrors/stable/linux-stable-rc-queues
+  stable-rc:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git
+  stable-rt:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git
+  tegra:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/tegra/linux.git
+  thermal:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/thermal/linux.git
+  third_party-kernel:
+    url: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
+  tip:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
+  tnguy-net:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/tnguy/net-queue.git
+  tnguy-next:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/tnguy/next-queue.git
+  torvalds-linux-mainline:
+    url: https://gitlab.com/Linaro/lkft/mirrors/torvalds/linux-mainline
+  ulfh:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/ulfh/mmc.git
+  upstream-arm-acpi:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/lpieralisi/linux.git
+  upstream-nf:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/netfilter/nf.git
+  upstream-nf-next:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/netfilter/nf-next.git
+  upstream-rt-devel:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-rt-devel.git
+  upstream-xfs:
+    url: https://git.kernel.org/pub/scm/fs/xfs/xfs-linux.git
+  vireshk:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/vireshk/linux.git

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -31,6 +31,8 @@ def get_json_env_var(name, default):
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Path of data directory
+BACKEND_DATA_DIR = os.path.join(BASE_DIR, "data")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/

--- a/backend/kernelCI_app/management/commands/treeproof.py
+++ b/backend/kernelCI_app/management/commands/treeproof.py
@@ -1,0 +1,91 @@
+from django.core.management.base import BaseCommand
+from kernelCI_app.models import Checkouts
+import re
+import yaml
+import os
+from django.conf import settings
+
+
+class Command(BaseCommand):
+    def __init__(self):
+        self.maestro_trees = dict()
+        self.non_maestro_trees = dict()
+        self.trees: dict[str, dict] = {"trees": {}}
+
+    def _define_tree_name(self, git_url: str):
+        regex = r"([^/]+)/([^/]+)?$"
+        match = re.search(regex, git_url)
+
+        first_part = match.group(1)
+        second_part = match.group(2).split(".")[0]
+
+        new_tree_name = first_part
+
+        if second_part.lower() not in first_part.lower():
+            new_tree_name += f"-{second_part}"
+
+        return new_tree_name
+
+    def _get_trees_proofs(self, *, is_maestro=False):
+        query = (
+            Checkouts.objects.values("tree_name", "git_repository_url")
+            .distinct("tree_name", "git_repository_url")
+            .filter(git_repository_url__isnull=False)
+        )
+
+        origin_trees = self.maestro_trees if is_maestro else self.non_maestro_trees
+
+        if is_maestro:
+            records = query.filter(origin="maestro")
+        else:
+            records = query.exclude(origin="maestro")
+
+        for record in records:
+            tree_name = record["tree_name"]
+            git_url = record["git_repository_url"]
+
+            if not tree_name:
+                tree_name = self._define_tree_name(git_url)
+
+            if tree_name not in origin_trees:
+                origin_trees[tree_name] = git_url
+
+    def _merge_trees(self):
+        merged_trees = {}
+
+        for tree, git_url in self.maestro_trees.items():
+            tree_in_dict = tree in merged_trees
+            git_url_in_dict = git_url in merged_trees.values()
+
+            if not (tree_in_dict or git_url_in_dict):
+                merged_trees[tree] = git_url
+
+        for tree, git_url in self.non_maestro_trees.items():
+            tree_in_dict = tree in merged_trees
+            git_url_in_dict = git_url in merged_trees.values()
+
+            if not (tree_in_dict or git_url_in_dict):
+                merged_trees[tree] = git_url
+
+        return merged_trees
+
+    def _format_trees_to_yml_format(self, trees: dict):
+        trees_yml = {"trees": {}}
+
+        for tree, git_url in trees.items():
+            trees_yml["trees"][tree] = {"url": git_url}
+
+        return trees_yml
+
+    def handle(self, *args, **options):
+        self._get_trees_proofs()
+        self._get_trees_proofs(is_maestro=True)
+
+        merged_dict = self._merge_trees()
+        formatted_dict = self._format_trees_to_yml_format(merged_dict)
+
+        filepath = os.path.join(settings.BACKEND_DATA_DIR, "trees-name.yaml")
+        with open(filepath, "w") as file:
+            yaml.dump(
+                formatted_dict, file, default_flow_style=False, allow_unicode=True
+            )


### PR DESCRIPTION
- create admin command to make a file with trees of all origin (focus in maestro trees)
- create a initial file with the trees

Close #1015

### **How to test**

- Drop `kernelCI_app/management/commands/data/tree-proof.yml` file
- Run the command `poetry run python3 manage.py treeproof`
- See that it's generate a new `tree-proof.yml`