### PR TITLE
Feat: status history improvements

### DIFF
--- a/backend/kernelCI_app/queries/test.py
+++ b/backend/kernelCI_app/queries/test.py
@@ -1,6 +1,13 @@
-import datetime
 from typing import Optional
 from kernelCI_app.models import Tests
+from kernelCI_app.typeModels.databases import (
+    Build__ConfigName,
+    Checkout__GitRepositoryBranch,
+    Checkout__GitRepositoryUrl,
+    Origin,
+    Test__Path,
+    Test__StartTime,
+)
 
 
 def get_test_details_data(*, test_id):
@@ -18,7 +25,6 @@ def get_test_details_data(*, test_id):
             "start_time",
             "environment_compatible",
             "output_files",
-            "field_timestamp",
             "build__compiler",
             "build__architecture",
             "build__config_name",
@@ -35,29 +41,26 @@ def get_test_details_data(*, test_id):
 
 def get_test_status_history(
     *,
-    path: str,
-    origin: str,
-    git_repository_url: str,
-    git_repository_branch: str,
+    path: Test__Path,
+    origin: Origin,
+    git_repository_url: Checkout__GitRepositoryUrl,
+    git_repository_branch: Checkout__GitRepositoryBranch,
     platform: Optional[str],
-    current_test_timestamp: datetime,
+    current_test_start_time: Test__StartTime,
+    config_name: Build__ConfigName,
 ):
     query = Tests.objects.filter(
         path=path,
         build__checkout__origin=origin,
         build__checkout__git_repository_url=git_repository_url,
         build__checkout__git_repository_branch=git_repository_branch,
-        field_timestamp__lte=current_test_timestamp,
-    ).values(
-        "field_timestamp",
-        "id",
-        "status",
-        "build__checkout__git_commit_hash",
-    )
+        start_time__lte=current_test_start_time,
+        build__config_name=config_name,
+    ).values("start_time", "id", "status")
 
     if platform is None:
         query = query.filter(environment_misc__platform__isnull=True)
     else:
         query = query.filter(environment_misc__platform=platform)
 
-    return query.order_by("-field_timestamp")[:10]
+    return query.order_by("-start_time")[:10]

--- a/backend/kernelCI_app/typeModels/testDetails.py
+++ b/backend/kernelCI_app/typeModels/testDetails.py
@@ -22,7 +22,6 @@ from kernelCI_app.typeModels.databases import (
     Checkout__GitRepositoryUrl,
     Checkout__GitCommitTags,
     Checkout__TreeName,
-    Timestamp,
 )
 
 
@@ -55,19 +54,15 @@ class TestDetailsResponse(BaseModel):
     )
     tree_name: Checkout__TreeName = Field(validation_alias="build__checkout__tree_name")
     origin: Origin = Field(validation_alias="build__checkout__origin")
-    field_timestamp: Timestamp
 
 
 type PossibleRegressionType = Literal["regression", "fixed", "unstable", "pass", "fail"]
 
 
 class TestStatusHistoryItem(BaseModel):
-    field_timestamp: Timestamp
+    start_time: Test__StartTime
     id: Test__Id
     status: Test__Status
-    git_commit_hash: Checkout__GitCommitHash = Field(
-        validation_alias="build__checkout__git_commit_hash"
-    )
 
 
 class TestStatusHistoryResponse(BaseModel):
@@ -81,4 +76,5 @@ class TestStatusHistoryRequest(BaseModel):
     git_repository_url: Checkout__GitRepositoryUrl = None
     git_repository_branch: Checkout__GitRepositoryBranch = None
     platform: Optional[str] = None
-    current_test_timestamp: Timestamp
+    current_test_start_time: Test__StartTime = None
+    config_name: Build__ConfigName = None

--- a/backend/kernelCI_app/unitTests/testStatusHistory_test.py
+++ b/backend/kernelCI_app/unitTests/testStatusHistory_test.py
@@ -19,13 +19,16 @@ client = TestClient()
     "params, status_code, has_error_body",
     [
         (
+            # https://staging.dashboard.kernelci.org:9000/test/maestro%3A67ce452318018371957dbf70
             TestStatusHistoryRequest(
                 path="fluster.debian.v4l2.gstreamer_av1.validate-fluster-results",
                 origin="maestro",
                 git_repository_url="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
                 git_repository_branch="master",
                 platform="mt8195-cherry-tomato-r2",
-                current_test_timestamp="2025-03-10T01:52:01.230777Z",
+                current_test_start_time="2025-03-10T01:49:23.064000Z",
+                config_name="defconfig+lab-setup+arm64-chromebook"
+                + "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
             ),
             HTTPStatus.OK,
             False,
@@ -34,7 +37,7 @@ client = TestClient()
             TestStatusHistoryRequest(
                 path="unexistent",
                 origin="maestro",
-                current_test_timestamp="2025-03-10T01:39:01.486560Z",
+                current_test_start_time="2025-03-10T01:39:01.486560Z",
             ),
             HTTPStatus.BAD_REQUEST,
             True,

--- a/backend/kernelCI_app/unitTests/utils/fields/tests.py
+++ b/backend/kernelCI_app/unitTests/utils/fields/tests.py
@@ -19,7 +19,6 @@ test_expected_fields = [
     "tree_name",
     "git_repository_branch",
     "origin",
-    "field_timestamp",
 ]
 
 status_history_expected_fields = [

--- a/backend/kernelCI_app/views/testStatusHistoryView.py
+++ b/backend/kernelCI_app/views/testStatusHistoryView.py
@@ -65,7 +65,8 @@ class TestStatusHistory(APIView):
                 git_repository_branch=request.GET.get("git_repository_branch"),
                 git_repository_url=request.GET.get("git_repository_url"),
                 platform=request.GET.get("platform"),
-                current_test_timestamp=request.GET.get("current_test_timestamp"),
+                current_test_start_time=request.GET.get("current_test_start_time"),
+                config_name=request.GET.get("config_name"),
             )
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
@@ -76,7 +77,8 @@ class TestStatusHistory(APIView):
             git_repository_url=params.git_repository_url,
             git_repository_branch=params.git_repository_branch,
             platform=params.platform,
-            current_test_timestamp=params.current_test_timestamp,
+            current_test_start_time=params.current_test_start_time,
+            config_name=params.config_name,
         )
 
         if len(status_history_response) == 0:

--- a/backend/requests/test-details-get.sh
+++ b/backend/requests/test-details-get.sh
@@ -3,11 +3,11 @@ http 'http://localhost:8000/api/test/maestro:67a182c5661a7bc8748b9905'
 # HTTP/1.1 200 OK
 # Allow: GET, HEAD, OPTIONS
 # Cache-Control: max-age=0
-# Content-Length: 18677
+# Content-Length: 18629
 # Content-Type: application/json
 # Cross-Origin-Opener-Policy: same-origin
-# Date: Mon, 10 Mar 2025 19:59:02 GMT
-# Expires: Mon, 10 Mar 2025 19:59:02 GMT
+# Date: Thu, 13 Mar 2025 11:40:18 GMT
+# Expires: Thu, 13 Mar 2025 11:40:18 GMT
 # Referrer-Policy: same-origin
 # Server: WSGIServer/0.2 CPython/3.12.7
 # Vary: Accept, Cookie, origin
@@ -23,7 +23,6 @@ http 'http://localhost:8000/api/test/maestro:67a182c5661a7bc8748b9905'
 #     "environment_misc": {
 #         "platform": "kubernetes"
 #     },
-#     "field_timestamp": "2025-02-04T03:02:01.190150Z",
 #     "git_commit_hash": "170c9fb62732486d54f4876cfee81654f217364c",
 #     "git_commit_tags": [],
 #     "git_repository_branch": "android15-6.6",

--- a/backend/requests/test-status-history-get.sh
+++ b/backend/requests/test-status-history-get.sh
@@ -1,13 +1,13 @@
-http 'http://localhost:8000/api/test/status-history?path=fluster.debian.v4l2.gstreamer_av1.validate-fluster-results&origin=maestro&git_repository_url=https:%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Ftorvalds%2Flinux.git&git_repository_branch=master&platform=mt8195-cherry-tomato-r2&current_test_timestamp=2025-03-10T01:52:01.230777Z'
+http 'http://localhost:8000/api/test/status-history?path=fluster.debian.v4l2.gstreamer_av1.validate-fluster-results&origin=maestro&git_repository_url=https:%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Ftorvalds%2Flinux.git&git_repository_branch=master&platform=mt8195-cherry-tomato-r2&current_test_start_time=2025-03-10T01:49:23.064000Z&config_name=defconfig%2Blab-setup%2Barm64-chromebook%2BCONFIG_MODULE_COMPRESS%3Dn%2BCONFIG_MODULE_COMPRESS_NONE%3Dy'
 
 # HTTP/1.1 200 OK
 # Allow: GET, HEAD, OPTIONS
 # Cache-Control: max-age=0
-# Content-Length: 1719
+# Content-Length: 1059
 # Content-Type: application/json
 # Cross-Origin-Opener-Policy: same-origin
-# Date: Mon, 10 Mar 2025 19:54:14 GMT
-# Expires: Mon, 10 Mar 2025 19:54:14 GMT
+# Date: Thu, 13 Mar 2025 11:44:01 GMT
+# Expires: Thu, 13 Mar 2025 11:44:01 GMT
 # Referrer-Policy: same-origin
 # Server: WSGIServer/0.2 CPython/3.12.7
 # Vary: Accept, Cookie, origin
@@ -18,63 +18,53 @@ http 'http://localhost:8000/api/test/status-history?path=fluster.debian.v4l2.gst
 #     "regression_type": "unstable",
 #     "status_history": [
 #         {
-#             "field_timestamp": "2025-03-10T01:52:01.230777Z",
-#             "git_commit_hash": "80e54e84911a923c40d7bee33a34c1b4be148d7a",
 #             "id": "maestro:67ce452318018371957dbf70",
+#             "start_time": "2025-03-10T01:49:23.064000Z",
 #             "status": "FAIL"
 #         },
 #         {
-#             "field_timestamp": "2025-03-09T22:25:05.510433Z",
-#             "git_commit_hash": "0dc1f314f854257eb64dcea604a42a55225453a9",
 #             "id": "maestro:67cdfbb418018371957c8ad1",
+#             "start_time": "2025-03-09T20:36:03.512000Z",
 #             "status": "PASS"
 #         },
 #         {
-#             "field_timestamp": "2025-03-09T09:34:09.140715Z",
-#             "git_commit_hash": "2e51e0ac575c2095da869ea62d406f617550e6ed",
 #             "id": "maestro:67cc9ce518018371957a5983",
+#             "start_time": "2025-03-08T19:39:17.288000Z",
 #             "status": "PASS"
 #         },
 #         {
-#             "field_timestamp": "2025-03-09T05:38:44.649757Z",
-#             "git_commit_hash": "2a520073e74fbb956b5564818fc5529dcc7e9f0e",
 #             "id": "maestro:67cbd2ec180183719579a321",
+#             "start_time": "2025-03-08T05:17:31.649000Z",
 #             "status": "PASS"
 #         },
 #         {
-#             "field_timestamp": "2025-03-09T04:22:13.548635Z",
-#             "git_commit_hash": "21e4543a2e2f8538373d1d19264c4bae6f13e798",
 #             "id": "maestro:67cb8431180183719578aa98",
+#             "start_time": "2025-03-07T23:41:37.618000Z",
 #             "status": "FAIL"
 #         },
 #         {
-#             "field_timestamp": "2025-03-08T23:05:14.256486Z",
-#             "git_commit_hash": "0f52fd4f67c67f7f2ea3063c627e466255f027fd",
 #             "id": "maestro:67ca566a180183719574464c",
+#             "start_time": "2025-03-07T02:14:02.539000Z",
 #             "status": "FAIL"
 #         },
 #         {
-#             "field_timestamp": "2025-03-08T21:31:56.959566Z",
-#             "git_commit_hash": "7f0e9ee5e44887272627d0fcde0b19a675daf597",
 #             "id": "maestro:67ca05601801837195720596",
+#             "start_time": "2025-03-06T20:28:15.903000Z",
 #             "status": "PASS"
 #         },
 #         {
-#             "field_timestamp": "2025-03-04T07:01:03.088880Z",
-#             "git_commit_hash": "99fa936e8e4f117d62f229003c9799686f74cebc",
 #             "id": "maestro:67c60821460b36c9f254aab0",
+#             "start_time": "2025-03-03T19:50:57.687000Z",
 #             "status": "FAIL"
 #         },
 #         {
-#             "field_timestamp": "2025-03-02T19:36:06.013938Z",
-#             "git_commit_hash": "b91872c56940950a6a0852e499d249c3091d4284",
 #             "id": "maestro:67c4b17d3218f15c74c2a87f",
+#             "start_time": "2025-03-02T19:29:01.187000Z",
 #             "status": "PASS"
 #         },
 #         {
-#             "field_timestamp": "2025-02-27T22:10:01.952215Z",
-#             "git_commit_hash": "1e15510b71c99c6e49134d756df91069f7d18141",
 #             "id": "maestro:67c0e25e7d9799de2b4dcab6",
+#             "start_time": "2025-02-27T22:08:29.891000Z",
 #             "status": "PASS"
 #         }
 #     ]

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -2656,8 +2656,6 @@ components:
           $ref: '#/components/schemas/Checkout__TreeName'
         origin:
           $ref: '#/components/schemas/Origin'
-        field_timestamp:
-          $ref: '#/components/schemas/Timestamp'
       required:
       - id
       - build_id
@@ -2679,7 +2677,6 @@ components:
       - git_commit_tags
       - tree_name
       - origin
-      - field_timestamp
       title: TestDetailsResponse
       type: object
     TestHistoryItem:
@@ -2798,19 +2795,16 @@ components:
       type: object
     TestStatusHistoryItem:
       properties:
-        field_timestamp:
-          $ref: '#/components/schemas/Timestamp'
+        start_time:
+          $ref: '#/components/schemas/Test__StartTime'
         id:
           $ref: '#/components/schemas/Test__Id'
         status:
           $ref: '#/components/schemas/Test__Status'
-        git_commit_hash:
-          $ref: '#/components/schemas/Checkout__GitCommitHash'
       required:
-      - field_timestamp
+      - start_time
       - id
       - status
-      - git_commit_hash
       title: TestStatusHistoryItem
       type: object
     TestStatusHistoryResponse:

--- a/dashboard/src/components/TestDetails/StatusHistoryItem.tsx
+++ b/dashboard/src/components/TestDetails/StatusHistoryItem.tsx
@@ -8,6 +8,8 @@ import {
 
 import { Link } from '@tanstack/react-router';
 
+import { TiArrowSortedDown } from 'react-icons/ti';
+
 import type { TestStatusHistoryItem } from '@/types/tree/TestDetails';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
@@ -16,9 +18,11 @@ import { cn } from '@/lib/utils';
 export const StatusHistoryItem = ({
   historyItem,
   iconsClassName,
+  isCurrentTest = false,
 }: {
   historyItem: TestStatusHistoryItem;
   iconsClassName?: string;
+  isCurrentTest?: boolean;
 }): JSX.Element => {
   const statusIcon = useMemo(() => {
     const status = historyItem.status;
@@ -26,23 +30,35 @@ export const StatusHistoryItem = ({
       case 'FAIL':
         return (
           <MdOutlineCancel
-            className={cn(iconsClassName, 'text-red text-2xl')}
+            className={cn(
+              iconsClassName,
+              'text-red text-3xl',
+              !isCurrentTest && 'mt-6',
+            )}
           />
         );
       case 'PASS':
         return (
           <MdOutlineCheckCircle
-            className={cn(iconsClassName, 'text-green text-2xl')}
+            className={cn(
+              iconsClassName,
+              'text-green text-3xl',
+              !isCurrentTest && 'mt-6',
+            )}
           />
         );
       default:
         return (
           <MdOutlinePending
-            className={cn(iconsClassName, 'text-2xl text-amber-500')}
+            className={cn(
+              iconsClassName,
+              'text-3xl text-amber-500',
+              !isCurrentTest && 'mt-6',
+            )}
           />
         );
     }
-  }, [historyItem.status, iconsClassName]);
+  }, [historyItem.status, iconsClassName, isCurrentTest]);
 
   return (
     <Tooltip>
@@ -53,11 +69,19 @@ export const StatusHistoryItem = ({
           from="/test/$testId/"
           search={s => s}
           state={s => s}
+          className="flex flex-col items-center"
         >
+          {isCurrentTest && <TiArrowSortedDown className="size-6" />}
           {statusIcon}
         </Link>
       </TooltipTrigger>
-      <TooltipContent>{historyItem.id}</TooltipContent>
+      <TooltipContent>
+        <p className="text-center">
+          {historyItem.id}
+          <br />
+          {historyItem.status}
+        </p>
+      </TooltipContent>
     </Tooltip>
   );
 };

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -417,7 +417,8 @@ const TestDetails = ({ breadcrumb }: TestsDetailsProps): JSX.Element => {
             typeof data.environment_misc?.['platform'] === 'string'
               ? data.environment_misc['platform']
               : undefined,
-          current_test_timestamp: data.field_timestamp,
+          current_test_start_time: data.start_time,
+          config_name: data.config_name,
         }
       : undefined,
   );

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -143,22 +143,74 @@ const TestDetailsSections = ({
   );
 
   const regressionData: JSX.Element[] | undefined = useMemo(() => {
-    return statusHistory?.status_history.reverse().map((historyItem, index) => {
-      return (
-        <Fragment key={historyItem.id}>
-          <StatusHistoryItem historyItem={historyItem} />
-          {index !== statusHistory.status_history.length - 1 && (
-            <MdChevronRight />
-          )}
-        </Fragment>
-      );
-    });
-  }, [statusHistory?.status_history]);
+    return statusHistory?.status_history
+      .slice()
+      .reverse()
+      .map((historyItem, index) => {
+        return (
+          <Fragment key={historyItem.id}>
+            <StatusHistoryItem
+              historyItem={historyItem}
+              isCurrentTest={historyItem.id === test.id}
+            />
+            {index !== statusHistory.status_history.length - 1 && (
+              <MdChevronRight className="mt-6 size-6" />
+            )}
+          </Fragment>
+        );
+      });
+  }, [statusHistory?.status_history, test.id]);
 
   const regressionSection: ISection | undefined = useMemo(() => {
     if (statusHistoryStatus === 'error') {
       return;
     }
+
+    const regressionTypeTooltip: string | null = ((): string | null => {
+      switch (statusHistory?.regression_type) {
+        case 'fixed':
+          return formatMessage({ id: 'testDetails.regressionTooltip.fixed' });
+        case 'regression':
+          return formatMessage({
+            id: 'testDetails.regressionTooltip.regression',
+          });
+        case 'unstable':
+          return formatMessage({
+            id: 'testDetails.regressionTooltip.unstable',
+          });
+        default:
+          return null;
+      }
+    })();
+
+    const regressionSubtitle = (
+      <div>
+        <Tooltip>
+          <TooltipTrigger>
+            <Badge variant="blueTag">{statusHistory?.regression_type}</Badge>
+          </TooltipTrigger>
+          <TooltipContent className="whitespace-pre-line">
+            <FormattedMessage
+              id="testDetails.regressionTypeTooltip"
+              values={{
+                fixedTooltip: formatMessage({
+                  id: 'testDetails.regressionTooltip.fixed',
+                }),
+                regressionTooltip: formatMessage({
+                  id: 'testDetails.regressionTooltip.regression',
+                }),
+                unstableTooltip: formatMessage({
+                  id: 'testDetails.regressionTooltip.unstable',
+                }),
+              }}
+            />
+          </TooltipContent>
+        </Tooltip>
+        {regressionTypeTooltip !== null && (
+          <span> - {regressionTypeTooltip}</span>
+        )}
+      </div>
+    );
 
     return {
       title: formatMessage({ id: 'testDetails.statusHistory' }),
@@ -170,18 +222,7 @@ const TestDetailsSections = ({
           contentClassName="whitespace-pre-line"
         />
       ),
-      subtitle: statusHistory && (
-        <div>
-          <Tooltip>
-            <TooltipTrigger>
-              <Badge variant="blueTag">{statusHistory?.regression_type}</Badge>
-            </TooltipTrigger>
-            <TooltipContent className="whitespace-pre-line">
-              <FormattedMessage id="testDetails.regressionTypeTooltip" />
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      ),
+      subtitle: statusHistory && regressionSubtitle,
       subsections: [
         {
           infos: [

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -241,13 +241,19 @@ export const messages = {
       'Inconclusive groups tests with ERROR, MISS, SKIP, DONE, and unknown statuses defined by KCIDB.',
     'testDetails.buildInfo': 'Build Info',
     'testDetails.notFound': 'Test not found',
+    'testDetails.regressionTooltip.fixed':
+      'Test was failing but passed in the last iterations',
+    'testDetails.regressionTooltip.regression':
+      'Test was passing but failed in the last iterations',
+    'testDetails.regressionTooltip.unstable':
+      'Test has inconclusive results or is not consistent',
     'testDetails.regressionTypeTooltip':
       'The regression type of the test.\n' +
-      'Pass - test passed in all previous tests\n' +
-      'Fail - test failed in all previous tests\n' +
-      'Fixed - test was failing but passed in the last iterations\n' +
-      'Regression - test was passing but failed in the last iterations\n' +
-      'Unstable - test has inconclusive results or is not consistent',
+      'Pass - Test passed in all previous tests\n' +
+      'Fail - Test failed in all previous tests\n' +
+      'Fixed - {fixedTooltip}\n' +
+      'Regression - {regressionTooltip}\n' +
+      'Unstable - {unstableTooltip}',
     'testDetails.statusHistory': 'Status History',
     'testDetails.statusHistoryTooltip':
       'The {amount} previous tests before the current test.\nClick on an icon to see details of that specific test.',

--- a/dashboard/src/types/tree/TestDetails.tsx
+++ b/dashboard/src/types/tree/TestDetails.tsx
@@ -25,10 +25,9 @@ export type TTestDetails = {
 };
 
 export type TestStatusHistoryItem = {
-  field_timestamp: string;
+  start_time: string;
   id: string;
   status: Status;
-  git_commit_hash: string;
 };
 
 type PossibleRegressionType =
@@ -49,5 +48,6 @@ export type TestStatusHistoryParams = {
   git_repository_url?: string;
   git_repository_branch?: string;
   platform?: string;
-  current_test_timestamp?: string;
+  current_test_start_time?: string;
+  config_name?: string;
 };


### PR DESCRIPTION
Changes backend query to also consider the build config as a part of a test definition; also uses `start_time` instead of `_timestamp` for filtering and ordering.
Changes frontend to be more visible and clearer in the informations - increased icon size, current test indicator, explicit regression type tooltip.
Changes the way the reverse status history icons are calculated, fixing a bug where it was reverting the already reversed array.

## How to test
Go to any test details pages and compare with staging.
Localhost examples:
[Regression test](http://localhost:5173/test/maestro:67ce445218018371957db690)
[Fixed test](http://localhost:5173/test/maestro%3A67c8eddd18018371956edb3d)
[Unstable test](http://localhost:5173/test/maestro:67cf61dec5336ecbf369c77e) - This one also has a "crossed" timestamp x start time with the latest test, meaning that timestamp from A is > B but start time from A is < B, so on its [staging counterpart](https://staging.dashboard.kernelci.org:9000/test/maestro:67cf61dec5336ecbf369c77e) there is one last test missing

Closes #1048 
Closes #1065 
Closes #1073 