### PR TITLE
feat: send notification when server errors happen

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -92,6 +92,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "kernelCI_app.middleware.logServerErrorMiddleware.LogServerErrorMiddleware",
 ]
 
 ROOT_URLCONF = "kernelCI.urls"

--- a/backend/kernelCI_app/middleware/logServerErrorMiddleware.py
+++ b/backend/kernelCI_app/middleware/logServerErrorMiddleware.py
@@ -1,0 +1,51 @@
+import json
+from http import HTTPStatus
+from kernelCI_app.helpers.logger import create_endpoint_notification
+from kernelCI_app.helpers.discordWebhook import send_discord_notification
+
+REASON_MAX_LEN = 500
+
+
+class LogServerErrorMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if HTTPStatus(response.status_code).is_server_error:
+            reason = (
+                response.data
+                if hasattr(response, "data")
+                else response.content.decode()
+            )
+            reason = self.process_validation_error(reason)
+            message = f"Request failed with error {response.status_code}: {response.reason_phrase}"
+            if reason is not None and reason != "":
+                reason = str(reason)[:REASON_MAX_LEN]
+                message += f"\nReason (limited to {REASON_MAX_LEN} characters):\n```json\n{reason}```"
+
+            notification = create_endpoint_notification(
+                message=message,
+                request=request,
+            )
+            send_discord_notification(content=notification)
+
+        return response
+
+    def process_validation_error(self, data: dict | list | str) -> dict | list:
+        if isinstance(data, str):
+            try:
+                data = json.loads(data)
+            except json.JSONDecodeError:
+                return data
+
+        if isinstance(data, dict):
+            return data
+
+        new_data = []
+        for error in data:
+            if isinstance(error, dict):
+                error.pop("input")
+                error.pop("url")
+            new_data.append(error)
+        return new_data

--- a/backend/kernelCI_app/views/hardwareDetailsBootsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBootsView.py
@@ -109,7 +109,7 @@ class HardwareDetailsBoots(APIView):
         try:
             unstable_parse_post_body(instance=self, request=request)
         except ValidationError as e:
-            return Response(data={"error": e.json()}, status=HTTPStatus.BAD_REQUEST)
+            return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
         except json.JSONDecodeError:
             return Response(
                 data={
@@ -176,6 +176,6 @@ class HardwareDetailsBoots(APIView):
                 boots=self.boots,
             )
         except ValidationError as e:
-            return Response(data=e.errors(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
@@ -102,7 +102,7 @@ class HardwareDetailsBuilds(APIView):
         try:
             unstable_parse_post_body(instance=self, request=request)
         except ValidationError as e:
-            return Response(data={"error": e.json()}, status=HTTPStatus.BAD_REQUEST)
+            return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
         except json.JSONDecodeError:
             return Response(
                 data={
@@ -172,8 +172,6 @@ class HardwareDetailsBuilds(APIView):
                 builds=self.builds,
             )
         except ValidationError as e:
-            return Response(
-                data={"error": e.errors()}, status=HTTPStatus.INTERNAL_SERVER_ERROR
-            )
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -251,7 +251,7 @@ class HardwareDetailsSummary(APIView):
         try:
             unstable_parse_post_body(instance=self, request=request)
         except ValidationError as e:
-            return Response(data={"error": e.json()}, status=HTTPStatus.BAD_REQUEST)
+            return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
         except json.JSONDecodeError:
             return Response(
                 data={

--- a/backend/kernelCI_app/views/hardwareDetailsTestsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsTestsView.py
@@ -107,7 +107,7 @@ class HardwareDetailsTests(APIView):
         try:
             unstable_parse_post_body(instance=self, request=request)
         except ValidationError as e:
-            return Response(data={"error": e.json()}, status=HTTPStatus.BAD_REQUEST)
+            return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
         except json.JSONDecodeError:
             return Response(
                 data={
@@ -174,6 +174,6 @@ class HardwareDetailsTests(APIView):
                 tests=self.tests,
             )
         except ValidationError as e:
-            return Response(data=e.errors(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -220,7 +220,7 @@ class HardwareDetails(APIView):
         try:
             unstable_parse_post_body(instance=self, request=request)
         except ValidationError as e:
-            return Response(data={"error": e.json()}, status=HTTPStatus.BAD_REQUEST)
+            return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
         except json.JSONDecodeError:
             return Response(
                 data={
@@ -367,6 +367,6 @@ class HardwareDetails(APIView):
                 ),
             )
         except ValidationError as e:
-            return Response(data=e.errors(), status=HTTPStatus.BAD_REQUEST)
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/treeDetailsBootsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBootsView.py
@@ -105,6 +105,6 @@ class TreeDetailsBoots(APIView):
                 boots=self.bootHistory,
             )
         except ValidationError as e:
-            return Response(data=e.errors(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/treeDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBuildsView.py
@@ -101,6 +101,6 @@ class TreeDetailsBuilds(APIView):
                 builds=self.builds,
             )
         except ValidationError as e:
-            return Response(data=e.errors(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -275,6 +275,6 @@ class TreeDetailsSummary(APIView):
                 ),
             )
         except ValidationError as e:
-            return Response(data=e.errors(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/treeDetailsTestsView.py
+++ b/backend/kernelCI_app/views/treeDetailsTestsView.py
@@ -109,6 +109,6 @@ class TreeDetailsTests(APIView):
                 tests=self.testHistory,
             )
         except ValidationError as e:
-            return Response(data=e.errors(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/treeLatest.py
+++ b/backend/kernelCI_app/views/treeLatest.py
@@ -52,7 +52,7 @@ class TreeLatest(APIView):
         try:
             parsed_params = TreeLatestPathParameters(tree_name=tree_name, branch=branch)
         except ValidationError as e:
-            return create_api_error_response(error_message=e.json())
+            return Response(data=e.json, status=HTTPStatus.BAD_REQUEST)
 
         tree_not_found_error_message = "Tree not found."
         origin = request.GET.get("origin")
@@ -95,8 +95,6 @@ class TreeLatest(APIView):
         try:
             valid_response = TreeLatestResponse(**response_data)
         except ValidationError as e:
-            return create_api_error_response(
-                error_message=e.json(), status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-            )
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())

--- a/backend/kernelCI_app/views/treeView.py
+++ b/backend/kernelCI_app/views/treeView.py
@@ -93,8 +93,6 @@ class TreeView(APIView):
         try:
             valid_response = TreeListingResponse(checkouts)
         except ValidationError as e:
-            return create_api_error_response(
-                error_message=e.json(), status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-            )
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump(by_alias=True))

--- a/backend/kernelCI_app/views/treeViewFast.py
+++ b/backend/kernelCI_app/views/treeViewFast.py
@@ -97,8 +97,6 @@ class TreeViewFast(APIView):
         try:
             valid_response = TreeListingFastResponse(response_data)
         except ValidationError as e:
-            return create_api_error_response(
-                error_message=e.json(), status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-            )
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())


### PR DESCRIPTION
Closes #1050

## Visual Reference
Some examples of this happening
![image](https://github.com/user-attachments/assets/d5dda806-4464-4732-9595-bb603bd27ad8)

## How to test
- Set `DISCORD_WEBHOOK_URL` to the private server channel
- Force a server error (500-599). You can do it just returning a Response with HTTPStatus.INTERNAL_SERVER_ERROR in any view you'd like and check the server to see the error message showing there