### PR TITLE
fix: pass origin to build/test/issue details

### DIFF
--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -91,7 +91,8 @@ const BuildDetails = ({
         to="/tree/$treeId"
         params={{ treeId: data?.git_commit_hash }}
         state={s => s}
-        search={{
+        search={s => ({
+          origin: s.origin,
           treeInfo: {
             gitBranch: data?.git_repository_branch,
             gitUrl: data?.git_repository_url,
@@ -99,7 +100,7 @@ const BuildDetails = ({
             commitName: data?.git_commit_name,
             headCommitHash: data?.git_commit_hash,
           },
-        }}
+        })}
       >
         {truncateBigText(data?.git_commit_hash)}
         <LinkIcon className="text-blue text-xl" />

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -68,9 +68,10 @@ const IssuesList = ({
         params: {
           issueId: issueId,
         },
-        search: {
+        search: s => ({
+          origin: s.origin,
           issueVersion: version,
-        },
+        }),
         state: s => ({ ...s, id: detailsId, from: pageFrom }),
       };
     },

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -50,9 +50,10 @@ const IssueSection = ({
             to="/issue/$issueId"
             params={{ issueId: issue.id }}
             state={s => s}
-            search={{
+            search={s => ({
+              origin: s.origin,
               issueVersion: issue.version,
-            }}
+            })}
           >
             <ListingItem
               unknown={issue.incidents_info.incidentsCount}

--- a/dashboard/src/components/IssueTable/IssueTable.tsx
+++ b/dashboard/src/components/IssueTable/IssueTable.tsx
@@ -78,6 +78,9 @@ const getLinkProps = (
       id: row.original.id,
       from: RedirectFrom.Issues,
     }),
+    search: s => ({
+      origin: s.origin,
+    }),
   };
 };
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -97,6 +97,9 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
         testId: bootId,
         treeId: treeId,
       },
+      search: s => ({
+        origin: s.origin,
+      }),
     }),
     [treeId],
   );

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -28,6 +28,9 @@ export function TreeDetailsBuildsTable({
         buildId: buildId,
         treeId: treeId,
       },
+      search: s => ({
+        origin: s.origin,
+      }),
     }),
     [treeId],
   );

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -79,6 +79,9 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
           testId: bootId,
           treeId: treeId,
         },
+        search: s => ({
+          origin: s.origin,
+        }),
       };
     },
     [treeId],

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -67,6 +67,9 @@ const BootsTab = ({
         testId: bootId,
         hardwareId: hardwareId,
       },
+      search: s => ({
+        origin: s.origin,
+      }),
     }),
     [hardwareId],
   );

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/HardwareDetailsBuildsTable.tsx
@@ -49,6 +49,9 @@ export function HardwareDetailsBuildsTable({
         buildId: buildId,
         hardwareId: hardwareId,
       },
+      search: s => ({
+        origin: s.origin,
+      }),
     }),
     [hardwareId],
   );

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/HardwareDetailsTestsTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/HardwareDetailsTestsTable.tsx
@@ -99,6 +99,9 @@ const HardwareDetailsTestTable = ({
         testId: bootId,
         hardwareId: hardwareId,
       },
+      search: s => ({
+        origin: s.origin,
+      }),
     }),
     [hardwareId],
   );

--- a/dashboard/src/routes/_main/issue/$issueId/route.tsx
+++ b/dashboard/src/routes/_main/issue/$issueId/route.tsx
@@ -6,9 +6,10 @@ import {
   zTableFilterInfoDefault,
   zTableFilterInfoValidator,
 } from '@/types/tree/TreeDetails';
-import { type SearchSchema } from '@/types/general';
+import { DEFAULT_ORIGIN, type SearchSchema } from '@/types/general';
 
 export const issueDetailsDefaultValues = {
+  origin: DEFAULT_ORIGIN,
   tableFilter: zTableFilterInfoDefault,
   issueVersion: undefined,
 };


### PR DESCRIPTION
After removing some of the search params from the details pages one essential search param `origin` was removed as well. This commit fixes this problem, sending again the `origin` param to build/test/issue details

Closes #1043

## How to test
Please check that every link to an issue/test/build details correctly passes the `origin` param. I've tested it myself but I might have missed something