### PR TITLE
Fix: left join checkouts for issue incidents

### DIFF
--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -1,10 +1,9 @@
 import os
+from django.db import connection
 from django.db.utils import ProgrammingError
-from django.db.models import F
+from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.logger import log_message
 import typing_extensions
-from typing import Optional
-from kernelCI_app.models import Incidents
 from kernelCI_app.helpers.build import valid_do_not_exist_exception, valid_status_field
 from kernelCI_app.constants.general import SCHEMA_VERSION_ENV
 
@@ -12,31 +11,76 @@ from kernelCI_app.constants.general import SCHEMA_VERSION_ENV
 @typing_extensions.deprecated(
     "This implementation is temporary while the schema is being updated."
 )
-def get_issue_builds(*, issue_id: str, version: int) -> Optional[dict]:
-    fields = [
-        "build__id",
-        "build__architecture",
-        "build__config_name",
-        f"build__{valid_status_field()}",
-        "build__start_time",
-        "build__duration",
-        "build__compiler",
-        "build__log_url",
-        "build__checkout__tree_name",
-        "build__checkout__git_repository_branch",
-    ]
+def get_issue_builds(*, issue_id: str, version: int) -> list[dict]:
+    params = {
+        "issue_id": issue_id,
+        "issue_version": version,
+    }
+
+    query = f"""
+        SELECT
+            B.ID,
+            B.ARCHITECTURE,
+            B.CONFIG_NAME,
+            B.{valid_status_field()} AS build_status,
+            B.START_TIME,
+            B.DURATION,
+            B.COMPILER,
+            B.LOG_URL,
+            C.TREE_NAME,
+            C.GIT_REPOSITORY_BRANCH
+        FROM
+            INCIDENTS INC
+            INNER JOIN BUILDS B ON (INC.BUILD_ID = B.ID)
+            LEFT JOIN CHECKOUTS C ON (B.CHECKOUT_ID = C.ID)
+        WHERE
+            (
+                INC.ISSUE_ID = %(issue_id)s
+                AND INC.ISSUE_VERSION = %(issue_version)s
+            )
+    """
 
     try:
-        # Here, `list` forces the execution of the query, ensuring any ProgrammingError
-        # thrown will be caught by the try catch block
-        return list(
-            Incidents.objects.filter(issue_id=issue_id, issue_version=version)
-            .values(*fields)
-            .annotate(build_status=F(f"build__{valid_status_field()}"))
-        )
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            return dict_fetchall(cursor)
     except ProgrammingError as e:
         if valid_do_not_exist_exception(e):
             os.environ[SCHEMA_VERSION_ENV] = "5"
             log_message("Issue Builds -- Schema version updated to 5")
         else:
             raise
+
+
+def get_issue_tests(*, issue_id: str, version: int) -> list[dict]:
+    params = {
+        "issue_id": issue_id,
+        "issue_version": version,
+    }
+
+    query = """
+        SELECT
+            T.ID,
+            T.STATUS,
+            T.DURATION,
+            T.PATH,
+            T.START_TIME,
+            T.ENVIRONMENT_COMPATIBLE,
+            T.ENVIRONMENT_MISC,
+            C.TREE_NAME,
+            C.GIT_REPOSITORY_BRANCH
+        FROM
+            INCIDENTS INC
+            INNER JOIN TESTS T ON (INC.TEST_ID = T.ID)
+            LEFT JOIN BUILDS B ON (T.BUILD_ID = B.ID)
+            LEFT JOIN CHECKOUTS C ON (B.CHECKOUT_ID = C.ID)
+        WHERE
+            (
+                INC.ISSUE_ID = %(issue_id)s
+                AND INC.ISSUE_VERSION = %(issue_version)s
+            )
+    """
+
+    with connection.cursor() as cursor:
+        cursor.execute(query, params)
+        return dict_fetchall(cursor)

--- a/backend/kernelCI_app/typeModels/issueDetails.py
+++ b/backend/kernelCI_app/typeModels/issueDetails.py
@@ -1,5 +1,6 @@
-from typing import List, Optional, Any
-from pydantic import BaseModel, RootModel, Field, field_validator
+from typing import List, Optional
+from typing_extensions import Annotated
+from pydantic import BaseModel, BeforeValidator, RootModel, Field, field_validator
 from kernelCI_app.helpers.build import build_status_map
 
 from kernelCI_app.typeModels.databases import (
@@ -34,51 +35,45 @@ from kernelCI_app.typeModels.databases import (
 )
 from kernelCI_app.typeModels.issues import ProcessedExtraDetailedIssues
 
+from kernelCI_app.utils import validate_str_to_dict
+
 
 class IssueDetailsPathParameters(BaseModel):
     issue_id: str
 
 
 class IssueBuildItem(BaseModel):
-    id: Build__Id = Field(validation_alias="build__id")
-    architecture: Build__Architecture = Field(validation_alias="build__architecture")
-    config_name: Build__ConfigName = Field(validation_alias="build__config_name")
+    id: Build__Id
+    architecture: Build__Architecture
+    config_name: Build__ConfigName
     status: Build__Status = Field(validation_alias="build_status")
-    start_time: Build__StartTime = Field(validation_alias="build__start_time")
-    duration: Build__Duration = Field(validation_alias="build__duration")
-    compiler: Build__Compiler = Field(validation_alias="build__compiler")
-    log_url: Build__LogUrl = Field(validation_alias="build__log_url")
-    tree_name: Checkout__TreeName = Field(validation_alias="build__checkout__tree_name")
-    git_repository_branch: Checkout__GitRepositoryBranch = Field(
-        validation_alias="build__checkout__git_repository_branch"
-    )
+    start_time: Build__StartTime
+    duration: Build__Duration
+    compiler: Build__Compiler
+    log_url: Build__LogUrl
+    tree_name: Checkout__TreeName
+    git_repository_branch: Checkout__GitRepositoryBranch
 
     @field_validator("status", mode="before")
     @classmethod
-    def valid_to_status(cls, value: Any) -> str:
+    def valid_to_status(cls, value) -> str:
         if isinstance(value, bool) or value is None:
             return build_status_map(value)
         return value
 
 
 class IssueTestItem(BaseModel):
-    id: Test__Id = Field(validation_alias="test__id")
-    status: Test__Status = Field(validation_alias="test__status")
-    duration: Test__Duration = Field(validation_alias="test__duration")
-    path: Test__Path = Field(validation_alias="test__path")
-    start_time: Test__StartTime = Field(validation_alias="test__start_time")
-    environment_compatible: Test__EnvironmentCompatible = Field(
-        validation_alias="test__environment_compatible"
-    )
-    environment_misc: Test__EnvironmentMisc = Field(
-        validation_alias="test__environment_misc"
-    )
-    tree_name: Checkout__TreeName = Field(
-        validation_alias="test__build__checkout__tree_name"
-    )
-    git_repository_branch: Checkout__GitRepositoryBranch = Field(
-        validation_alias="test__build__checkout__git_repository_branch"
-    )
+    id: Test__Id
+    status: Test__Status
+    duration: Test__Duration
+    path: Test__Path
+    start_time: Test__StartTime
+    environment_compatible: Test__EnvironmentCompatible
+    environment_misc: Annotated[
+        Test__EnvironmentMisc, BeforeValidator(validate_str_to_dict)
+    ]
+    tree_name: Checkout__TreeName
+    git_repository_branch: Checkout__GitRepositoryBranch
 
 
 class IssueTestsResponse(RootModel):

--- a/backend/kernelCI_app/typeModels/testDetails.py
+++ b/backend/kernelCI_app/typeModels/testDetails.py
@@ -1,5 +1,6 @@
 from typing import Literal, Optional
-from pydantic import BaseModel, Field
+from typing_extensions import Annotated
+from pydantic import BaseModel, BeforeValidator
 
 from kernelCI_app.typeModels.databases import (
     Origin,
@@ -23,6 +24,7 @@ from kernelCI_app.typeModels.databases import (
     Checkout__GitCommitTags,
     Checkout__TreeName,
 )
+from kernelCI_app.utils import validate_str_to_dict
 
 
 class TestDetailsResponse(BaseModel):
@@ -32,28 +34,22 @@ class TestDetailsResponse(BaseModel):
     path: Test__Path
     log_excerpt: Test__LogExcerpt
     log_url: Test__LogUrl
-    misc: Test__Misc
-    environment_misc: Test__EnvironmentMisc
+    misc: Annotated[Test__Misc, BeforeValidator(validate_str_to_dict)]
+    environment_misc: Annotated[
+        Test__EnvironmentMisc, BeforeValidator(validate_str_to_dict)
+    ]
     start_time: Test__StartTime
     environment_compatible: Test__EnvironmentCompatible
-    output_files: Test__OutputFiles
-    compiler: Build__Compiler = Field(validation_alias="build__compiler")
-    architecture: Build__Architecture = Field(validation_alias="build__architecture")
-    config_name: Build__ConfigName = Field(validation_alias="build__config_name")
-    git_commit_hash: Checkout__GitCommitHash = Field(
-        validation_alias="build__checkout__git_commit_hash"
-    )
-    git_repository_branch: Checkout__GitRepositoryBranch = Field(
-        validation_alias="build__checkout__git_repository_branch"
-    )
-    git_repository_url: Checkout__GitRepositoryUrl = Field(
-        validation_alias="build__checkout__git_repository_url"
-    )
-    git_commit_tags: Checkout__GitCommitTags = Field(
-        validation_alias="build__checkout__git_commit_tags"
-    )
-    tree_name: Checkout__TreeName = Field(validation_alias="build__checkout__tree_name")
-    origin: Origin = Field(validation_alias="build__checkout__origin")
+    output_files: Annotated[Test__OutputFiles, BeforeValidator(validate_str_to_dict)]
+    compiler: Build__Compiler
+    architecture: Build__Architecture
+    config_name: Build__ConfigName
+    git_commit_hash: Checkout__GitCommitHash
+    git_repository_branch: Checkout__GitRepositoryBranch
+    git_repository_url: Checkout__GitRepositoryUrl
+    git_commit_tags: Checkout__GitCommitTags
+    tree_name: Checkout__TreeName
+    origin: Optional[Origin]
 
 
 type PossibleRegressionType = Literal["regression", "fixed", "unstable", "pass", "fail"]

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -88,3 +88,9 @@ def string_to_json(string: str) -> Optional[dict]:
 
 def is_boot(path: str | None) -> bool:
     return path is not None and (path == "boot" or path.startswith("boot."))
+
+
+def validate_str_to_dict(value):
+    if isinstance(value, str):
+        return json.loads(value)
+    return value

--- a/backend/kernelCI_app/views/testDetailsView.py
+++ b/backend/kernelCI_app/views/testDetailsView.py
@@ -17,13 +17,13 @@ class TestDetails(APIView):
     def get(self, _request, test_id: str) -> Response:
         response = get_test_details_data(test_id=test_id)
 
-        if response is None:
+        if not response:
             return create_api_error_response(
                 error_message="Test not found", status_code=HTTPStatus.OK
             )
 
         try:
-            valid_response = TestDetailsResponse(**response)
+            valid_response = TestDetailsResponse(**response[0])
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -2574,7 +2574,9 @@ components:
         tree_name:
           $ref: '#/components/schemas/Checkout__TreeName'
         origin:
-          $ref: '#/components/schemas/Origin'
+          anyOf:
+          - $ref: '#/components/schemas/Origin'
+          - type: 'null'
       required:
       - id
       - build_id

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1054,33 +1054,47 @@ components:
     BuildArchitectures:
       properties:
         PASS:
+          anyOf:
+          - type: integer
+          - type: 'null'
           default: 0
           title: Pass
-          type: integer
-        FAIL:
-          default: 0
-          title: Fail
-          type: integer
         ERROR:
+          anyOf:
+          - type: integer
+          - type: 'null'
           default: 0
           title: Error
-          type: integer
+        FAIL:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: 0
+          title: Fail
         SKIP:
+          anyOf:
+          - type: integer
+          - type: 'null'
           default: 0
           title: Skip
-          type: integer
         MISS:
+          anyOf:
+          - type: integer
+          - type: 'null'
           default: 0
           title: Miss
-          type: integer
         DONE:
+          anyOf:
+          - type: integer
+          - type: 'null'
           default: 0
           title: Done
-          type: integer
         'NULL':
+          anyOf:
+          - type: integer
+          - type: 'null'
           default: 0
           title: 'Null'
-          type: integer
         compilers:
           anyOf:
           - items:
@@ -1206,42 +1220,10 @@ components:
       - git_repository_branch
       title: BuildHistoryItem
       type: object
-    BuildStatusCount:
-      properties:
-        PASS:
-          default: 0
-          title: Pass
-          type: integer
-        FAIL:
-          default: 0
-          title: Fail
-          type: integer
-        ERROR:
-          default: 0
-          title: Error
-          type: integer
-        SKIP:
-          default: 0
-          title: Skip
-          type: integer
-        MISS:
-          default: 0
-          title: Miss
-          type: integer
-        DONE:
-          default: 0
-          title: Done
-          type: integer
-        'NULL':
-          default: 0
-          title: 'Null'
-          type: integer
-      title: BuildStatusCount
-      type: object
     BuildSummary:
       properties:
         status:
-          $ref: '#/components/schemas/BuildStatusCount'
+          $ref: '#/components/schemas/StatusCount'
         architectures:
           additionalProperties:
             $ref: '#/components/schemas/BuildArchitectures'
@@ -1249,7 +1231,7 @@ components:
           type: object
         configs:
           additionalProperties:
-            $ref: '#/components/schemas/BuildStatusCount'
+            $ref: '#/components/schemas/StatusCount'
           title: Configs
           type: object
         issues:
@@ -1380,7 +1362,7 @@ components:
         start_time:
           $ref: '#/components/schemas/Timestamp'
         build_status:
-          $ref: '#/components/schemas/BuildStatusCount'
+          $ref: '#/components/schemas/StatusCount'
         test_status:
           $ref: '#/components/schemas/TestStatusCount'
         boot_status:
@@ -1948,11 +1930,11 @@ components:
             uniqueItems: true
           title: Platform
         test_status_summary:
-          $ref: '#/components/schemas/TestStatusCount'
+          $ref: '#/components/schemas/StatusCount'
         boot_status_summary:
-          $ref: '#/components/schemas/TestStatusCount'
+          $ref: '#/components/schemas/StatusCount'
         build_status_summary:
-          $ref: '#/components/schemas/BuildStatusCount'
+          $ref: '#/components/schemas/StatusCount'
       required:
       - hardware_name
       - platform
@@ -2451,6 +2433,52 @@ components:
       additionalProperties:
         $ref: '#/components/schemas/ExtraIssuesData'
       type: object
+    StatusCount:
+      properties:
+        PASS:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: 0
+          title: Pass
+        ERROR:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: 0
+          title: Error
+        FAIL:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: 0
+          title: Fail
+        SKIP:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: 0
+          title: Skip
+        MISS:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: 0
+          title: Miss
+        DONE:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: 0
+          title: Done
+        'NULL':
+          anyOf:
+          - type: integer
+          - type: 'null'
+          default: 0
+          title: 'Null'
+      title: StatusCount
+      type: object
     StatusValues:
       enum:
       - FAIL
@@ -2498,7 +2526,7 @@ components:
           title: Compiler
           type: string
         status:
-          $ref: '#/components/schemas/TestStatusCount'
+          $ref: '#/components/schemas/StatusCount'
       required:
       - arch
       - compiler
@@ -2646,48 +2674,35 @@ components:
       type: object
     TestStatusCount:
       properties:
-        PASS:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          default: 0
+        pass:
           title: Pass
-        ERROR:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          default: 0
+          type: integer
+        error:
           title: Error
-        FAIL:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          default: 0
+          type: integer
+        fail:
           title: Fail
-        SKIP:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          default: 0
+          type: integer
+        skip:
           title: Skip
-        MISS:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          default: 0
+          type: integer
+        miss:
           title: Miss
-        DONE:
-          anyOf:
-          - type: integer
-          - type: 'null'
-          default: 0
+          type: integer
+        done:
           title: Done
-        'NULL':
-          anyOf:
-          - type: integer
-          - type: 'null'
-          default: 0
+          type: integer
+        'null':
           title: 'Null'
+          type: integer
+      required:
+      - pass
+      - error
+      - fail
+      - skip
+      - miss
+      - done
+      - 'null'
       title: TestStatusCount
       type: object
     TestStatusHistoryItem:
@@ -2721,7 +2736,7 @@ components:
     TestSummary:
       properties:
         status:
-          $ref: '#/components/schemas/TestStatusCount'
+          $ref: '#/components/schemas/StatusCount'
         architectures:
           items:
             $ref: '#/components/schemas/TestArchSummaryItem'
@@ -2729,7 +2744,7 @@ components:
           type: array
         configs:
           additionalProperties:
-            $ref: '#/components/schemas/TestStatusCount'
+            $ref: '#/components/schemas/StatusCount'
           title: Configs
           type: object
         issues:
@@ -2765,7 +2780,7 @@ components:
         platforms:
           anyOf:
           - additionalProperties:
-              $ref: '#/components/schemas/TestStatusCount'
+              $ref: '#/components/schemas/StatusCount'
             type: object
           - type: 'null'
           default: null
@@ -2909,7 +2924,7 @@ components:
           title: Earliest Start Time
           type: string
         builds:
-          $ref: '#/components/schemas/BuildStatusCount'
+          $ref: '#/components/schemas/StatusCount'
         boots:
           $ref: '#/components/schemas/TestStatusCount'
         tests:

--- a/dashboard/src/components/IssueTable/IssueTable.tsx
+++ b/dashboard/src/components/IssueTable/IssueTable.tsx
@@ -86,6 +86,7 @@ const getLinkProps = (
     }),
     search: s => ({
       origin: s.origin,
+      issueVersion: row.original.version,
     }),
   };
 };


### PR DESCRIPTION
## Changes

- Replaces django queryset with raw query to perform a left join on checkouts (and also left join on builds from issue tests);
- Adds issue version search parameters to issue details when navigating from issue listing to avoid unnecessary processing in the backend to get the latest issue version

## How to test

Check that issues such as this [localhost redhat issue](http://localhost:5173/issue/redhat%3A61ff6ef41135804ad96bc8107bc29426caefa1dc?iv=1) returns the builds correctly, and compare it to the [staging equivalent](https://staging.dashboard.kernelci.org:9000/issue/redhat%3A61ff6ef41135804ad96bc8107bc29426caefa1dc?iv=1)

Other examples:
[localhost maestro issue](http://localhost:5173/issue/maestro:1bad4fd734ada1f413164870f3d66961f9eccbfb?iv=0) where the related checkout from a build doesn't exist
[localhost maestro issue](http://localhost:5173/issue/maestro:b91eba41d9d0281c086ee574a82bdee035760751?iv=0) where the related build from a test doesn't exist

Closes #1085