### PR TITLE
fix: remove wrong error messages

### DIFF
--- a/dashboard/src/api/commonRequest.ts
+++ b/dashboard/src/api/commonRequest.ts
@@ -9,7 +9,7 @@ export class RequestData {
     const res = await http.get<ResponseData<T>>(url, config);
 
     if (res.data.error) {
-      throw new Error(res.data.error);
+      throw new Error(`${res.status}:${res.data.error}`);
     }
 
     return res.data;

--- a/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
@@ -16,6 +16,7 @@ import type {
 import { TestsTable } from '@/components/TestsTable/TestsTable';
 
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 
 interface IBuildDetailsTestSection {
   buildId: string;
@@ -31,16 +32,26 @@ const BuildDetailsTestSection = ({
   getRowLink,
 }: IBuildDetailsTestSection): JSX.Element => {
   const intl = useIntl();
-  const { data, error, isLoading } = useBuildTests(buildId);
+  const { data, error, status, isLoading } = useBuildTests(buildId);
 
-  const hasTest = data && data.length > 0;
   return (
     <>
       <span className="text-2xl font-bold">
         {intl.formatMessage({ id: 'buildDetails.testResults' })}
       </span>
       <Separator className="bg-dark-gray my-6" />
-      {hasTest ? (
+      <QuerySwitcher
+        skeletonClassname="h-[100px]"
+        status={status}
+        data={data}
+        customError={
+          <MemoizedSectionError
+            isLoading={isLoading}
+            errorMessage={error?.message}
+            emptyLabel="buildDetails.noTestResults"
+          />
+        }
+      >
         <div className="flex flex-col gap-6">
           <TestsTable
             tableKey="buildDetailsTests"
@@ -50,14 +61,7 @@ const BuildDetailsTestSection = ({
             getRowLink={getRowLink}
           />
         </div>
-      ) : (
-        <MemoizedSectionError
-          isLoading={isLoading}
-          errorMessage={error?.message}
-          isEmpty={data?.length === 0}
-          emptyLabel={'buildDetails.noTestResults'}
-        />
-      )}
+      </QuerySwitcher>
     </>
   );
 };

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -10,7 +10,6 @@ import { DumbListingContent } from '@/components/ListingContent/ListingContent';
 import ListingItem, { ItemType } from '@/components/ListingItem/ListingItem';
 
 import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
-import { NoIssueFound } from '@/components/Issue/IssueSection';
 import type {
   RedirectFrom,
   TFilter,
@@ -37,6 +36,7 @@ import { TooltipDateTime } from '@/components/TooltipDateTime';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 
 import { BranchBadge } from '@/components/Badge/BranchBadge';
+import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 interface IIssuesList {
   issues: TIssue[];
@@ -125,7 +125,12 @@ const IssuesList = ({
   }, [extraDetailsLoading, issueExtraDetails, issues]);
 
   const contentElement = !hasIssue ? (
-    <NoIssueFound />
+    <MemoizedSectionError
+      isEmpty={true}
+      isLoading={false}
+      emptyLabel="issue.noIssueFound"
+      variant="warning"
+    />
   ) : (
     <DumbListingContent>
       {sortedIssues.map(issue => {

--- a/dashboard/src/components/DetailsPages/SectionError.tsx
+++ b/dashboard/src/components/DetailsPages/SectionError.tsx
@@ -1,3 +1,4 @@
+import { HttpStatusCode } from 'axios';
 import { Fragment, memo, useMemo, type JSX } from 'react';
 import { RiProhibited2Line } from 'react-icons/ri';
 import type { MessageDescriptor } from 'react-intl';
@@ -37,16 +38,22 @@ const SectionError = ({
   customEmptyDataComponent,
   variant = 'error',
 }: ISectionError): JSX.Element => {
+  let errorStatusCode: number | undefined;
+  const splittedError = errorMessage?.split(':');
+  if (splittedError && splittedError.length > 1) {
+    errorStatusCode = parseInt(splittedError[0]);
+  }
+
   const message = useMemo((): MessageDescriptor['id'] => {
     if (isLoading) {
       return 'global.loading';
-    } else if (isEmpty) {
+    } else if (isEmpty || errorStatusCode === HttpStatusCode.Ok) {
       return emptyLabel;
     } else if (errorMessage) {
       return globalErrorMessage[variant].id;
     }
     return globalErrorMessage[variant].id;
-  }, [emptyLabel, errorMessage, isEmpty, isLoading, variant]);
+  }, [emptyLabel, errorMessage, isEmpty, isLoading, variant, errorStatusCode]);
 
   if (isLoading === undefined) {
     return customEmptyDataComponent ?? <Fragment />;
@@ -54,13 +61,15 @@ const SectionError = ({
 
   return (
     <div className="text-weak-gray flex flex-col items-center py-6">
-      {variant === 'error' && !isLoading && (
-        <RiProhibited2Line className="h-14 w-14" />
-      )}
+      {variant === 'error' &&
+        !isLoading &&
+        errorStatusCode !== HttpStatusCode.Ok && (
+          <RiProhibited2Line className="h-14 w-14" />
+        )}
       <p className="text-2xl font-semibold">
         <FormattedMessage id={message} />
       </p>
-      {errorMessage && (
+      {errorMessage && errorStatusCode !== HttpStatusCode.Ok && (
         <p>
           {globalErrorMessage[variant].label}: {errorMessage}
         </p>

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -6,8 +6,6 @@ import type { UseQueryResult } from '@tanstack/react-query';
 
 import { Link } from '@tanstack/react-router';
 
-import { RiProhibited2Line } from 'react-icons/ri';
-
 import ListingItem from '@/components/ListingItem/ListingItem';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
@@ -17,17 +15,6 @@ import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 import type { TIssue } from '@/types/issues';
 
 import { IssueTooltip } from './IssueTooltip';
-
-export const NoIssueFound = (): JSX.Element => {
-  return (
-    <div className="text-weak-gray flex flex-col items-center py-6">
-      <RiProhibited2Line className="h-14 w-14" />
-      <h1 className="text-2xl font-semibold">
-        <FormattedMessage id={'issue.noIssueFound'} />
-      </h1>
-    </div>
-  );
-};
 
 const IssueSection = ({
   data,
@@ -82,7 +69,7 @@ const IssueSection = ({
           <MemoizedSectionError
             isLoading={status === 'pending'}
             errorMessage={error}
-            emptyLabel={'global.error'}
+            emptyLabel="issue.noIssueFound"
             variant={variant}
           />
         }

--- a/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
@@ -83,7 +83,10 @@ export const IssueDetailsBuildSection = ({
           />
         </div>
       ) : (
-        <MemoizedSectionError isLoading={isLoading} />
+        <MemoizedSectionError
+          isLoading={isLoading}
+          emptyLabel="issueDetails.noBuildResults"
+        />
       )}
     </>
   );

--- a/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
@@ -75,7 +75,10 @@ export const IssueDetailsTestSection = ({
           />
         </div>
       ) : (
-        <MemoizedSectionError isLoading={isLoading} />
+        <MemoizedSectionError
+          isLoading={isLoading}
+          emptyLabel="issueDetails.noTestResults"
+        />
       )}
     </>
   );

--- a/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
@@ -147,7 +147,7 @@ const TreeListingPage = ({ inputFilter }: ITreeListingPage): JSX.Element => {
         <MemoizedSectionError
           isLoading={isFastLoading}
           errorMessage={fastError?.message}
-          emptyLabel={'global.error'}
+          emptyLabel="treeListing.notFound"
         />
       }
     >

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -32,7 +32,7 @@ export const messages = {
     'buildDetails.buildLogs': 'Build Logs',
     'buildDetails.gitDescribe': 'Git Describe',
     'buildDetails.kernelConfig': 'Kernel Config',
-    'buildDetails.noTestResults': 'No test results found.',
+    'buildDetails.noTestResults': 'No tests executed for this build',
     'buildDetails.startTime': 'Start Time',
     'buildDetails.testResults': 'Test Results',
     'buildTab.buildStatus': 'Build status',
@@ -173,11 +173,12 @@ export const messages = {
     'hardwareDetails.timeFrame':
       'Results from {startDate} and {startTime} to {endDate} {endTime}',
     'hardwareListing.description': 'List of hardware from kernel tests',
+    'hardwareListing.notFound': 'No hardware information available',
     'hardwareListing.title': 'Hardware Listing ― KCI Dashboard',
     'issue.alsoPresentTooltip': 'Issue also present in {tree}',
     'issue.firstSeen': 'First seen',
     'issue.newIssue': 'New issue: This is the first time this issue was seen',
-    'issue.noIssueFound': 'No issue found.',
+    'issue.noIssueFound': 'No issues found for this tree checkout',
     'issue.path': 'Issues',
     'issue.searchPlaceholder': 'Search by issue comment with a regex',
     'issue.tooltip':
@@ -193,6 +194,8 @@ export const messages = {
     'issueDetails.id': 'Issue Id',
     'issueDetails.issueDetails': 'Issue Details',
     'issueDetails.logspecData': 'Logspec Data',
+    'issueDetails.noBuildResults': 'No builds associated with this issue',
+    'issueDetails.noTestResults': 'No tests associated with this issue',
     'issueDetails.notFound': 'Issue not found',
     'issueDetails.reportSubject': 'Report Subject',
     'issueDetails.reportUrl': 'Report URL',
@@ -200,6 +203,7 @@ export const messages = {
     'issueListing.culpritInfo':
       'Layers of the execution stack responsible for the issue.  If all are false, the issue is considered invalid.',
     'issueListing.description': 'List of issues from builds and tests',
+    'issueListing.notFound': 'No issue information available',
     'issueListing.title': 'Issue Listing ― KCI Dashboard',
     'issueListing.treeBranchTooltip':
       'The tree name and git repository branch of the first incident\nClick a cell to see details of that checkout',
@@ -293,6 +297,7 @@ export const messages = {
     'treeDetails.testsSuccess': 'Success tests',
     'treeDetails.validBuilds': 'Success builds',
     'treeListing.description': 'List of trees for kernel builds and tests',
+    'treeListing.notFound': 'No tree information available',
     'treeListing.title': 'Tree Listing ― KCI Dashboard',
   },
 };

--- a/dashboard/src/pages/Hardware/HardwareListingPage.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPage.tsx
@@ -138,7 +138,7 @@ const HardwareListingPage = ({
         <MemoizedSectionError
           isLoading={isLoading}
           errorMessage={error?.message}
-          emptyLabel={'global.error'}
+          emptyLabel="hardwareListing.notFound"
         />
       }
     >

--- a/dashboard/src/pages/IssueListing/IssueListingPage.tsx
+++ b/dashboard/src/pages/IssueListing/IssueListingPage.tsx
@@ -54,7 +54,7 @@ export const IssueListingPage = ({
         <MemoizedSectionError
           isLoading={isLoading}
           errorMessage={error?.message}
-          emptyLabel={'global.error'}
+          emptyLabel="issueListing.notFound"
         />
       }
     >

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -1,12 +1,10 @@
 import { FormattedMessage } from 'react-intl';
 import { memo, useMemo, type JSX } from 'react';
 
-import { Link } from '@tanstack/react-router';
-
 import { DumbListingContent } from '@/components/ListingContent/ListingContent';
 import type { IBaseCard } from '@/components/Cards/BaseCard';
 import BaseCard from '@/components/Cards/BaseCard';
-import ListingItem, { ItemType } from '@/components/ListingItem/ListingItem';
+import ListingItem from '@/components/ListingItem/ListingItem';
 import { GroupedTestStatus } from '@/components/Status/Status';
 import type { TTreeTestsData } from '@/types/tree/TreeDetails';
 
@@ -15,15 +13,12 @@ import StatusChartMemoized, {
   Colors,
 } from '@/components/StatusChart/StatusCharts';
 import { groupStatus } from '@/utils/status';
-import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
 import type { ArchCompilerStatus } from '@/types/general';
-import { NoIssueFound } from '@/components/Issue/IssueSection';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
 import { Badge } from '@/components/ui/badge';
 import FilterLink from '@/components/Tabs/FilterLink';
 import { DumbSummary, MemoizedSummaryItem } from '@/components/Tabs/Summary';
-import type { TIssue } from '@/types/issues';
 
 interface IConfigList extends Pick<TTreeTestsData, 'configStatusCounts'> {
   title: IBaseCard['title'];
@@ -274,51 +269,6 @@ const StatusChart = ({ statusCounts, title }: IStatusChart): JSX.Element => {
 };
 
 export const MemoizedStatusChart = memo(StatusChart);
-
-interface IIssuesList {
-  issues: TIssue[];
-  title: IBaseCard['title'];
-}
-
-const IssuesList = ({ issues, title }: IIssuesList): JSX.Element => {
-  const hasIssue = issues.length > 0;
-
-  const titleElement = (
-    <span>
-      {title}
-      {hasIssue && (
-        <ColoredCircle
-          className="ml-2 font-normal"
-          backgroundClassName={ItemType.Error}
-          quantity={issues.length}
-        />
-      )}
-    </span>
-  );
-
-  const contentElement = !hasIssue ? (
-    <NoIssueFound />
-  ) : (
-    <DumbListingContent>
-      {issues.map(issue => {
-        return (
-          <Link key={issue.id} to={issue.report_url} target="_blank">
-            <ListingItem
-              unknown={issue.incidents_info.incidentsCount}
-              hasBottomBorder
-              text={issue.comment ?? ''}
-              tooltip={issue.comment}
-            />
-          </Link>
-        );
-      })}
-    </DumbListingContent>
-  );
-
-  return <BaseCard title={titleElement} content={contentElement} />;
-};
-
-export const MemoizedIssuesList = memo(IssuesList);
 
 interface IHardwareUsed {
   title: IBaseCard['title'];


### PR DESCRIPTION
Closes #1079

## How to test
- Open these pages listed in the issue and check that they are showing the correct error messages
  - http://localhost:5173/hardware?o=tuxsuite
  - http://localhost:5173/tree/8b83b87af0bfcaa972ca160170bae3e716ae4a24?p=bt&ti%7Cc=ASB-2025-03-05_13-5.15-3-g8b83b87af0bfc&ti%7Cch=8b83b87af0bfcaa972ca160170bae3e716ae4a24&ti%7Cgb=android13-5.15&ti%7Cgu=https%3A%2F%2Fandroid.googlesource.com%2Fkernel%2Fcommon&ti%7Ct=android
  - http://localhost:5173/build/maestro%3A67d374faf378f0c5986c8bbe
  - http://localhost:5173/test/maestro%3A67d40b04f378f0c5986dc939