### PR TITLE
Feat: solidify schema change

### DIFF
--- a/backend/kernelCI/envconfig/schema-version.yaml
+++ b/backend/kernelCI/envconfig/schema-version.yaml
@@ -1,0 +1,1 @@
+schema-version: '4'

--- a/backend/kernelCI/envconfig/schema-version.yaml
+++ b/backend/kernelCI/envconfig/schema-version.yaml
@@ -1,1 +1,1 @@
-schema-version: '4'
+schema-version: '5'

--- a/backend/kernelCI_app/constants/general.py
+++ b/backend/kernelCI_app/constants/general.py
@@ -6,6 +6,7 @@ UNCATEGORIZED_STRING = "Uncategorized"
 
 MAESTRO_DUMMY_BUILD_PREFIX = "maestro:dummy_"
 
-SCHEMA_VERSION_ENV = "SCHEMA_VERSION"
+SCHEMA_VERSION_ENV_NAME = "schema-version"
+SCHEMA_VERSION_ENV_FILE = "kernelCI/envconfig/schema-version.yaml"
 
 PRODUCTION_HOST = "https://dashboard.kernelci.org"

--- a/backend/kernelCI_app/helpers/build.py
+++ b/backend/kernelCI_app/helpers/build.py
@@ -1,9 +1,7 @@
 import re
-import os
-import typing_extensions
 from typing import Optional
 
-from kernelCI_app.constants.general import SCHEMA_VERSION_ENV
+from kernelCI_app.helpers.environment import get_schema_version
 from kernelCI_app.typeModels.databases import PASS_STATUS, FAIL_STATUS, NULL_STATUS
 
 
@@ -14,19 +12,13 @@ def build_status_map(status: Optional[bool | str]) -> str:
     return status_map.get(status)
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
 def valid_status_field() -> str:
-    is_new_schema = os.getenv(SCHEMA_VERSION_ENV, "4") == "5"
+    is_new_schema = get_schema_version() == "5"
     return "status" if is_new_schema else "valid"
 
 
 VALID_COL_REGEX = re.compile(r"column \S*valid\S* does not exist")
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
-def valid_do_not_exist_exception(e: Exception) -> bool:
+def is_valid_does_not_exist_exception(e: Exception) -> bool:
     return bool(VALID_COL_REGEX.search(str(e)))

--- a/backend/kernelCI_app/helpers/environment.py
+++ b/backend/kernelCI_app/helpers/environment.py
@@ -6,7 +6,7 @@ from kernelCI_app.constants.general import (
 )
 from kernelCI_app.helpers.logger import log_message
 
-DEFAULT_SCHEMA_VERSION = "4"
+DEFAULT_SCHEMA_VERSION = "5"
 
 
 def get_yaml_data(*, file: str):

--- a/backend/kernelCI_app/helpers/environment.py
+++ b/backend/kernelCI_app/helpers/environment.py
@@ -1,0 +1,44 @@
+import yaml
+
+from kernelCI_app.constants.general import (
+    SCHEMA_VERSION_ENV_FILE,
+    SCHEMA_VERSION_ENV_NAME,
+)
+from kernelCI_app.helpers.logger import log_message
+
+DEFAULT_SCHEMA_VERSION = "4"
+
+
+def get_yaml_data(*, file: str):
+    try:
+        with open(file, "r") as f:
+            data = yaml.safe_load(f)
+            return data
+    except FileNotFoundError as e:
+        log_message(f"File not found at {file}\n Error: {e}")
+        return None
+    except yaml.YAMLError as e:
+        log_message(f"Error parsing YAML: {e}")
+        return None
+
+
+def set_yaml_data(*, file: str, data) -> None:
+    try:
+        with open(file, "w") as f:
+            yaml.safe_dump(data, f, default_flow_style=False)
+    except (yaml.YAMLError, IOError) as e:
+        log_message(f"Error writing YAML: {e}")
+
+
+def get_schema_version() -> str:
+    data = get_yaml_data(file=SCHEMA_VERSION_ENV_FILE)
+    schema_version = data.get(SCHEMA_VERSION_ENV_NAME, DEFAULT_SCHEMA_VERSION)
+    return schema_version
+
+
+def set_schema_version(*, version: str) -> None:
+    if version is not None and version != "":
+        set_yaml_data(
+            file=SCHEMA_VERSION_ENV_FILE, data={SCHEMA_VERSION_ENV_NAME: version}
+        )
+    return

--- a/backend/kernelCI_app/helpers/errorHandling.py
+++ b/backend/kernelCI_app/helpers/errorHandling.py
@@ -1,18 +1,5 @@
-import typing_extensions
-from django.http import JsonResponse
 from http import HTTPStatus
 from rest_framework.response import Response
-
-
-@typing_extensions.deprecated(
-    "The `create_error_response` method is deprecated; use `create_api_error_response` "
-    "and use the rest_framework.response type instead.",
-    category=None,
-)
-def create_error_response(
-    error_message: str, status_code: HTTPStatus = HTTPStatus.BAD_REQUEST
-) -> JsonResponse:
-    return JsonResponse({"error": error_message}, status=status_code.value)
 
 
 def create_api_error_response(

--- a/backend/kernelCI_app/queries/build.py
+++ b/backend/kernelCI_app/queries/build.py
@@ -1,12 +1,14 @@
-import os
 from django.db.utils import ProgrammingError
 import typing_extensions
 from typing import Optional
 from querybuilder.query import Query
+from kernelCI_app.helpers.environment import set_schema_version
 from kernelCI_app.models import Builds, Tests
-from kernelCI_app.helpers.build import valid_do_not_exist_exception, valid_status_field
+from kernelCI_app.helpers.build import (
+    is_valid_does_not_exist_exception,
+    valid_status_field,
+)
 from kernelCI_app.helpers.logger import log_message
-from kernelCI_app.constants.general import SCHEMA_VERSION_ENV
 
 
 @typing_extensions.deprecated(
@@ -53,8 +55,8 @@ def get_build_details(build_id: str) -> Optional[list[dict]]:
     try:
         return query.select()
     except ProgrammingError as e:
-        if valid_do_not_exist_exception(e):
-            os.environ[SCHEMA_VERSION_ENV] = "5"
+        if is_valid_does_not_exist_exception(e):
+            set_schema_version(version="5")
             log_message("Build Details -- Schema version updated to 5")
         else:
             raise
@@ -75,10 +77,10 @@ def get_build_tests(build_id: str) -> Optional[list[dict]]:
             "environment_misc",
             f"build__{valid_status_field()}",
         )
-        return result
+        return list(result)
     except ProgrammingError as e:
-        if valid_do_not_exist_exception(e):
-            os.environ[SCHEMA_VERSION_ENV] = "5"
+        if is_valid_does_not_exist_exception(e):
+            set_schema_version(version="5")
             log_message("Build Details Tests -- Schema version updated to 5")
         else:
             raise

--- a/backend/kernelCI_app/queries/build.py
+++ b/backend/kernelCI_app/queries/build.py
@@ -1,5 +1,4 @@
 from django.db.utils import ProgrammingError
-import typing_extensions
 from typing import Optional
 from querybuilder.query import Query
 from kernelCI_app.helpers.environment import set_schema_version
@@ -11,9 +10,6 @@ from kernelCI_app.helpers.build import (
 from kernelCI_app.helpers.logger import log_message
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
 def get_build_details(build_id: str) -> Optional[list[dict]]:
     build_fields = [
         "id",
@@ -58,13 +54,11 @@ def get_build_details(build_id: str) -> Optional[list[dict]]:
         if is_valid_does_not_exist_exception(e):
             set_schema_version(version="5")
             log_message("Build Details -- Schema version updated to 5")
+            return get_build_details(build_id=build_id)
         else:
             raise
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
 def get_build_tests(build_id: str) -> Optional[list[dict]]:
     try:
         result = Tests.objects.filter(build_id=build_id).values(
@@ -82,5 +76,6 @@ def get_build_tests(build_id: str) -> Optional[list[dict]]:
         if is_valid_does_not_exist_exception(e):
             set_schema_version(version="5")
             log_message("Build Details Tests -- Schema version updated to 5")
+            return get_build_tests(build_id=build_id)
         else:
             raise

--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -340,9 +340,6 @@ def get_hardware_details_data(
     return records
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
 def query_records(
     *, hardware_id: str, origin: str, trees: list[Tree], start_date: int, end_date: int
 ) -> list[dict] | None:
@@ -430,6 +427,13 @@ def query_records(
         if is_valid_does_not_exist_exception(e):
             set_schema_version(version="5")
             log_message("Hardware Details -- Schema version updated to 5")
+            return query_records(
+                hardware_id=hardware_id,
+                origin=origin,
+                trees=trees,
+                start_date=start_date,
+                end_date=end_date,
+            )
         else:
             raise
 

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -1,12 +1,14 @@
-import os
 from django.db import connection
 from django.db.utils import ProgrammingError
 from kernelCI_app.helpers.database import dict_fetchall
+from kernelCI_app.helpers.environment import set_schema_version
 from kernelCI_app.helpers.logger import log_message
 import typing_extensions
 from kernelCI_app.models import Issues
-from kernelCI_app.helpers.build import valid_do_not_exist_exception, valid_status_field
-from kernelCI_app.constants.general import SCHEMA_VERSION_ENV
+from kernelCI_app.helpers.build import (
+    is_valid_does_not_exist_exception,
+    valid_status_field,
+)
 from datetime import datetime
 from django.db.models import Q
 
@@ -48,8 +50,8 @@ def get_issue_builds(*, issue_id: str, version: int) -> list[dict]:
             cursor.execute(query, params)
             return dict_fetchall(cursor)
     except ProgrammingError as e:
-        if valid_do_not_exist_exception(e):
-            os.environ[SCHEMA_VERSION_ENV] = "5"
+        if is_valid_does_not_exist_exception(e):
+            set_schema_version(version="5")
             log_message("Issue Builds -- Schema version updated to 5")
         else:
             raise

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -3,7 +3,6 @@ from django.db.utils import ProgrammingError
 from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.environment import set_schema_version
 from kernelCI_app.helpers.logger import log_message
-import typing_extensions
 from kernelCI_app.models import Issues
 from kernelCI_app.helpers.build import (
     is_valid_does_not_exist_exception,
@@ -13,9 +12,6 @@ from datetime import datetime
 from django.db.models import Q
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
 def get_issue_builds(*, issue_id: str, version: int) -> list[dict]:
     params = {
         "issue_id": issue_id,
@@ -53,6 +49,7 @@ def get_issue_builds(*, issue_id: str, version: int) -> list[dict]:
         if is_valid_does_not_exist_exception(e):
             set_schema_version(version="5")
             log_message("Issue Builds -- Schema version updated to 5")
+            return get_issue_builds(issue_id=issue_id, version=version)
         else:
             raise
 

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -297,9 +297,6 @@ def get_tree_listing_status(
         return cursor.fetchall()
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
 def get_tree_details_data(
     origin_param: str, git_url_param: str, git_branch_param: str, commit_hash: str
 ) -> Optional[list[tuple]]:
@@ -403,15 +400,18 @@ def get_tree_details_data(
             if is_valid_does_not_exist_exception(e):
                 set_schema_version(version="5")
                 log_message("Tree Details -- Schema version updated to 5")
+                return get_tree_details_data(
+                    origin_param=origin_param,
+                    git_url_param=git_url_param,
+                    commit_hash=commit_hash,
+                    git_branch_param=git_branch_param,
+                )
             else:
                 raise
 
     return rows
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
 def get_tree_commit_history(
     commit_hash: str, origin: str, git_url: str, git_branch: str
 ) -> Optional[list[tuple]]:
@@ -517,5 +517,11 @@ def get_tree_commit_history(
         if is_valid_does_not_exist_exception(e):
             set_schema_version(version="5")
             log_message("Tree Commit History -- Schema version updated to 5")
+            return get_tree_commit_history(
+                commit_hash=commit_hash,
+                origin=origin,
+                git_url=git_url,
+                git_branch=git_branch,
+            )
         else:
             raise

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -1,4 +1,3 @@
-import typing_extensions
 from typing import TypedDict, Optional
 from django.db import connection
 from django.db.utils import ProgrammingError
@@ -18,283 +17,166 @@ class IntervalInDays(TypedDict):
     days: int
 
 
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
 def get_tree_listing_data(
     origin: str, interval_in_days: IntervalInDays
 ) -> Optional[list[tuple]]:
+    build_valid_count_clause = """
+        COUNT(DISTINCT CASE WHEN (builds.valid = true AND builds.id NOT LIKE 'maestro:dummy_%%')
+            THEN builds.id END) AS pass_builds,
+        COUNT(DISTINCT CASE WHEN (builds.valid = false AND builds.id NOT LIKE 'maestro:dummy_%%')
+            THEN builds.id END) AS fail_builds,
+        COUNT(DISTINCT CASE WHEN (builds.valid IS NULL AND builds.id IS NOT NULL
+            AND builds.id NOT LIKE 'maestro:dummy_%%') THEN builds.id END) AS null_builds,
+        0 AS error_builds,
+        0 AS miss_builds,
+        0 AS done_builds,
+        0 AS skip_builds,
+    """
+
+    build_status_count_clause = """
+        COUNT(DISTINCT CASE WHEN (builds.status = 'PASS' AND builds.id NOT LIKE 'maestro:dummy_%%')
+            THEN builds.id END) AS pass_builds,
+        COUNT(DISTINCT CASE WHEN (builds.status = 'FAIL' AND builds.id NOT LIKE 'maestro:dummy_%%')
+            THEN builds.id END) AS fail_builds,
+        COUNT(DISTINCT CASE WHEN (builds.status IS NULL AND builds.id IS NOT NULL
+            AND builds.id NOT LIKE 'maestro:dummy_%%') THEN builds.id END) AS null_builds,
+        COUNT(DISTINCT CASE WHEN (builds.status = 'ERROR' AND builds.id NOT LIKE 'maestro:dummy_%%')
+            THEN builds.id END) AS fail_builds,
+        COUNT(DISTINCT CASE WHEN (builds.status = 'MISS' AND builds.id NOT LIKE 'maestro:dummy_%%')
+            THEN builds.id END) AS fail_builds,
+        COUNT(DISTINCT CASE WHEN (builds.status = 'DONE' AND builds.id NOT LIKE 'maestro:dummy_%%')
+            THEN builds.id END) AS fail_builds,
+        COUNT(DISTINCT CASE WHEN (builds.status = 'SKIP' AND builds.id NOT LIKE 'maestro:dummy_%%')
+            THEN builds.id END) AS fail_builds,
+    """
+
+    build_count_clause = (
+        build_valid_count_clause
+        if get_schema_version() == "4"
+        else build_status_count_clause
+    )
+
+    params = {
+        "origin_param": origin,
+        "interval_param": get_query_time_interval(**interval_in_days).timestamp(),
+    }
+
+    # '1 as id' is necessary in this case because django raw queries must include the primary key.
+    # In this case we don't need the primary key and adding it would alter the GROUP BY clause,
+    # potentially causing the tree listing page show the same tree multiple times
+    query = f"""
+            SELECT
+                1 as id,
+                checkouts.tree_name,
+                checkouts.git_repository_branch,
+                checkouts.git_repository_url,
+                checkouts.git_commit_hash,
+                CASE
+                    WHEN COUNT(DISTINCT checkouts.git_commit_tags) > 0 THEN
+                    COALESCE(
+                        ARRAY_AGG(DISTINCT checkouts.git_commit_tags) FILTER (
+                            WHERE checkouts.git_commit_tags IS NOT NULL
+                            AND checkouts.git_commit_tags::TEXT <> '{"{}"}'
+                        ),
+                        ARRAY[]::TEXT[]
+                    )
+                    ELSE ARRAY[]::TEXT[]
+                END AS git_commit_tags,
+                MAX(checkouts.git_commit_name) AS git_commit_name,
+                MAX(checkouts.start_time) AS start_time,
+                {build_count_clause}
+                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
+                    AND tests.status = 'FAIL' THEN 1 END) AS fail_tests,
+                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
+                    AND tests.status = 'ERROR' THEN 1 END) AS error_tests,
+                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
+                    AND tests.status = 'MISS' THEN 1 END) AS miss_tests,
+                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
+                    AND tests.status = 'PASS' THEN 1 END) AS pass_tests,
+                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
+                    AND tests.status = 'DONE' THEN 1 END) AS done_tests,
+                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
+                    AND tests.status = 'SKIP' THEN 1 END) AS skip_tests,
+                SUM(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
+                    AND tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END) AS null_tests,
+                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
+                    AND tests.status = 'FAIL' THEN 1 END) AS fail_boots,
+                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
+                    AND tests.status = 'ERROR' THEN 1 END) AS error_boots,
+                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
+                    AND tests.status = 'MISS' THEN 1 END) AS miss_boots,
+                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
+                    AND tests.status = 'PASS' THEN 1 END) AS pass_boots,
+                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
+                    AND tests.status = 'DONE' THEN 1 END) AS done_boots,
+                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
+                    AND tests.status = 'SKIP' THEN 1 END) AS skip_boots,
+                SUM(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
+                    AND tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END) AS null_boots,
+                COALESCE(
+                    ARRAY_AGG(DISTINCT tree_name) FILTER (
+                        WHERE tree_name IS NOT NULL
+                    ),
+                    ARRAY[]::TEXT[]
+                ) AS tree_names
+            FROM
+                checkouts
+            LEFT JOIN
+                builds ON builds.checkout_id = checkouts.id
+            LEFT JOIN
+                tests ON tests.build_id = builds.id
+            WHERE
+                checkouts.git_commit_hash IN (
+                    SELECT
+                        git_commit_hash
+                    FROM
+                        (
+                            SELECT
+                                git_repository_branch,
+                                git_repository_url,
+                                git_commit_hash,
+                                ROW_NUMBER() OVER (
+                                    PARTITION BY git_repository_url, git_repository_branch
+                                    ORDER BY start_time DESC
+                                ) AS time_order
+                            FROM
+                                checkouts
+                            WHERE
+                                origin = %(origin_param)s
+                                AND start_time >= TO_TIMESTAMP(%(interval_param)s)
+                        ) AS ordered_checkouts_by_tree
+                    WHERE
+                        time_order = 1
+                    ORDER BY
+                        git_repository_branch,
+                        git_repository_url,
+                        time_order
+                )
+                AND checkouts.origin = %(origin_param)s
+            GROUP BY
+                checkouts.git_commit_hash,
+                checkouts.git_repository_branch,
+                checkouts.git_repository_url,
+                checkouts.tree_name
+            ORDER BY
+                checkouts.git_commit_hash;
+            ;
+            """
+
     try:
-        if get_schema_version() != "5":
-            return get_tree_listing_valid(origin, interval_in_days)
-        return get_tree_listing_status(origin, interval_in_days)
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            return cursor.fetchall()
     except ProgrammingError as e:
         if is_valid_does_not_exist_exception(e):
-            set_schema_version("5")
+            set_schema_version(version="5")
             log_message("Tree Listing Status -- Schema version updated to 5")
-            return get_tree_listing_status(origin, interval_in_days)
+            return get_tree_listing_data(
+                origin=origin,
+                interval_in_days=interval_in_days,
+            )
         else:
             raise
-
-
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
-def get_tree_listing_valid(
-    origin: str, interval_in_days: IntervalInDays
-) -> Optional[list[tuple]]:
-    params = {
-        "origin_param": origin,
-        "interval_param": get_query_time_interval(**interval_in_days).timestamp(),
-    }
-
-    # TODO: Check if this status count is correct
-
-    # '1 as id' is necessary in this case because django raw queries must include the primary key.
-    # In this case we don't need the primary key and adding it would alter the GROUP BY clause,
-    # potentially causing the tree listing page show the same tree multiple times
-    query = """
-            SELECT
-                1 as id,
-                checkouts.tree_name,
-                checkouts.git_repository_branch,
-                checkouts.git_repository_url,
-                checkouts.git_commit_hash,
-                CASE
-                    WHEN COUNT(DISTINCT checkouts.git_commit_tags) > 0 THEN
-                    COALESCE(
-                        ARRAY_AGG(DISTINCT checkouts.git_commit_tags) FILTER (
-                            WHERE checkouts.git_commit_tags IS NOT NULL
-                            AND checkouts.git_commit_tags::TEXT <> '{}'
-                        ),
-                        ARRAY[]::TEXT[]
-                    )
-                    ELSE ARRAY[]::TEXT[]
-                END AS git_commit_tags,
-                MAX(checkouts.git_commit_name) AS git_commit_name,
-                MAX(checkouts.start_time) AS start_time,
-                COUNT(DISTINCT CASE WHEN (builds.valid = true AND builds.id NOT LIKE 'maestro:dummy_%%')
-                    THEN builds.id END) AS pass_builds,
-                COUNT(DISTINCT CASE WHEN (builds.valid = false AND builds.id NOT LIKE 'maestro:dummy_%%')
-                    THEN builds.id END) AS fail_builds,
-                COUNT(DISTINCT CASE WHEN (builds.valid IS NULL AND builds.id IS NOT NULL
-                    AND builds.id NOT LIKE 'maestro:dummy_%%') THEN builds.id END) AS null_builds,
-                0 AS error_builds,
-                0 AS miss_builds,
-                0 AS done_builds,
-                0 AS skip_builds,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'FAIL' THEN 1 END) AS fail_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'ERROR' THEN 1 END) AS error_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'MISS' THEN 1 END) AS miss_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'PASS' THEN 1 END) AS pass_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'DONE' THEN 1 END) AS done_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'SKIP' THEN 1 END) AS skip_tests,
-                SUM(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END) AS null_tests,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'FAIL' THEN 1 END) AS fail_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'ERROR' THEN 1 END) AS error_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'MISS' THEN 1 END) AS miss_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'PASS' THEN 1 END) AS pass_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'DONE' THEN 1 END) AS done_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'SKIP' THEN 1 END) AS skip_boots,
-                SUM(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END) AS null_boots,
-                COALESCE(
-                    ARRAY_AGG(DISTINCT tree_name) FILTER (
-                        WHERE tree_name IS NOT NULL
-                    ),
-                    ARRAY[]::TEXT[]
-                ) AS tree_names
-            FROM
-                checkouts
-            LEFT JOIN
-                builds ON builds.checkout_id = checkouts.id
-            LEFT JOIN
-                tests ON tests.build_id = builds.id
-            WHERE
-                checkouts.git_commit_hash IN (
-                    SELECT
-                        git_commit_hash
-                    FROM
-                        (
-                            SELECT
-                                git_repository_branch,
-                                git_repository_url,
-                                git_commit_hash,
-                                ROW_NUMBER() OVER (
-                                    PARTITION BY git_repository_url, git_repository_branch
-                                    ORDER BY start_time DESC
-                                ) AS time_order
-                            FROM
-                                checkouts
-                            WHERE
-                                origin = %(origin_param)s
-                                AND start_time >= TO_TIMESTAMP(%(interval_param)s)
-                        ) AS ordered_checkouts_by_tree
-                    WHERE
-                        time_order = 1
-                    ORDER BY
-                        git_repository_branch,
-                        git_repository_url,
-                        time_order
-                )
-                AND checkouts.origin = %(origin_param)s
-            GROUP BY
-                checkouts.git_commit_hash,
-                checkouts.git_repository_branch,
-                checkouts.git_repository_url,
-                checkouts.tree_name
-            ORDER BY
-                checkouts.git_commit_hash;
-            ;
-            """
-
-    with connection.cursor() as cursor:
-        cursor.execute(query, params)
-        return cursor.fetchall()
-
-
-@typing_extensions.deprecated(
-    "This implementation is temporary while the schema is being updated."
-)
-def get_tree_listing_status(
-    origin: str, interval_in_days: IntervalInDays
-) -> Optional[list[tuple]]:
-    params = {
-        "origin_param": origin,
-        "interval_param": get_query_time_interval(**interval_in_days).timestamp(),
-    }
-
-    # '1 as id' is necessary in this case because django raw queries must include the primary key.
-    # In this case we don't need the primary key and adding it would alter the GROUP BY clause,
-    # potentially causing the tree listing page show the same tree multiple times
-    query = """
-            SELECT
-                1 as id,
-                checkouts.tree_name,
-                checkouts.git_repository_branch,
-                checkouts.git_repository_url,
-                checkouts.git_commit_hash,
-                CASE
-                    WHEN COUNT(DISTINCT checkouts.git_commit_tags) > 0 THEN
-                    COALESCE(
-                        ARRAY_AGG(DISTINCT checkouts.git_commit_tags) FILTER (
-                            WHERE checkouts.git_commit_tags IS NOT NULL
-                            AND checkouts.git_commit_tags::TEXT <> '{}'
-                        ),
-                        ARRAY[]::TEXT[]
-                    )
-                    ELSE ARRAY[]::TEXT[]
-                END AS git_commit_tags,
-                MAX(checkouts.git_commit_name) AS git_commit_name,
-                MAX(checkouts.start_time) AS start_time,
-                COUNT(DISTINCT CASE WHEN (builds.status = 'PASS' AND builds.id NOT LIKE 'maestro:dummy_%%')
-                    THEN builds.id END) AS pass_builds,
-                COUNT(DISTINCT CASE WHEN (builds.status = 'FAIL' AND builds.id NOT LIKE 'maestro:dummy_%%')
-                    THEN builds.id END) AS fail_builds,
-                COUNT(DISTINCT CASE WHEN (builds.status IS NULL AND builds.id IS NOT NULL
-                    AND builds.id NOT LIKE 'maestro:dummy_%%') THEN builds.id END) AS null_builds,
-                COUNT(DISTINCT CASE WHEN (builds.status = 'ERROR' AND builds.id NOT LIKE 'maestro:dummy_%%')
-                    THEN builds.id END) AS fail_builds,
-                COUNT(DISTINCT CASE WHEN (builds.status = 'MISS' AND builds.id NOT LIKE 'maestro:dummy_%%')
-                    THEN builds.id END) AS fail_builds,
-                COUNT(DISTINCT CASE WHEN (builds.status = 'DONE' AND builds.id NOT LIKE 'maestro:dummy_%%')
-                    THEN builds.id END) AS fail_builds,
-                COUNT(DISTINCT CASE WHEN (builds.status = 'SKIP' AND builds.id NOT LIKE 'maestro:dummy_%%')
-                    THEN builds.id END) AS fail_builds,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'FAIL' THEN 1 END) AS fail_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'ERROR' THEN 1 END) AS error_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'MISS' THEN 1 END) AS miss_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'PASS' THEN 1 END) AS pass_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'DONE' THEN 1 END) AS done_tests,
-                COUNT(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status = 'SKIP' THEN 1 END) AS skip_tests,
-                SUM(CASE WHEN (tests.path <> 'boot' AND tests.path NOT LIKE 'boot.%%')
-                    AND tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END) AS null_tests,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'FAIL' THEN 1 END) AS fail_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'ERROR' THEN 1 END) AS error_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'MISS' THEN 1 END) AS miss_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'PASS' THEN 1 END) AS pass_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'DONE' THEN 1 END) AS done_boots,
-                COUNT(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status = 'SKIP' THEN 1 END) AS skip_boots,
-                SUM(CASE WHEN (tests.path = 'boot' OR tests.path LIKE 'boot.%%')
-                    AND tests.status IS NULL AND tests.id IS NOT NULL THEN 1 ELSE 0 END) AS null_boots,
-                COALESCE(
-                    ARRAY_AGG(DISTINCT tree_name) FILTER (
-                        WHERE tree_name IS NOT NULL
-                    ),
-                    ARRAY[]::TEXT[]
-                ) AS tree_names
-            FROM
-                checkouts
-            LEFT JOIN
-                builds ON builds.checkout_id = checkouts.id
-            LEFT JOIN
-                tests ON tests.build_id = builds.id
-            WHERE
-                checkouts.git_commit_hash IN (
-                    SELECT
-                        git_commit_hash
-                    FROM
-                        (
-                            SELECT
-                                git_repository_branch,
-                                git_repository_url,
-                                git_commit_hash,
-                                ROW_NUMBER() OVER (
-                                    PARTITION BY git_repository_url, git_repository_branch
-                                    ORDER BY start_time DESC
-                                ) AS time_order
-                            FROM
-                                checkouts
-                            WHERE
-                                origin = %(origin_param)s
-                                AND start_time >= TO_TIMESTAMP(%(interval_param)s)
-                        ) AS ordered_checkouts_by_tree
-                    WHERE
-                        time_order = 1
-                    ORDER BY
-                        git_repository_branch,
-                        git_repository_url,
-                        time_order
-                )
-                AND checkouts.origin = %(origin_param)s
-            GROUP BY
-                checkouts.git_commit_hash,
-                checkouts.git_repository_branch,
-                checkouts.git_repository_url,
-                checkouts.tree_name
-            ORDER BY
-                checkouts.git_commit_hash;
-            ;
-            """
-
-    with connection.cursor() as cursor:
-        cursor.execute(query, params)
-        return cursor.fetchall()
 
 
 def get_tree_details_data(

--- a/backend/kernelCI_app/views/buildDetailsView.py
+++ b/backend/kernelCI_app/views/buildDetailsView.py
@@ -13,17 +13,6 @@ class BuildDetails(APIView):
     def get(self, request, build_id: str) -> Response:
         records = get_build_details(build_id)
 
-        # Temporary during schema transition
-        if records is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if not records:
             return create_api_error_response(
                 error_message="Build not found",

--- a/backend/kernelCI_app/views/buildTestsView.py
+++ b/backend/kernelCI_app/views/buildTestsView.py
@@ -17,21 +17,10 @@ class BuildTests(APIView):
     def get(self, request, build_id: str) -> Response:
         result = get_build_tests(build_id)
 
-        # Temporary during schema transition
-        if result is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if not result:
-            return Response(
-                data={"error": "No tests found for this build"},
-                status=HTTPStatus.OK,
+            return create_api_error_response(
+                error_message="No tests found for this build",
+                status_code=HTTPStatus.OK,
             )
 
         if (

--- a/backend/kernelCI_app/views/hardwareDetailsBootsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBootsView.py
@@ -151,20 +151,10 @@ class HardwareDetailsBoots(APIView):
             end_datetime=self.end_datetime,
         )
 
-        # Temporary during schema transition
-        if records is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(records) == 0:
-            return Response(
-                data={"error": "No boots found for this hardware"}, status=HTTPStatus.OK
+            return create_api_error_response(
+                error_message="No boots found for this hardware",
+                status_code=HTTPStatus.OK,
             )
 
         is_all_selected = len(self.selected_commits) == 0

--- a/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
@@ -98,7 +98,7 @@ class HardwareDetailsBuilds(APIView):
         methods=["POST"],
         responses=HardwareDetailsBuildsResponse,
     )
-    def post(self, request, hardware_id):
+    def post(self, request, hardware_id) -> Response:
         try:
             unstable_parse_post_body(instance=self, request=request)
         except ValidationError as e:
@@ -144,21 +144,10 @@ class HardwareDetailsBuilds(APIView):
             end_datetime=self.end_datetime,
         )
 
-        # Temporary during schema transition
-        if records is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(records) == 0:
-            return Response(
-                data={"error": "No builds found for this hardware"},
-                status=HTTPStatus.OK,
+            return create_api_error_response(
+                error_message="No builds found for this hardware",
+                status_code=HTTPStatus.OK,
             )
 
         is_all_selected = len(self.selected_commits) == 0

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -294,19 +294,11 @@ class HardwareDetailsSummary(APIView):
             end_datetime=self.end_datetime,
         )
 
-        # Temporary during schema transition
-        if records is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(records) == 0:
-            return Response(data={"error": "Hardware not found"}, status=HTTPStatus.OK)
+            return create_api_error_response(
+                error_message="Hardware not found",
+                status_code=HTTPStatus.OK,
+            )
 
         is_all_selected = len(self.selected_commits) == 0
 

--- a/backend/kernelCI_app/views/hardwareDetailsTestsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsTestsView.py
@@ -149,20 +149,10 @@ class HardwareDetailsTests(APIView):
             end_datetime=self.end_datetime,
         )
 
-        # Temporary during schema transition
-        if records is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(records) == 0:
-            return Response(
-                data={"error": "No tests found for this hardware"}, status=HTTPStatus.OK
+            return create_api_error_response(
+                error_message="No tests found for this hardware",
+                status_code=HTTPStatus.OK,
             )
 
         is_all_selected = len(self.selected_commits) == 0

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -216,7 +216,7 @@ class HardwareDetails(APIView):
         request=HardwareDetailsPostBody,
         methods=["POST"],
     )
-    def post(self, request, hardware_id):
+    def post(self, request, hardware_id) -> Response:
         try:
             unstable_parse_post_body(instance=self, request=request)
         except ValidationError as e:
@@ -262,19 +262,11 @@ class HardwareDetails(APIView):
             end_datetime=self.end_datetime,
         )
 
-        # Temporary during schema transition
-        if records is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(records) == 0:
-            return Response(data={"error": "Hardware not found"}, status=HTTPStatus.OK)
+            return create_api_error_response(
+                error_message="Hardware not found",
+                status_code=HTTPStatus.OK,
+            )
 
         is_all_selected = len(self.selected_commits) == 0
 

--- a/backend/kernelCI_app/views/issueDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/issueDetailsBuildsView.py
@@ -42,17 +42,6 @@ class IssueDetailsBuilds(APIView):
             issue_id=parsed_params.issue_id, version=parsed_query.version
         )
 
-        # Temporary during schema transition
-        if builds_data is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if not builds_data:
             return create_api_error_response(
                 error_message="No builds found for this issue",

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -413,17 +413,6 @@ class TreeCommitsHistory(APIView):
             git_branch=git_branch_param,
         )
 
-        # Temporary during schema transition
-        if rows is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if not rows:
             return create_api_error_response(
                 error_message="History of tree commits not found",

--- a/backend/kernelCI_app/views/treeDetailsBootsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBootsView.py
@@ -4,10 +4,7 @@ from http import HTTPStatus
 from drf_spectacular.utils import extend_schema
 from kernelCI_app.typeModels.issues import Issue
 from pydantic import ValidationError
-from kernelCI_app.helpers.errorHandling import (
-    create_api_error_response,
-    create_error_response,
-)
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
 )
@@ -71,7 +68,7 @@ class TreeDetailsBoots(APIView):
         methods=["GET"],
         responses=CommonDetailsBootsResponse,
     )
-    def get(self, request, commit_hash: str | None):
+    def get(self, request, commit_hash: str | None) -> Response:
         origin_param = request.GET.get("origin")
         git_url_param = request.GET.get("git_url")
         git_branch_param = request.GET.get("git_branch")
@@ -82,20 +79,10 @@ class TreeDetailsBoots(APIView):
 
         self.filters = FilterParams(request)
 
-        # Temporary during schema transition
-        if rows is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(rows) == 0:
-            return create_error_response(
-                error_message="No boots found for this tree", status_code=HTTPStatus.OK
+            return create_api_error_response(
+                error_message="No boots found for this tree",
+                status_code=HTTPStatus.OK,
             )
 
         try:

--- a/backend/kernelCI_app/views/treeDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBuildsView.py
@@ -4,10 +4,7 @@ from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from kernelCI_app.helpers.errorHandling import (
-    create_api_error_response,
-    create_error_response,
-)
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
 )
@@ -67,7 +64,7 @@ class TreeDetailsBuilds(APIView):
         responses=TreeDetailsBuildsResponse,
         methods=["GET"],
     )
-    def get(self, request, commit_hash: str | None):
+    def get(self, request, commit_hash: str | None) -> Response:
         origin_param = request.GET.get("origin")
         git_url_param = request.GET.get("git_url")
         git_branch_param = request.GET.get("git_branch")
@@ -78,20 +75,10 @@ class TreeDetailsBuilds(APIView):
 
         self.filters = FilterParams(request)
 
-        # Temporary during schema transition
-        if rows is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(rows) == 0:
-            return create_error_response(
-                error_message="No builds found for this tree", status_code=HTTPStatus.OK
+            return create_api_error_response(
+                error_message="No builds found for this tree",
+                status_code=HTTPStatus.OK,
             )
 
         self._sanitize_rows(rows)

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -43,10 +43,7 @@ from collections import defaultdict
 from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 from kernelCI_app.viewCommon import create_details_build_summary
-from kernelCI_app.helpers.errorHandling import (
-    create_api_error_response,
-    create_error_response,
-)
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from http import HTTPStatus
 from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 
@@ -181,7 +178,7 @@ class TreeDetailsSummary(APIView):
         parameters=[TreeQueryParameters],
         methods=["GET"],
     )
-    def get(self, request, commit_hash: str | None):
+    def get(self, request, commit_hash: str | None) -> Response:
         origin_param = request.GET.get("origin")
         git_url_param = request.GET.get("git_url")
         git_branch_param = request.GET.get("git_branch")
@@ -190,20 +187,10 @@ class TreeDetailsSummary(APIView):
             origin_param, git_url_param, git_branch_param, commit_hash
         )
 
-        # Temporary during schema transition
-        if rows is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(rows) == 0:
-            return create_error_response(
-                error_message="Tree not found", status_code=HTTPStatus.OK
+            return create_api_error_response(
+                error_message="Tree not found",
+                status_code=HTTPStatus.OK,
             )
 
         self.filters = FilterParams(request)

--- a/backend/kernelCI_app/views/treeDetailsTestsView.py
+++ b/backend/kernelCI_app/views/treeDetailsTestsView.py
@@ -5,10 +5,7 @@ from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from http import HTTPStatus
-from kernelCI_app.helpers.errorHandling import (
-    create_api_error_response,
-    create_error_response,
-)
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
 )
@@ -75,7 +72,7 @@ class TreeDetailsTests(APIView):
         parameters=[TreeQueryParameters],
         responses=CommonDetailsTestsResponse,
     )
-    def get(self, request, commit_hash: str | None):
+    def get(self, request, commit_hash: str | None) -> Response:
         origin_param = request.GET.get("origin")
         git_url_param = request.GET.get("git_url")
         git_branch_param = request.GET.get("git_branch")
@@ -86,20 +83,10 @@ class TreeDetailsTests(APIView):
 
         self.filters = FilterParams(request)
 
-        # Temporary during schema transition
-        if rows is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(rows) == 0:
-            return create_error_response(
-                error_message="No tests found for this tree", status_code=HTTPStatus.OK
+            return create_api_error_response(
+                error_message="No tests found for this tree",
+                status_code=HTTPStatus.OK,
             )
 
         try:

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -199,20 +199,10 @@ class TreeDetails(APIView):
 
         self.filters = FilterParams(request)
 
-        # Temporary during schema transition
-        if rows is None:
-            message = (
-                "This error was probably caused because the server was using"
-                "an old version of the database. Please try requesting again"
-            )
-            return create_api_error_response(
-                error_message=message,
-                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-
         if len(rows) == 0:
             return create_api_error_response(
-                error_message="Tree not found", status_code=HTTPStatus.OK
+                error_message="Tree not found",
+                status_code=HTTPStatus.OK,
             )
 
         self._sanitize_rows(rows)
@@ -285,8 +275,6 @@ class TreeDetails(APIView):
                 ),
             )
         except ValidationError as e:
-            return create_api_error_response(
-                error_message=e.json(), status_code=HTTPStatus.INTERNAL_SERVER_ERROR
-            )
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())


### PR DESCRIPTION
## Changes
- Adds schema-version file instead of environment variable, so it can be shared between processes in the production docker instance
- Makes queries with db schema version 4 update schema and return correct data instead of just returning an error
- Refactors queries with build valid/status versions to be a single function
- Updates default db schema version to 5 and removes temporary error messages
  - Also updates some endpoints to only return a `Response`, removing the need for `create_error_response`

## How to test
To test the update from db schema version 4 to 5, change the file "schema-version.yaml" to set the variable as '4' and check endpoints which can change the db schema
Also test running on docker
Check if the updated queries are still returning correct data

Closes #1109 