### PR TITLE
fix: disable refetch on windows focus

### DIFF
--- a/dashboard/src/api/buildDetails.ts
+++ b/dashboard/src/api/buildDetails.ts
@@ -2,7 +2,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
 import type { TBuildDetails } from '@/types/tree/BuildDetails';
-
+import type { ApiUseQueryOptions } from '@/types/api';
 import type { TIssue } from '@/types/issues';
 
 import { RequestData } from './commonRequest';
@@ -21,7 +21,10 @@ const fetchBuildDetailsData = async (
 
 export const useBuildDetails = (
   buildId: string,
-  config: { enabled?: boolean } = { enabled: true },
+  config: ApiUseQueryOptions<TBuildDetails> = {
+    enabled: true,
+    refetchOnWindowFocus: false,
+  },
 ): UseQueryResult<TBuildDetails> => {
   return useQuery({
     queryKey: ['treeData', buildId],
@@ -41,5 +44,6 @@ export const useBuildIssues = (buildId: string): UseQueryResult<TIssue[]> => {
     queryKey: ['buildIssues', buildId],
     queryFn: () => fetchBuildIssues(buildId),
     enabled: buildId !== '',
+    refetchOnWindowFocus: false,
   });
 };

--- a/dashboard/src/api/buildTests.ts
+++ b/dashboard/src/api/buildTests.ts
@@ -19,5 +19,6 @@ export const useBuildTests = (
   return useQuery({
     queryKey: ['buildTests', buildId],
     queryFn: () => fetchBuildTestsData(buildId),
+    refetchOnWindowFocus: false,
   });
 };

--- a/dashboard/src/api/hardware.ts
+++ b/dashboard/src/api/hardware.ts
@@ -49,5 +49,6 @@ export const useHardwareListing = (
         startTimestampInSeconds,
         endTimestampInSeconds,
       ),
+    refetchOnWindowFocus: false,
   });
 };

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -179,6 +179,7 @@ export const useHardwareDetails = <T extends HardwareDetailsVariants>({
     queryFn: () => fetchHardwareDetails({ hardwareId, body, variant }),
     placeholderData: previousData => previousData,
     enabled: enabled,
+    refetchOnWindowFocus: false,
   });
 };
 

--- a/dashboard/src/api/issueDetails.ts
+++ b/dashboard/src/api/issueDetails.ts
@@ -63,6 +63,7 @@ export const useIssueDetailsTests = (
     queryKey: ['issueTestsData', issueId, versionNumber],
     queryFn: () => fetchIssueDetailsTests(issueId, versionNumber),
     retry: 1,
+    refetchOnWindowFocus: false,
   });
 };
 
@@ -90,5 +91,6 @@ export const useIssueDetailsBuilds = (
     queryKey: ['issueBuildsData', issueId, versionNumber],
     queryFn: () => fetchIssueDetailsBuilds(issueId, versionNumber),
     retry: 1,
+    refetchOnWindowFocus: false,
   });
 };

--- a/dashboard/src/api/testDetails.ts
+++ b/dashboard/src/api/testDetails.ts
@@ -8,6 +8,7 @@ import type {
 } from '@/types/tree/TestDetails';
 
 import type { TIssue } from '@/types/issues';
+import type { ApiUseQueryOptions } from '@/types/api';
 
 import { RequestData } from './commonRequest';
 
@@ -18,7 +19,10 @@ const fetchTestDetails = async (testId: string): Promise<TTestDetails> => {
 
 export const useTestDetails = (
   testId: string,
-  config: { enabled?: boolean } = { enabled: true },
+  config: ApiUseQueryOptions<TTestDetails> = {
+    enabled: true,
+    refetchOnWindowFocus: false,
+  },
 ): UseQueryResult<TTestDetails> => {
   return useQuery({
     queryKey: ['testDetailsData', testId],
@@ -41,6 +45,7 @@ export const useTestIssues = (
     queryKey: ['testIssues', testId],
     enabled: testId !== '' && enabled,
     queryFn: () => fetchTestIssues(testId),
+    refetchOnWindowFocus: false,
   });
 };
 

--- a/dashboard/src/api/treeDetails.ts
+++ b/dashboard/src/api/treeDetails.ts
@@ -123,6 +123,7 @@ export const useTreeDetails = <T extends TreeDetailsVariants>({
         },
       }),
     enabled,
+    refetchOnWindowFocus: false,
     placeholderData: previousData => previousData,
   });
 };

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -1,0 +1,6 @@
+import type { UseBaseQueryOptions } from '@tanstack/react-query';
+
+export type ApiUseQueryOptions<T> = Omit<
+  Partial<UseBaseQueryOptions<T>>,
+  'queryKey' | 'queryFn'
+>;


### PR DESCRIPTION
Disabled refetch on window focus for the queries where this was a problem:
- useBuildTests
- useBuildIssues
- useTestIssues

Closes #1066

## How to test
Open the a build or test details, wait until the issue section and test results section (for build details) are loaded, change tabs and go back to the details page. The section should not start loading again like it does on prod. You can test the same thing for the issue section in builds/boots/tests tables on any page (tree details, for example)