### PR TITLE
fix: update error messages for empty data

### DIFF
--- a/dashboard/src/api/commonRequest.ts
+++ b/dashboard/src/api/commonRequest.ts
@@ -23,7 +23,7 @@ export class RequestData {
     const res = await http.post<ResponseData<T>>(url, data, config);
 
     if (res.data.error) {
-      throw new Error(res.data.error);
+      throw new Error(`${res.status}:${res.data.error}`);
     }
 
     return res.data;

--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -291,7 +291,7 @@ const BuildDetails = ({
           <MemoizedSectionError
             isLoading={isLoading}
             errorMessage={error?.message}
-            emptyLabel={'global.error'}
+            emptyLabel="buildDetails.notFound"
           />
         }
       >

--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -218,7 +218,7 @@ export const IssueDetails = ({
           <MemoizedSectionError
             isLoading={isLoading}
             errorMessage={error?.message}
-            emptyLabel={'global.error'}
+            emptyLabel="issueDetails.notFound"
           />
         }
       >

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -497,7 +497,7 @@ const TestDetails = ({ breadcrumb }: TestsDetailsProps): JSX.Element => {
           <MemoizedSectionError
             isLoading={isLoading}
             errorMessage={error?.message}
-            emptyLabel={'global.error'}
+            emptyLabel="testDetails.notFound"
           />
         }
       >

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -33,6 +33,7 @@ export const messages = {
     'buildDetails.gitDescribe': 'Git Describe',
     'buildDetails.kernelConfig': 'Kernel Config',
     'buildDetails.noTestResults': 'No tests executed for this build',
+    'buildDetails.notFound': 'Build not found',
     'buildDetails.startTime': 'Start Time',
     'buildDetails.testResults': 'Test Results',
     'buildTab.buildStatus': 'Build status',
@@ -170,6 +171,7 @@ export const messages = {
     'hardware.path': 'Hardware',
     'hardware.searchPlaceholder':
       'Search by hardware name or platform with a regex',
+    'hardwareDetails.notFound': 'Hardware not found',
     'hardwareDetails.platforms': 'Platforms',
     'hardwareDetails.timeFrame':
       'Results from {startDate} and {startTime} to {endDate} {endTime}',
@@ -293,6 +295,7 @@ export const messages = {
     'treeDetails.inconclusiveBuilds': 'Inconclusive Builds',
     'treeDetails.inconclusiveTests': 'Inconclusive Tests',
     'treeDetails.invalidBuilds': 'Failed builds',
+    'treeDetails.notFound': 'Tree not found',
     'treeDetails.successBoots': 'Success boots',
     'treeDetails.testsFailed': 'Failed tests',
     'treeDetails.testsHistory': 'Tests History',

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -334,7 +334,7 @@ function TreeDetails(): JSX.Element {
           <MemoizedSectionError
             isLoading={isLoading}
             errorMessage={error?.message}
-            emptyLabel={'global.error'}
+            emptyLabel="treeDetails.notFound"
           />
         }
       >

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -361,7 +361,7 @@ function HardwareDetails(): JSX.Element {
           <MemoizedSectionError
             isLoading={summaryResponse.isLoading}
             errorMessage={summaryResponse.error?.message}
-            emptyLabel={'global.error'}
+            emptyLabel="hardwareDetails.notFound"
           />
         }
       >


### PR DESCRIPTION
Closes #1119

**NOTE:** I did not change `CommitNavigationGraph` and `TestStatusHistory` messages because if the page is loaded them they should also return with no errors (since they should return at least the data for the current page)