### PR TITLE
Feat: discord message improvements

### DIFF
--- a/backend/kernelCI_app/cache.py
+++ b/backend/kernelCI_app/cache.py
@@ -2,6 +2,9 @@ from django.core.cache import cache
 from django.conf import settings
 
 timeout = settings.CACHE_TIMEOUT
+DISCORD_NOTIFICATION_COOLDOWN = 600
+
+DISCORD_NOTIFICATION_KEY = "discord_notification"
 
 _commit_lookup = {}
 _build_lookup = {}
@@ -31,6 +34,18 @@ def set_query_cache(
 def get_query_cache(key, params: dict):
     params_hash = _create_cache_params_hash(params)
     return cache.get("%s-%s" % (key, params_hash))
+
+
+def set_notification_cache(*, notification: str) -> None:
+    notification_hash = hash(notification)
+    hash_key = f"{DISCORD_NOTIFICATION_KEY}-{notification_hash}"
+    return cache.set(hash_key, notification, DISCORD_NOTIFICATION_COOLDOWN)
+
+
+def get_notification_cache(*, notification: str) -> str:
+    notification_hash = hash(notification)
+    hash_key = f"{DISCORD_NOTIFICATION_KEY}-{notification_hash}"
+    return cache.get(hash_key)
 
 
 def _add_to_lookup(cache_key, property_key, lookup):

--- a/backend/kernelCI_app/constants/general.py
+++ b/backend/kernelCI_app/constants/general.py
@@ -10,3 +10,4 @@ SCHEMA_VERSION_ENV_NAME = "schema-version"
 SCHEMA_VERSION_ENV_FILE = "kernelCI/envconfig/schema-version.yaml"
 
 PRODUCTION_HOST = "https://dashboard.kernelci.org"
+STAGING_HOST = "https://staging.dashboard.kernelci.org:9000"

--- a/backend/kernelCI_app/helpers/discordWebhook.py
+++ b/backend/kernelCI_app/helpers/discordWebhook.py
@@ -1,8 +1,14 @@
+from datetime import datetime, timezone
 from typing import Any, Optional, TypedDict
 
 import requests
 import os
 
+from kernelCI_app.cache import (
+    DISCORD_NOTIFICATION_COOLDOWN,
+    get_notification_cache,
+    set_notification_cache,
+)
 from kernelCI_app.helpers.logger import log_message
 
 # For more information on discord webhook structure, visit
@@ -25,6 +31,29 @@ class DiscordEmbed(TypedDict):
     image: Optional[DiscordImage]
 
 
+def validate_notification(
+    *,
+    url,
+    content: Optional[str],
+    embeds: Optional[list[DiscordEmbed]],
+) -> bool:
+    if not url:
+        log_message("DISCORD_WEBHOOK_URL environment variable is not set.")
+        return False
+
+    if not content and not embeds:
+        log_message(
+            "Either content or embeds must be set in order to send notifications."
+        )
+        return False
+
+    if embeds is not None and len(embeds) > 10:
+        log_message("The embed list can contain at most 10 elements.")
+        return False
+
+    return True
+
+
 def send_discord_notification(
     *,
     content: Optional[str] = None,
@@ -33,18 +62,12 @@ def send_discord_notification(
     webhook_name: Optional[str] = WEBHOOK_NAME,
 ) -> None:
     url = os.getenv("DISCORD_WEBHOOK_URL")
-    if not url:
-        log_message("DISCORD_WEBHOOK_URL environment variable is not set.")
-        return
-
-    if not content and not embeds:
-        log_message(
-            "Either content or embeds must be set in order to send notifications."
-        )
-        return
-
-    if embeds is not None and len(embeds) > 10:
-        log_message("The embed list can contain at most 10 elements.")
+    is_valid_notification = validate_notification(
+        url=url,
+        content=content,
+        embeds=embeds,
+    )
+    if not is_valid_notification:
         return
 
     data: dict[str, Any] = {
@@ -52,7 +75,25 @@ def send_discord_notification(
         "username": webhook_name,
     }
     if content is not None:
-        data["content"] = content
+        try:
+            message_cache = get_notification_cache(notification=content)
+            if message_cache is not None:
+                log_message(
+                    f"Message already sent in the last {DISCORD_NOTIFICATION_COOLDOWN} seconds."
+                )
+                return
+        except Exception as e:
+            log_message(f"Error when getting discord notification cache.\nError: {e}")
+            return
+        set_notification_cache(notification=content)
+
+        access_time = (
+            "\nAccessed in: "
+            + datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+            + "\n---"
+        )
+        data["content"] = content + access_time
+
     if embeds is not None:
         data["embeds"] = embeds
 

--- a/backend/kernelCI_app/helpers/system.py
+++ b/backend/kernelCI_app/helpers/system.py
@@ -1,11 +1,30 @@
+from typing import Literal
 from django.conf import settings
 
 from kernelCI_app.constants.general import PRODUCTION_HOST
 
 
+# TODO: combine with the function below once it is verified
+# that this way of identifying the production instance works
 def is_production_instance():
     if not hasattr(settings, "CORS_ALLOWED_ORIGINS"):
         return False
     if PRODUCTION_HOST in settings.CORS_ALLOWED_ORIGINS:
         return True
     return False
+
+
+type PossibleHosts = Literal["production", "staging"]
+
+
+# TODO: verify if this is the correct way to identify
+# the production instance
+def get_running_instance() -> PossibleHosts | None:
+    if (
+        hasattr(settings, "CORS_ALLOWED_ORIGINS")
+        and PRODUCTION_HOST in settings.CORS_ALLOWED_ORIGINS
+    ):
+        return "production"
+    elif hasattr(settings, "DEBUG") and settings.DEBUG is False:
+        return "staging"
+    return

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
             - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
             - DEBUG=False
             - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
-            - SCHEMA_VERSION="4"
 
     dashboard:
         build: ./dashboard


### PR DESCRIPTION
## Changes
- Adds hardcoded staging and production urls to the notification to be differentiated when running in the wild;
- Adds timezone to access time;
- Adds a cooldown to the messages with the already existing cache system.

## How to test
Trigger a discord notification, for example with this failed [build with tests](http://localhost:8000/api/build/maestro:67dadf0028b1441c0820bacc/tests)
Trigger the same notification again in a 10 minute interval
Check the backend process, it should trigger a log with "This message was already sent in the last 600 seconds"

Closes #1096