### PR TITLE
fix: hardware parameter typo

### DIFF
--- a/backend/kernelCI_app/typeModels/hardwareListing.py
+++ b/backend/kernelCI_app/typeModels/hardwareListing.py
@@ -27,7 +27,7 @@ class HardwareQueryParamsDocumentationOnly(BaseModel):
         Field(default=DEFAULT_ORIGIN),
     ]
     startTimestampInSeconds: str  # noqa: N815
-    endTimeStampInSeconds: str  # noqa: N815
+    endTimestampInSeconds: str  # noqa: N815
 
 
 class HardwareQueryParams(BaseModel):

--- a/backend/kernelCI_app/unitTests/hardware_test.py
+++ b/backend/kernelCI_app/unitTests/hardware_test.py
@@ -22,7 +22,7 @@ from http import HTTPStatus
             HardwareQueryParamsDocumentationOnly(
                 origin="maestro",
                 startTimestampInSeconds="1741192200",
-                endTimeStampInSeconds="1741624200",
+                endTimestampInSeconds="1741624200",
             ),
             False,
         ),
@@ -31,7 +31,7 @@ from http import HTTPStatus
             HardwareQueryParamsDocumentationOnly(
                 origin="redhat",
                 startTimestampInSeconds="1741192200",
-                endTimeStampInSeconds="1741624200",
+                endTimestampInSeconds="1741624200",
             ),
             True,
         ),
@@ -39,7 +39,7 @@ from http import HTTPStatus
             HardwareQueryParamsDocumentationOnly(
                 origin="invalid_origin",
                 startTimestampInSeconds="1741192200",
-                endTimeStampInSeconds="1741624200",
+                endTimestampInSeconds="1741624200",
             ),
             True,
         ),

--- a/backend/kernelCI_app/views/hardwareView.py
+++ b/backend/kernelCI_app/views/hardwareView.py
@@ -91,7 +91,7 @@ class HardwareView(APIView):
         try:
             query_params = HardwareQueryParams(
                 start_date=request.GET.get("startTimestampInSeconds"),
-                end_date=request.GET.get("endTimeStampInSeconds"),
+                end_date=request.GET.get("endTimestampInSeconds"),
                 origin=request.GET.get("origin"),
             )
 

--- a/backend/requests/hardware-listing.sh
+++ b/backend/requests/hardware-listing.sh
@@ -1,2 +1,2 @@
-http 'http://localhost:8000/api/hardware/?startTimestampInSeconds=1736510400&endTimeStampInSeconds=1736942400&origin=maestro'
+http 'http://localhost:8000/api/hardware/?startTimestampInSeconds=1736510400&endTimestampInSeconds=1736942400&origin=maestro'
 

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -75,7 +75,7 @@ paths:
       operationId: hardware_retrieve
       parameters:
       - in: query
-        name: endTimeStampInSeconds
+        name: endTimestampInSeconds
         schema:
           title: Endtimestampinseconds
           type: string
@@ -313,6 +313,30 @@ paths:
     get:
       operationId: issue_retrieve
       parameters:
+      - in: query
+        name: culprit_code
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          default: false
+          title: Culprit Code
+      - in: query
+        name: culprit_harness
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          default: false
+          title: Culprit Harness
+      - in: query
+        name: culprit_tool
+        schema:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          default: false
+          title: Culprit Tool
       - in: query
         name: interval_in_days
         schema:
@@ -2214,6 +2238,8 @@ components:
           $ref: '#/components/schemas/Issue__Id'
         comment:
           $ref: '#/components/schemas/Issue__Comment'
+        origin:
+          $ref: '#/components/schemas/Origin'
         version:
           $ref: '#/components/schemas/Issue__Version'
         culprit_code:
@@ -2226,6 +2252,7 @@ components:
       - field_timestamp
       - id
       - comment
+      - origin
       - version
       - culprit_code
       - culprit_tool

--- a/dashboard/src/api/hardware.ts
+++ b/dashboard/src/api/hardware.ts
@@ -12,14 +12,14 @@ import { RequestData } from './commonRequest';
 const fetchHardwareListing = async (
   origin: TOrigins,
   startTimestampInSeconds: number,
-  endTimeStampInSeconds: number,
+  endTimestampInSeconds: number,
 ): Promise<HardwareListingResponse> => {
   const data = await RequestData.get<HardwareListingResponse>(
     '/api/hardware/',
     {
       params: {
         startTimestampInSeconds,
-        endTimeStampInSeconds,
+        endTimestampInSeconds,
         origin,
       },
     },


### PR DESCRIPTION
From endTimeStampInSeconds to endTimestampInSeconds

Closes #1122

## How to test
- Run the unit tests in `hardware_test.py`
- Run `backend/requests/hardware-listing.sh`
- Open Hardware Listing Page and check it's working properly
- Open some Hardware Details Page and check it's working properly