### PR TITLE
fix: disable highlight on log viewer by file size

### DIFF
--- a/dashboard/src/components/Filter/CodeBlock.tsx
+++ b/dashboard/src/components/Filter/CodeBlock.tsx
@@ -6,8 +6,6 @@ import { FormattedMessage } from 'react-intl';
 import type { PropsWithChildren, JSX } from 'react';
 import { memo, useMemo } from 'react';
 
-import { useSearch } from '@tanstack/react-router';
-
 import { cn } from '@/lib/utils';
 
 import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
@@ -21,7 +19,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { zOrigin } from '@/types/general';
 
 export type CodeBlockVariant = 'default' | 'log-viewer';
 
@@ -88,7 +85,7 @@ const Code = ({
         )}
       >
         {disableHighlight ? (
-          <>parsedCode</>
+          <>{parsedCode}</>
         ) : (
           <div dangerouslySetInnerHTML={{ __html: parsedCode }}></div>
         )}
@@ -205,17 +202,14 @@ const generateHighlightedCode = (code: string): IHighlightedCode => {
   };
 };
 
+const MAX_HIGHLIGHT_CODE_LENGTH = 6000000;
+
 const CodeBlock = ({
   code,
   highlightsClassnames,
   variant = 'default',
 }: TCodeBlockProps): JSX.Element => {
-  const { origin: unsafeOrigin } = useSearch({ strict: false });
-
-  const parsedOrigin = zOrigin.parse(unsafeOrigin);
-  // TODO Disable highlight based on filesize
-  const disableHighlight =
-    parsedOrigin === 'redhat' && variant === 'log-viewer';
+  const disableHighlight = code.length >= MAX_HIGHLIGHT_CODE_LENGTH;
 
   const parsedCode: IHighlightedCode | string = useMemo(() => {
     if (disableHighlight) {
@@ -257,6 +251,11 @@ const CodeBlock = ({
           )}
         </div>
 
+        {disableHighlight && (
+          <span className="text-gray-500">
+            <FormattedMessage id="logViewer.disabledHighlight" />
+          </span>
+        )}
         {variant !== 'log-viewer' && (
           <CodeBlockDialog>
             <MemoizedCode

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -220,6 +220,8 @@ export const messages = {
       'This log url is not supported in the log viewer yet, but you can still download the log in the link above',
     'logSheet.noLogFound': 'No logs available',
     'logSheet.title': 'Log Viewer',
+    'logViewer.disabledHighlight':
+      'The text highlight was disabled in this log due to the log size',
     'logViewer.download': 'Download full log',
     'logViewer.viewFullLog': 'View full log for {fileName}',
     'logspec.info':


### PR DESCRIPTION
I couldn't find a log greater then 4 million characters. I also did some testing but to be sure I decided to go for this constraint of 6 million characters.

Closes #1059

## How to test
- Open logs in redhat origin and verify that every log does not take to much time to load and, in some cases, highlighted
[(localhost) example of a log with 14 million characters](http://localhost:5173/log-viewer?itemId=redhat%3A1729170198-x86_64-kernel-automotive&o=redhat&type=build&url=https%3A%2F%2Fs3.amazonaws.com%2Farr-cki-prod-trusted-artifacts%2Ftrusted-artifacts%2F1729170198%2Fbuild_x86_64%2F9489093468%2Fartifacts%2Fbuild.log)