### PR TITLE
Feat: docker performance improvements

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -43,5 +43,5 @@ EXPOSE 8000
 
 VOLUME ["/backend/data"]
 
-CMD ["--workers=5", "--forwarded-allow-ips=*", "--bind=0.0.0.0:8000"]
+CMD ["--workers=5", "--forwarded-allow-ips=*", "--bind=0.0.0.0:8000", "--timeout=240"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -79,8 +79,10 @@ class BuildHistoryItem(BaseModel):
             return json.loads(value)
         elif isinstance(value, dict):
             return value
+        elif value is None:
+            return None
         else:
-            log_message("Invalid misc for BuildHistoryItem")
+            log_message(f"Invalid misc for BuildHistoryItem;\nType: {type(value)}")
 
     @field_validator("status", mode="before")
     @classmethod

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -4,9 +4,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
-from kernelCI_app.helpers.filters import (
-    FilterParams,
-)
+from kernelCI_app.helpers.filters import FilterParams
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 from kernelCI_app.helpers.errorHandling import create_api_error_response

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -284,14 +284,16 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
       </QuerySwitcher>
       {isEmptySummary && (
         <div className="mx-48 max-2xl:mx-0">
-          <div className="px-4 pb-2">
-            <FormattedMessage
-              id="tab.findOnPreviousCheckoutsTooltip"
-              values={{
-                tab: formatMessage({ id: 'global.boots' }).toLowerCase(),
-              }}
-            />
-          </div>
+          {summaryError !== null && (
+            <div className="px-4 pb-2">
+              <FormattedMessage
+                id="tab.findOnPreviousCheckoutsTooltip"
+                values={{
+                  tab: formatMessage({ id: 'global.boots' }).toLowerCase(),
+                }}
+              />
+            </div>
+          )}
           <TreeCommitNavigationGraph />
         </div>
       )}

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -139,6 +139,13 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
     ],
   );
 
+  const isEmptySummary = useMemo((): boolean => {
+    if (!summaryBuildsData) {
+      return true;
+    }
+    return Object.values(summaryBuildsData.status).every(value => value === 0);
+  }, [summaryBuildsData]);
+
   const { formatMessage } = useIntl();
 
   return (
@@ -252,16 +259,18 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
           </QuerySwitcher>
         </div>
       </QuerySwitcher>
-      {summaryError !== null && (
+      {isEmptySummary && (
         <div className="mx-48 max-2xl:mx-0">
-          <div className="px-4 pb-2">
-            <FormattedMessage
-              id="tab.findOnPreviousCheckoutsTooltip"
-              values={{
-                tab: formatMessage({ id: 'global.builds' }).toLowerCase(),
-              }}
-            />
-          </div>
+          {summaryError !== null && (
+            <div className="px-4 pb-2">
+              <FormattedMessage
+                id="tab.findOnPreviousCheckoutsTooltip"
+                values={{
+                  tab: formatMessage({ id: 'global.builds' }).toLowerCase(),
+                }}
+              />
+            </div>
+          )}
           <TreeCommitNavigationGraph />
         </div>
       )}

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -287,14 +287,16 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
       </QuerySwitcher>
       {isEmptySummary && (
         <div className="mx-48 max-2xl:mx-0">
-          <div className="px-4 pb-2">
-            <FormattedMessage
-              id="tab.findOnPreviousCheckoutsTooltip"
-              values={{
-                tab: formatMessage({ id: 'global.tests' }).toLowerCase(),
-              }}
-            />
-          </div>
+          {summaryError !== null && (
+            <div className="px-4 pb-2">
+              <FormattedMessage
+                id="tab.findOnPreviousCheckoutsTooltip"
+                values={{
+                  tab: formatMessage({ id: 'global.tests' }).toLowerCase(),
+                }}
+              />
+            </div>
+          )}
           <TreeCommitNavigationGraph />
         </div>
       )}


### PR DESCRIPTION
## Changes
- Adds a timeout to the dockerfile so that the default (30, as described by [gunicorn's documentation](https://docs.gunicorn.org/en/stable/settings.html#timeout)) is overwritten by a larger value (120) to allow endpoints to be loading for longer, such as this [staging test](https://staging.dashboard.kernelci.org:9000/test/maestro:67ce429218018371957d9e59) that takes about 40s to load the status history, or this [staging tree](https://staging.dashboard.kernelci.org:9000/tree/bddc6e9322072ac3aa15bd972c5bcbf9f447d246?o=tuxsuite&p=t&ti%7Cc=v6.6.83-167-gbddc6e932207&ti%7Cch=bddc6e9322072ac3aa15bd972c5bcbf9f447d246&ti%7Cgb=&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fstable%2Flinux-stable-rc.git) that takes about 80s to get the full data.
- Piggybacking is a small fix to a log message that doesn't need to be sent when misc is null, and a small code style problem

## How to test
Check the pages linked above, and also access them through the localhost _while running on docker_, this effect will not be seen if you run without docker because the changes only affect the docker's `gunicorn`.
Also check the api pages that they make requests to, by looking into the network tab of the page
You can try changing the timeout parameter and see that the workers will complain about it after the given time

Closes #1029

PS.: Understandably, this does not solve the issue of heavy queries, but it does prevent the error from happening until we have improvements to the query or the processing of data in the endpoints, which will be tackled in #1131 and #1132