### PR TITLE
fix: show 'NULL' instead of '-' in status field

### DIFF
--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -269,7 +269,7 @@ const TestDetailsSections = ({
           infos: [
             {
               title: 'global.status',
-              linkText: truncateBigText(test.status),
+              linkText: truncateBigText(valueOrEmpty(test.status, 'NULL')),
               icon: <StatusIcon status={test.status} className="text-xl" />,
             },
             {


### PR DESCRIPTION
Closes #1042

## How to test
- Check a test with status null on [dashboard](https://dashboard.kernelci.org/test/maestro%3A67c834d818018371956b4350) and on [localhost](http://localhost:5173/test/maestro%3A67c834d818018371956b4350)