### PR TITLE
feat(test-details): add link to hardware details

### DIFF
--- a/dashboard/src/lib/string.ts
+++ b/dashboard/src/lib/string.ts
@@ -1,6 +1,8 @@
+export const EMPTY_VALUE = '-';
+
 export const valueOrEmpty = (
   value: string | undefined,
-  emptyValue = '-',
+  emptyValue = EMPTY_VALUE,
 ): string => value || emptyValue;
 
 export const shouldTruncate = (value: string, maxLength = 50): boolean =>


### PR DESCRIPTION
Build has no direct relation with hardware so that's why I didn't add any link to it as well. Even 'platform' that's inside the `misc` field in the `builds` table has no direct relation with the available hardware details pages, since we only consider platform and compatibles of tests in this case

Closes #960

## How to test
- Enter a page with environment compatible: http://localhost:5173/test/maestro%3A67ea51dc67593f2aa0417959
- Enter a page with platform and no environment compatible: http://localhost:5173/test/maestro%3A67e9d6b667593f2aa0405adb
- Enter a page with none: http://localhost:5173/test/redhat%3A1739009469-aarch64-kernel-automotive_upt_aws_5?o=redhat