### PR TITLE
Fix: start_time None in test status history

### DIFF
--- a/backend/kernelCI_app/typeModels/databases.py
+++ b/backend/kernelCI_app/typeModels/databases.py
@@ -24,7 +24,7 @@ class EnvironmentMisc(BaseModel):
 
 
 type Origin = str
-type Timestamp = datetime
+type Timestamp = Optional[datetime]
 
 type Checkout__Id = str
 type Checkout__TreeName = Optional[str]

--- a/backend/kernelCI_app/typeModels/testDetails.py
+++ b/backend/kernelCI_app/typeModels/testDetails.py
@@ -23,11 +23,13 @@ from kernelCI_app.typeModels.databases import (
     Checkout__GitRepositoryUrl,
     Checkout__GitCommitTags,
     Checkout__TreeName,
+    Timestamp,
 )
 from kernelCI_app.utils import validate_str_to_dict
 
 
 class TestDetailsResponse(BaseModel):
+    field_timestamp: Timestamp = Field(validation_alias="_timestamp")
     id: Test__Id
     build_id: Build__Id
     status: Test__Status
@@ -77,3 +79,4 @@ class TestStatusHistoryRequest(BaseModel):
     platform: Optional[str] = None
     current_test_start_time: Test__StartTime = None
     config_name: Build__ConfigName = None
+    field_timestamp: Timestamp = None

--- a/backend/kernelCI_app/views/testStatusHistoryView.py
+++ b/backend/kernelCI_app/views/testStatusHistoryView.py
@@ -67,6 +67,7 @@ class TestStatusHistory(APIView):
                 platform=request.GET.get("platform"),
                 current_test_start_time=request.GET.get("current_test_start_time"),
                 config_name=request.GET.get("config_name"),
+                field_timestamp=request.GET.get("field_timestamp"),
             )
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
@@ -77,8 +78,9 @@ class TestStatusHistory(APIView):
             git_repository_url=params.git_repository_url,
             git_repository_branch=params.git_repository_branch,
             platform=params.platform,
-            current_test_start_time=params.current_test_start_time,
+            test_start_time=params.current_test_start_time,
             config_name=params.config_name,
+            field_timestamp=params.field_timestamp,
         )
 
         if len(status_history_response) == 0:

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -544,6 +544,7 @@ const TestDetails = ({ breadcrumb }: TestsDetailsProps): JSX.Element => {
               : undefined,
           current_test_start_time: data.start_time,
           config_name: data.config_name,
+          field_timestamp: data.field_timestamp,
         }
       : undefined,
   );

--- a/dashboard/src/types/tree/TestDetails.tsx
+++ b/dashboard/src/types/tree/TestDetails.tsx
@@ -51,4 +51,5 @@ export type TestStatusHistoryParams = {
   platform?: string;
   current_test_start_time?: string;
   config_name?: string;
+  field_timestamp?: string;
 };


### PR DESCRIPTION
Fixes a bug for tests with start_time null
Django takes care of None values by default only if the comparison is exact, but start_time uses an lower than equal comparison.

## How to test
Go to test details pages for tests with start_time null and compare with the staging counterpart. Examples:
- [localhost redhat api](http://localhost:8000/api/test/status-history?path=boot&origin=redhat&git_repository_url=https:%2F%2Fgitlab.com%2Fredhat%2Fcentos-stream%2Fsrc%2Fkernel%2Fcentos-stream-9.git&git_repository_branch=main-automotive&config_name=rpm:+%2Flib%2Fmodules%2F5.14.0-575.524.test.gcov.el9iv.aarch64%2Fconfig) - [staging redhat api](https://staging.dashboard.kernelci.org:9000/api/test/status-history?path=boot&origin=redhat&git_repository_url=https:%2F%2Fgitlab.com%2Fredhat%2Fcentos-stream%2Fsrc%2Fkernel%2Fcentos-stream-9.git&git_repository_branch=main-automotive&config_name=rpm:+%2Flib%2Fmodules%2F5.14.0-575.524.test.gcov.el9iv.aarch64%2Fconfig)

- [localhost broonie test details](http://localhost:5173/test/broonie%3Abcf2acd8f64b0a5783deeeb5fd70c6163ec5acd7-x86_64-kunit_defconfig) - [staging broonie test details](https://staging.dashboard.kernelci.org:9000/test/broonie%3Abcf2acd8f64b0a5783deeeb5fd70c6163ec5acd7-x86_64-kunit_defconfig?=)

Closes #1142