### PR TITLE
feat: define origins dynamically

### DIFF
--- a/backend/kernelCI_app/cache.py
+++ b/backend/kernelCI_app/cache.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from django.core.cache import cache
 from django.conf import settings
 
@@ -19,10 +20,20 @@ def _create_cache_params_hash(params: dict):
 
 
 def set_query_cache(
-    key, params, rows, commit_hash=None, build_id=None, test_id=None, timeout=timeout
+    *,
+    key,
+    params=None,
+    rows,
+    commit_hash=None,
+    build_id=None,
+    test_id=None,
+    timeout=timeout,
 ):
-    params_hash = _create_cache_params_hash(params)
-    hash_key = "%s-%s" % (key, params_hash)
+    if params is not None:
+        params_hash = _create_cache_params_hash(params)
+        hash_key = "%s-%s" % (key, params_hash)
+    else:
+        hash_key = "%s" % key
 
     _add_to_lookup(hash_key, commit_hash, _commit_lookup)
     _add_to_lookup(hash_key, build_id, _build_lookup)
@@ -31,9 +42,11 @@ def set_query_cache(
     return cache.set(hash_key, rows, timeout)
 
 
-def get_query_cache(key, params: dict):
-    params_hash = _create_cache_params_hash(params)
-    return cache.get("%s-%s" % (key, params_hash))
+def get_query_cache(key, params: Optional[dict] = None):
+    if params is not None:
+        params_hash = _create_cache_params_hash(params)
+        return cache.get("%s-%s" % (key, params_hash))
+    return cache.get("%s" % key)
 
 
 def set_notification_cache(*, notification: str) -> None:

--- a/backend/kernelCI_app/queries/checkout.py
+++ b/backend/kernelCI_app/queries/checkout.py
@@ -1,0 +1,18 @@
+from kernelCI_app.cache import get_query_cache, set_query_cache
+from kernelCI_app.models import Checkouts
+
+ORIGINS_QUERY_KEY = "origins"
+ORIGINS_CACHE_TIMEOUT = 12 * 60 * 60  # 12 hours
+
+
+def get_origins() -> list[str]:
+    origins = get_query_cache(key=ORIGINS_QUERY_KEY)
+    if origins is None:
+        origins = [
+            checkout["origin"]
+            for checkout in Checkouts.objects.values("origin").distinct()
+        ]
+        set_query_cache(
+            key=ORIGINS_QUERY_KEY, rows=origins, timeout=ORIGINS_CACHE_TIMEOUT
+        )
+    return origins

--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -220,7 +220,7 @@ def get_hardware_details_data(
             start_date=start_datetime,
             end_date=end_datetime,
         )
-        set_query_cache(cache_key, tests_cache_params, records)
+        set_query_cache(key=cache_key, params=tests_cache_params, rows=records)
 
     return records
 
@@ -400,6 +400,6 @@ def get_hardware_trees_data(
                 )
             )
 
-        set_query_cache(cache_key, trees_cache_params, trees)
+        set_query_cache(key=cache_key, params=trees_cache_params, rows=trees)
 
     return trees

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -422,7 +422,7 @@ def get_tree_details_data(
             with connection.cursor() as cursor:
                 cursor.execute(query, params)
                 rows = cursor.fetchall()
-                set_query_cache(cache_key, params, rows)
+                set_query_cache(key=cache_key, params=params, rows=rows)
         except ProgrammingError as e:
             if is_valid_does_not_exist_exception(e):
                 set_schema_version()

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -130,4 +130,5 @@ urlpatterns = [
         "schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"
     ),
     path("proxy/", views.ProxyView.as_view(), name="proxyView"),
+    path("origins/", views.OriginsView.as_view(), name="originsView"),
 ]

--- a/backend/kernelCI_app/views/originsView.py
+++ b/backend/kernelCI_app/views/originsView.py
@@ -1,0 +1,19 @@
+from http import HTTPStatus
+from kernelCI_app.helpers.errorHandling import create_api_error_response
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from kernelCI_app.queries.checkout import get_origins
+from drf_spectacular.utils import extend_schema
+
+
+class OriginsView(APIView):
+    @extend_schema(
+        responses={HTTPStatus.OK: list[str], HTTPStatus.BAD_REQUEST: dict[str, str]},
+        methods=["GET"],
+    )
+    def get(self, _request) -> Response:
+        origins = get_origins()
+        if len(origins) == 0:
+            return create_api_error_response(error_message="No origins found")
+
+        return Response(origins)

--- a/backend/requests/origins-get.sh
+++ b/backend/requests/origins-get.sh
@@ -1,0 +1,25 @@
+http 'http://localhost:8000/api/origins/'
+
+# HTTP/1.1 200 OK
+# Allow: GET, HEAD, OPTIONS
+# Content-Length: 88
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Wed, 02 Apr 2025 20:19:29 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# [
+#     "0dayci",
+#     "arm",
+#     "broonie",
+#     "kernelci",
+#     "maestro",
+#     "microsoft",
+#     "redhat",
+#     "syzbot",
+#     "tuxsuite"
+# ]

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -504,6 +504,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/LogDownloaderResponse'
           description: ''
+  /api/origins/:
+    get:
+      operationId: origins_retrieve
+      tags:
+      - origins
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+          description: ''
   /api/proxy/:
     get:
       operationId: proxy_retrieve
@@ -2584,6 +2610,8 @@ components:
       type: object
     TestDetailsResponse:
       properties:
+        field_timestamp:
+          $ref: '#/components/schemas/Timestamp'
         id:
           $ref: '#/components/schemas/Test__Id'
         build_id:
@@ -2627,6 +2655,7 @@ components:
           - $ref: '#/components/schemas/Origin'
           - type: 'null'
       required:
+      - field_timestamp
       - id
       - build_id
       - status
@@ -2904,8 +2933,10 @@ components:
       - $ref: '#/components/schemas/DatabaseStatusValues'
       - type: 'null'
     Timestamp:
-      format: date-time
-      type: string
+      anyOf:
+      - format: date-time
+        type: string
+      - type: 'null'
     Tree:
       properties:
         index:

--- a/dashboard/src/api/hardware.ts
+++ b/dashboard/src/api/hardware.ts
@@ -5,12 +5,10 @@ import { useSearch } from '@tanstack/react-router';
 
 import type { HardwareListingResponse } from '@/types/hardware';
 
-import type { TOrigins } from '@/types/general';
-
 import { RequestData } from './commonRequest';
 
 const fetchHardwareListing = async (
-  origin: TOrigins,
+  origin: string,
   startTimestampInSeconds: number,
   endTimestampInSeconds: number,
 ): Promise<HardwareListingResponse> => {

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -10,12 +10,7 @@ import type {
   THardwareDetailsFilter,
   TTreeCommits,
 } from '@/types/hardware/hardwareDetails';
-import type {
-  BuildsTabBuild,
-  TestHistory,
-  TFilter,
-  TOrigins,
-} from '@/types/general';
+import type { BuildsTabBuild, TestHistory, TFilter } from '@/types/general';
 import { getTargetFilter } from '@/types/general';
 
 import { isEmptyObject } from '@/utils/utils';
@@ -79,7 +74,7 @@ type HardwareDetailsVariants =
 type fetchHardwareDetailsBody = {
   startTimestampInSeconds: number;
   endTimestampInSeconds: number;
-  origin: TOrigins;
+  origin: string;
   selectedCommits: Record<string, string>;
   filter?: Record<string, string[]>;
 };
@@ -124,7 +119,7 @@ export type UseHardwareDetailsWithoutVariant = {
   hardwareId: string;
   startTimestampInSeconds: number;
   endTimestampInSeconds: number;
-  origin: TOrigins;
+  origin: string;
   filter: TFilter;
   selectedIndexes: number[];
   treeCommits: TTreeCommits;

--- a/dashboard/src/api/origin.ts
+++ b/dashboard/src/api/origin.ts
@@ -1,0 +1,21 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { MILLISECONDS_IN_ONE_HOUR } from '@/utils/date';
+
+import { RequestData } from './commonRequest';
+
+const fetchOrigins = async (): Promise<string[]> => {
+  const data = await RequestData.get<string[]>('/api/origins/');
+  return data;
+};
+
+const ORIGIN_CACHE_DURATION = 2 * MILLISECONDS_IN_ONE_HOUR;
+
+export const useOrigins = (): UseQueryResult<string[]> => {
+  return useQuery({
+    queryKey: ['origins'],
+    queryFn: () => fetchOrigins(),
+    refetchOnWindowFocus: false,
+    staleTime: ORIGIN_CACHE_DURATION,
+  });
+};

--- a/dashboard/src/api/tree.ts
+++ b/dashboard/src/api/tree.ts
@@ -8,7 +8,7 @@ import type {
   TreeFastPathResponse,
   TreeLatestResponse,
 } from '@/types/tree/Tree';
-import { DEFAULT_ORIGIN, type TOrigins } from '@/types/general';
+import { DEFAULT_ORIGIN } from '@/types/general';
 
 import { RequestData } from './commonRequest';
 
@@ -62,7 +62,7 @@ export const useTreeTableFast = (): UseQueryResult<TreeFastPathResponse> => {
 const fetchTreeLatest = async (
   treeName: string,
   branch: string,
-  origin?: TOrigins,
+  origin?: string,
 ): Promise<TreeLatestResponse> => {
   const data = await RequestData.get<TreeLatestResponse>(
     `/api/tree/${treeName}/${branch}`,
@@ -76,7 +76,7 @@ const fetchTreeLatest = async (
 export const useTreeLatest = (
   treeName: string,
   branch: string,
-  origin?: TOrigins,
+  origin?: string,
 ): UseQueryResult<TreeLatestResponse> => {
   return useQuery({
     queryKey: ['treeLatest', treeName, branch, origin],

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -23,8 +23,8 @@ import { Link, useNavigate, useSearch } from '@tanstack/react-router';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 
 import type { TreeTableBody } from '@/types/tree/Tree';
-import { RedirectFrom, zOrigin } from '@/types/general';
-import type { TFilter, TOrigins, BuildStatus } from '@/types/general';
+import { DEFAULT_ORIGIN, RedirectFrom } from '@/types/general';
+import type { TFilter, BuildStatus } from '@/types/general';
 
 import { formattedBreakLineValue } from '@/locales/messages';
 
@@ -65,7 +65,7 @@ import { shouldShowRelativeDate } from '@/lib/date';
 
 const getLinkProps = (
   row: Row<TreeTableBody>,
-  origin: TOrigins,
+  origin: string,
   tabTarget?: string,
   diffFilter?: TFilter,
 ): LinkProps => {
@@ -127,7 +127,7 @@ const getLinkProps = (
   };
 };
 
-const getColumns = (origin: TOrigins): ColumnDef<TreeTableBody>[] => {
+const getColumns = (origin: string): ColumnDef<TreeTableBody>[] => {
   return [
     {
       accessorKey: 'tree_name',
@@ -340,6 +340,7 @@ interface ITreeTable {
 
 export function TreeTable({ treeTableRows }: ITreeTable): JSX.Element {
   const { origin: unsafeOrigin, listingSize } = useSearch({ strict: false });
+  const origin = unsafeOrigin ?? DEFAULT_ORIGIN;
   const navigate = useNavigate({ from: '/tree' });
 
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -348,8 +349,6 @@ export function TreeTable({ treeTableRows }: ITreeTable): JSX.Element {
     'treeListing',
     listingSize,
   );
-
-  const origin = zOrigin.parse(unsafeOrigin);
 
   const columns = useMemo(() => getColumns(origin), [origin]);
 

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -147,23 +147,8 @@ export const makeZIntervalInDays = (
   defaultValue: number,
 ): z.ZodCatch<z.ZodNumber> => zIntervalInDaysUncatched.catch(defaultValue);
 
-const origins = [
-  '0dayci',
-  'broonie',
-  'maestro',
-  'microsoft',
-  'redhat',
-  'syzbot',
-  'tuxsuite',
-] as const;
 export const DEFAULT_ORIGIN = 'maestro';
-
-export type TOrigins = (typeof origins)[number];
-
-export const zOriginEnum = z.enum(origins);
-export const zOrigin = zOriginEnum
-  .default(DEFAULT_ORIGIN)
-  .catch(DEFAULT_ORIGIN);
+export const zOrigin = z.string().default(DEFAULT_ORIGIN).catch(DEFAULT_ORIGIN);
 
 const zFilterBoolValue = z.record(z.boolean()).optional();
 const zFilterNumberValue = z.number().optional();

--- a/dashboard/src/utils/date.ts
+++ b/dashboard/src/utils/date.ts
@@ -1,4 +1,5 @@
 const MILLISECONDS_IN_ONE_SECOND = 1000;
+export const MILLISECONDS_IN_ONE_HOUR = 3600000;
 const SECONDS_IN_ONE_DAY = 86400;
 
 export const dateObjectToTimestampInSeconds = (date: Date): number => {


### PR DESCRIPTION
## Changes
- Adds origins endpoint to retrieve all origins from checkouts;
- Uses that endpoint in the frontend instead of having the origins hardcoded;
  - The origin search parameter is now a simple string, and not an enum anymore; however, there is no way to change it from the dashboard unless the user changes it in the url and the fields that are an enum in the backend (all status fields) are also just a simple string in the frontend search parameters

## How to test
Go to the tree listing and see that the origin selector now loads for a second, getting the origins from the backend
All endpoints that require origins should run normally

Closes #1149
Closes #1144 