### PR TITLE
Fix: commit history counting

### DIFF
--- a/backend/kernelCI_app/typeModels/treeCommits.py
+++ b/backend/kernelCI_app/typeModels/treeCommits.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel, RootModel
 
 from kernelCI_app.typeModels.commonDetails import StatusCount
@@ -13,10 +13,10 @@ from kernelCI_app.typeModels.databases import (
 
 class TreeCommitsQueryParameters(BaseModel):
     origin: str
-    git_url: str
-    git_branch: str
-    start_time_stamp_in_seconds: str
-    end_time_stamp_in_seconds: str
+    git_url: Optional[str] = None
+    git_branch: Optional[str] = None
+    start_time_stamp_in_seconds: Optional[str] = None
+    end_time_stamp_in_seconds: Optional[str] = None
     # TODO: Add filters field in this model
 
 

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -906,21 +906,27 @@ paths:
       - in: query
         name: end_time_stamp_in_seconds
         schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
           title: End Time Stamp In Seconds
-          type: string
-        required: true
       - in: query
         name: git_branch
         schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
           title: Git Branch
-          type: string
-        required: true
       - in: query
         name: git_url
         schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
           title: Git Url
-          type: string
-        required: true
       - in: query
         name: origin
         schema:
@@ -930,9 +936,11 @@ paths:
       - in: query
         name: start_time_stamp_in_seconds
         schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
           title: Start Time Stamp In Seconds
-          type: string
-        required: true
       tags:
       - tree
       security:
@@ -1415,6 +1423,8 @@ components:
           $ref: '#/components/schemas/Checkout__OriginBuildsFinishTime'
         origin_tests_finish_time:
           $ref: '#/components/schemas/Checkout__OriginTestsFinishTime'
+        id:
+          $ref: '#/components/schemas/Checkout__Id'
         build_status:
           $ref: '#/components/schemas/StatusCount'
         test_status:
@@ -1436,6 +1446,7 @@ components:
       - start_time
       - origin_builds_finish_time
       - origin_tests_finish_time
+      - id
       - build_status
       - test_status
       - boot_status


### PR DESCRIPTION
Fixes a problem specially on broonie where checkouts fetched for the commit history graph were not the same as the checkout for tree details. On treeDetails the data was gotten by a combination of origin, hash, branch, url, while on the commitHistory it was gotten virtually only by checkout id.

## Changes
Refactors the endpoint a bit to use pydantic validation and fixes a start_timestamp search parameter that wasn't being used correctly
Adds an intermediate query to get all `checkout_id`s from the commitHistory - the final query is still the same and therefore the rest of the functions and data is processed the same way

## How to test
Go to tree details and check if the counting from the commit history graph is the same as the counting from the treeDetails page, comparing with the staging equivalent.
The graph for treeDetails and hardwareDetails (when there is only one tree selected) should still be working normally, the filters should also work normally.

Examples:
[localhost broonie mainline master](http://localhost:5173/tree/4e310626eb4df52a31a142c1360fead0fcbd3793?o=broonie&p=t&ti%7Cc=&ti%7Cch=4e310626eb4df52a31a142c1360fead0fcbd3793&ti%7Cgb=master&ti%7Cgu=&ti%7Ct=mainline) - [staging equivalent](https://staging.dashboard.kernelci.org:9000/tree/4e310626eb4df52a31a142c1360fead0fcbd3793?o=broonie&p=t&ti%7Cc=&ti%7Cch=4e310626eb4df52a31a142c1360fead0fcbd3793&ti%7Cgb=master&ti%7Cgu=&ti%7Ct=mainline&=)
[localhost broonie regulator for 6.16](http://localhost:5173/tree/1326e295d6b4ffc9647bd4f073b787b4f79d6b6e?=&o=broonie&p=t&ti%7Cc=&ti%7Cch=936df52c29b0d422665c5e84b0cffae61611411b&ti%7Cgb=for-6.16&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fbroonie%2Fregulator.git&ti%7Ct=regulator) - [staging equivalent](https://staging.dashboard.kernelci.org:9000/tree/1326e295d6b4ffc9647bd4f073b787b4f79d6b6e?=&o=broonie&p=t&ti%7Cc=&ti%7Cch=936df52c29b0d422665c5e84b0cffae61611411b&ti%7Cgb=for-6.16&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Fbroonie%2Fregulator.git&ti%7Ct=regulator&=)
[localhost redhat fedora-rawhide ark-latest](http://localhost:5173/tree/d117aa424f020fd7d241bf651ae8373d1666b05f?o=redhat&ti%7Cc=kernel-6.15.0-0.rc0.f4d2ef48250a.13&ti%7Cch=9e89d2a517cf0ab51d1f26d53f7be3065cdacfeb&ti%7Cgb=ark-latest&ti%7Cgu=https%3A%2F%2Fgitlab.com%2Fcki-project%2Fkernel-ark.git&ti%7Ct=fedora-rawhide) - [staging equivalent](https://staging.dashboard.kernelci.org:9000/tree/d117aa424f020fd7d241bf651ae8373d1666b05f?o=redhat&ti%7Cc=kernel-6.15.0-0.rc0.f4d2ef48250a.13&ti%7Cch=9e89d2a517cf0ab51d1f26d53f7be3065cdacfeb&ti%7Cgb=ark-latest&ti%7Cgu=https%3A%2F%2Fgitlab.com%2Fcki-project%2Fkernel-ark.git&ti%7Ct=fedora-rawhide)

Closes #803 