### PR TITLE
Feat: use tree names file

### DIFF
--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -331,8 +331,14 @@ def handle_test_history(
     *,
     record: Dict,
     task: List[HardwareTestHistoryItem],
+    tree_url_to_name: dict[str, str],
 ) -> None:
     create_record_test_platform(record=record)
+
+    defined_tree_name = tree_url_to_name.get(
+        record["build__checkout__git_repository_url"],
+        record["build__checkout__tree_name"],
+    )
 
     test_history_item = HardwareTestHistoryItem(
         id=record["id"],
@@ -346,7 +352,7 @@ def handle_test_history(
         architecture=record["build__architecture"],
         compiler=record["build__compiler"],
         environment_misc=EnvironmentMisc(platform=record["test_platform"]),
-        tree_name=record["build__checkout__tree_name"],
+        tree_name=defined_tree_name,
         git_repository_branch=record["build__checkout__git_repository_branch"],
     )
 
@@ -403,9 +409,15 @@ def handle_test_summary(
 
 
 def handle_build_history(
-    *, record: Dict, tree_idx: int, builds: List[HardwareBuildHistoryItem]
+    *,
+    record: Dict,
+    tree_idx: int,
+    builds: List[HardwareBuildHistoryItem],
+    tree_url_to_name: dict[str, str],
 ) -> None:
     build = get_build_typed(record=record, tree_idx=tree_idx)
+    defined_tree_name = tree_url_to_name.get(build.git_repository_url, build.tree_name)
+    build.tree_name = defined_tree_name
     builds.append(build)
 
 

--- a/backend/kernelCI_app/helpers/issueExtras.py
+++ b/backend/kernelCI_app/helpers/issueExtras.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import Dict, List, Set, Tuple
 
 from kernelCI_app.helpers.logger import log_message
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.typeModels.issues import (
     IssueWithExtraInfo,
     ProcessedExtraDetailedIssues,
@@ -88,6 +89,7 @@ def assign_issue_first_seen(
         issue_id_list,
     )
 
+    tree_url_to_name = get_tree_url_to_name_map()
     for record in incident_records:
         record_issue_id = record.issue_id
         first_seen = record.first_seen
@@ -95,7 +97,11 @@ def assign_issue_first_seen(
         first_git_repository_url = record.git_repository_url
         first_git_repository_branch = record.git_repository_branch
         first_git_commit_name = record.git_commit_name
-        first_tree_name = record.tree_name
+
+        defined_tree_name = tree_url_to_name.get(
+            record.git_repository_url, record.tree_name
+        )
+        first_tree_name = defined_tree_name
 
         processed_issue_from_id = processed_issues_table.get(record_issue_id)
         if processed_issue_from_id is None:
@@ -169,11 +175,15 @@ def assign_issue_trees(
         params,
     )
 
+    tree_url_to_name = get_tree_url_to_name_map()
     for record in trees_records:
         issue_id = record.issue_id
         issue_version = record.issue_version
         git_repository_url = record.git_repository_url
         git_repository_branch = record.git_repository_branch
+        defined_tree_name = tree_url_to_name.get(
+            record.git_repository_url, record.tree_name
+        )
 
         processed_issue_from_id = processed_issues_table.get(issue_id)
         if processed_issue_from_id is None:
@@ -187,7 +197,7 @@ def assign_issue_trees(
 
         current_detailed_issue.trees.append(
             TreeSetItem(
-                tree_name=record.tree_name,
+                tree_name=defined_tree_name,
                 git_repository_branch=git_repository_branch,
             )
         )

--- a/backend/kernelCI_app/helpers/trees.py
+++ b/backend/kernelCI_app/helpers/trees.py
@@ -1,4 +1,9 @@
 from datetime import datetime
+import os
+
+from django.conf import settings
+import yaml
+from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.models import Checkouts
 
 
@@ -30,3 +35,22 @@ def get_tree_heads(origin: str, start_date: datetime, end_date: datetime):
     )
 
     return checkouts_subquery
+
+
+def get_tree_url_to_name_map() -> dict[str, str]:
+    filepath = os.path.join(settings.BACKEND_DATA_DIR, "trees-name.yaml")
+    url_to_name = {}
+    try:
+        with open(filepath, "r") as file:
+            file_data = yaml.safe_load(file)
+
+        # From: {"trees": {"tree1": {"url": "url1"}, "tree2": {"url": "url2"}}}
+        # To: {"url1": "tree1", "url2": "tree2"}
+        if file_data and "trees" in file_data:
+            for tree_name, tree_data in file_data["trees"].items():
+                if "url" in tree_data:
+                    url_to_name[tree_data["url"]] = tree_name
+    except (yaml.YAMLError, FileNotFoundError) as e:
+        log_message(e)
+
+    return url_to_name

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -47,7 +47,8 @@ def get_issue_builds(*, issue_id: str, version: Optional[int]) -> list[dict]:
             B.COMPILER,
             B.LOG_URL,
             C.TREE_NAME,
-            C.GIT_REPOSITORY_BRANCH
+            C.GIT_REPOSITORY_BRANCH,
+            C.GIT_REPOSITORY_URL
         FROM
             INCIDENTS INC
             INNER JOIN BUILDS B ON (INC.BUILD_ID = B.ID)
@@ -90,7 +91,8 @@ def get_issue_tests(*, issue_id: str, version: Optional[int]) -> list[dict]:
             T.ENVIRONMENT_COMPATIBLE,
             T.ENVIRONMENT_MISC,
             C.TREE_NAME,
-            C.GIT_REPOSITORY_BRANCH
+            C.GIT_REPOSITORY_BRANCH,
+            C.GIT_REPOSITORY_URL
         FROM
             INCIDENTS INC
             INNER JOIN TESTS T ON (INC.TEST_ID = T.ID)

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -206,7 +206,9 @@ def get_tree_listing_data(origin: str, interval_in_days: int) -> Optional[list[d
 
 # TODO: rename and reuse this query
 # It is being used virtually as "latest checkout from trees"
-def get_tree_listing_fast(*, origin: Optional[str] = None, interval: dict):
+def get_tree_listing_fast(
+    *, origin: Optional[str] = None, interval: dict
+) -> list[Checkouts]:
     origin_clause = f"origin = '{origin}' AND" if origin is not None else ""
     interval_timestamp = get_query_time_interval(**interval).timestamp()
 
@@ -249,7 +251,7 @@ def get_tree_listing_fast(*, origin: Optional[str] = None, interval: dict):
         """,
     )
 
-    return checkouts
+    return list(checkouts)
 
 
 def get_tree_listing_data_by_checkout_id(*, checkout_ids: list[str]):

--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -23,6 +23,7 @@ class TreeLatestQueryParameters(BaseModel):
 
 class TreeLatestResponse(BaseCheckouts):
     api_url: str
+    tree_name: str
 
 
 class TreeCommon(BaseModel):

--- a/backend/kernelCI_app/views/buildDetailsView.py
+++ b/backend/kernelCI_app/views/buildDetailsView.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.typeModels.buildDetails import BuildDetailsResponse
 from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
@@ -18,6 +19,12 @@ class BuildDetails(APIView):
                 error_message="Build not found",
                 status_code=HTTPStatus.OK,
             )
+
+        tree_url_to_name = get_tree_url_to_name_map()
+        defined_name = tree_url_to_name.get(
+            records[0]["git_repository_url"], records[0]["tree_name"]
+        )
+        records[0]["tree_name"] = defined_name
 
         try:
             valid_response = BuildDetailsResponse(**records[0])

--- a/backend/kernelCI_app/views/hardwareDetailsBootsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBootsView.py
@@ -14,6 +14,7 @@ from kernelCI_app.helpers.hardwareDetails import (
     is_test_processed,
     unstable_parse_post_body,
 )
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
@@ -51,6 +52,8 @@ class HardwareDetailsBoots(APIView):
 
         self.boots: List[HardwareTestHistoryItem] = []
 
+        self.tree_url_to_name_map = get_tree_url_to_name_map()
+
     def _process_test(self, record: Dict) -> None:
         is_record_boot = is_boot(record["path"])
         if not is_record_boot:
@@ -73,6 +76,7 @@ class HardwareDetailsBoots(APIView):
             handle_test_history(
                 record=record,
                 task=self.boots,
+                tree_url_to_name=self.tree_url_to_name_map,
             )
             self.processed_tests.add(record["id"])
 

--- a/backend/kernelCI_app/views/hardwareDetailsCommitHistoryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsCommitHistoryView.py
@@ -7,7 +7,10 @@ from kernelCI_app.helpers.logger import log_message
 from django.utils.decorators import method_decorator
 from datetime import datetime, timezone
 from django.views.decorators.csrf import csrf_exempt
-from kernelCI_app.helpers.trees import make_tree_identifier_key
+from kernelCI_app.helpers.trees import (
+    get_tree_url_to_name_map,
+    make_tree_identifier_key,
+)
 from kernelCI_app.typeModels.hardwareDetails import (
     CommitHead,
     CommitHistoryPostBody,
@@ -151,10 +154,11 @@ class HardwareDetailsCommitHistoryView(APIView):
             checkouts_query_set = cursor.fetchall()
 
         formatted_checkouts = defaultdict(list)
+        tree_url_to_name = get_tree_url_to_name_map()
 
         for checkout in checkouts_query_set:
             dict_checkout = {
-                "tree_name": checkout[0],
+                "tree_name": tree_url_to_name.get(checkout[1], checkout[0]),
                 "git_repository_url": checkout[1],
                 "git_repository_branch": checkout[2],
                 "git_commit_tags": checkout[3],

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -30,6 +30,7 @@ from kernelCI_app.helpers.hardwareDetails import (
     format_issue_summary_for_response,
     unstable_parse_post_body,
 )
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
@@ -319,6 +320,16 @@ class HardwareDetailsSummary(APIView):
             set_trees_status_summary(
                 trees=trees, tree_status_summary=self.tree_status_summary
             )
+
+            # The change in tree_name happens here so that the filters works unchanged before.
+            # The selection of commits works based on a comparison between the record tree_name
+            # and the selected_trees tree_name, and is assigned to trees using the index
+            tree_url_to_name_map = get_tree_url_to_name_map()
+            for tree in trees:
+                defined_tree_name = tree_url_to_name_map.get(
+                    tree.git_repository_url, tree.tree_name
+                )
+                tree.tree_name = defined_tree_name
 
             valid_response = HardwareDetailsSummaryResponse(
                 summary=Summary(

--- a/backend/kernelCI_app/views/hardwareDetailsTestsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsTestsView.py
@@ -14,6 +14,7 @@ from kernelCI_app.helpers.hardwareDetails import (
     is_test_processed,
     unstable_parse_post_body,
 )
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
@@ -49,6 +50,8 @@ class HardwareDetailsTests(APIView):
 
         self.tests: List[HardwareTestHistoryItem] = []
 
+        self.tree_url_to_name_map = get_tree_url_to_name_map()
+
     def _process_test(self, record: Dict) -> None:
         is_record_boot = is_boot(record["path"])
         if is_record_boot:
@@ -71,6 +74,7 @@ class HardwareDetailsTests(APIView):
             handle_test_history(
                 record=record,
                 task=self.tests,
+                tree_url_to_name=self.tree_url_to_name_map,
             )
             self.processed_tests.add(record["id"])
 

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -30,6 +30,7 @@ from kernelCI_app.helpers.hardwareDetails import (
     unstable_parse_post_body,
     handle_test_history,
 )
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
@@ -107,6 +108,8 @@ class HardwareDetails(APIView):
 
         self.tree_status_summary = defaultdict(generate_tree_status_summary_dict)
 
+        self.tree_url_to_name_map = get_tree_url_to_name_map()
+
     def _process_test(self, record: Dict) -> None:
         is_record_boot = is_boot(record["path"])
         test_type_key: PossibleTestType = "boot" if is_record_boot else "test"
@@ -146,10 +149,15 @@ class HardwareDetails(APIView):
             handle_test_history(
                 record=record,
                 task=test_or_boot_history,
+                tree_url_to_name=self.tree_url_to_name_map,
             )
 
     def _process_build(self, record: Dict, tree_index: int) -> None:
         build = get_build_typed(record, tree_index)
+        defined_tree_name = self.tree_url_to_name_map.get(
+            build.git_repository_url, build.tree_name
+        )
+        build.tree_name = defined_tree_name
         build_id = record["build_id"]
 
         should_process_build = decide_if_is_build_in_filter(
@@ -291,6 +299,15 @@ class HardwareDetails(APIView):
         set_trees_status_summary(
             trees=trees, tree_status_summary=self.tree_status_summary
         )
+
+        # The change in tree_name happens here so that the filters works unchanged before.
+        # The selection of commits works based on a comparison between the record tree_name
+        # and the selected_trees tree_name, and is assigned to trees using the index
+        for tree in trees:
+            defined_tree_name = self.tree_url_to_name_map.get(
+                tree.git_repository_url, tree.tree_name
+            )
+            tree.tree_name = defined_tree_name
 
         try:
             valid_response = HardwareDetailsFullResponse(

--- a/backend/kernelCI_app/views/issueDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/issueDetailsBuildsView.py
@@ -3,6 +3,7 @@ from typing import Optional
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.typeModels.issueDetails import (
     IssueBuildsResponse,
     IssueDetailsPathParameters,
@@ -33,6 +34,13 @@ class IssueDetailsBuilds(APIView):
         builds_data = get_issue_builds(
             issue_id=path_params.issue_id, version=query_params.version
         )
+
+        tree_url_to_name = get_tree_url_to_name_map()
+        for build in builds_data:
+            defined_tree_name = tree_url_to_name.get(
+                build["git_repository_url"], build["tree_name"]
+            )
+            build["tree_name"] = defined_tree_name
 
         if not builds_data:
             return create_api_error_response(

--- a/backend/kernelCI_app/views/issueDetailsTestsView.py
+++ b/backend/kernelCI_app/views/issueDetailsTestsView.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from django.http import HttpRequest
 from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.issues import get_issue_tests
 from kernelCI_app.typeModels.issueDetails import (
     IssueDetailsPathParameters,
@@ -38,6 +39,13 @@ class IssueDetailsTests(APIView):
             return create_api_error_response(
                 error_message="No tests found for this issue", status_code=HTTPStatus.OK
             )
+
+        tree_url_to_name = get_tree_url_to_name_map()
+        for test in tests_data:
+            defined_tree_name = tree_url_to_name.get(
+                test["git_repository_url"], test["tree_name"]
+            )
+            test["tree_name"] = defined_tree_name
 
         try:
             valid_response = IssueTestsResponse(tests_data)

--- a/backend/kernelCI_app/views/testDetailsView.py
+++ b/backend/kernelCI_app/views/testDetailsView.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.test import get_test_details_data
 from kernelCI_app.typeModels.testDetails import (
     TestDetailsResponse,
@@ -21,6 +22,12 @@ class TestDetails(APIView):
             return create_api_error_response(
                 error_message="Test not found", status_code=HTTPStatus.OK
             )
+
+        tree_url_to_name = get_tree_url_to_name_map()
+        defined_name = tree_url_to_name.get(
+            response[0]["git_repository_url"], response[0]["tree_name"]
+        )
+        response[0]["tree_name"] = defined_name
 
         try:
             valid_response = TestDetailsResponse(**response[0])

--- a/backend/kernelCI_app/views/treeLatest.py
+++ b/backend/kernelCI_app/views/treeLatest.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.models import Checkouts
 from kernelCI_app.typeModels.treeDetails import (
     TreeLatestPathParameters,
@@ -27,6 +28,7 @@ class TreeLatest(APIView):
             "git_commit_hash",
             "git_commit_name",
             "git_repository_url",
+            "tree_name",
         ]
 
         query = (
@@ -68,11 +70,37 @@ class TreeLatest(APIView):
             origin=origin,
         )
 
+        tree_url_to_name = get_tree_url_to_name_map()
+
         if tree_data is None:
-            return create_api_error_response(
-                error_message=tree_not_found_error_message,
-                status_code=HTTPStatus.OK,
+            # It is possible that the user is trying to fetch a shortcut where
+            # the tree name was gotten from the trees-name file, in which case
+            # the real tree_name in the database could be null. This means that
+            # the tree exists, but the database doesn't see the tree_name.
+            # If this happpens, we can give another try with an empty tree_name
+            # and validate it with the file using its git_repository_url
+            tree_data = self._fetch_latest_tree(
+                tree_name=None, branch=parsed_params.branch, origin=origin
             )
+
+            if tree_data is not None:
+                defined_tree_name = tree_url_to_name.get(
+                    tree_data.get("git_repository_url", "")
+                )
+
+            if tree_data is None or defined_tree_name != tree_name:
+                return create_api_error_response(
+                    error_message=tree_not_found_error_message,
+                    status_code=HTTPStatus.OK,
+                )
+
+        # Since the priority is now the tree name from the yaml file,
+        # if a tree had a name A in kcidb but it has name B on the file,
+        # searching for the name A will return with its name replaced
+        defined_tree_name = tree_url_to_name.get(
+            tree_data["git_repository_url"], tree_data["tree_name"]
+        )
+        tree_data["tree_name"] = defined_tree_name
 
         base_url = reverse(
             "treeDetailsView",

--- a/dashboard/src/pages/TreeLatest.tsx
+++ b/dashboard/src/pages/TreeLatest.tsx
@@ -40,7 +40,7 @@ export const TreeLatest = (): JSX.Element | void => {
         treeInfo: {
           gitBranch: branch,
           gitUrl: data.git_repository_url || undefined,
-          treeName: treeName,
+          treeName: data.tree_name,
           commitName: data.git_commit_name || undefined,
           headCommitHash: data.git_commit_hash,
         },

--- a/dashboard/src/types/tree/Tree.tsx
+++ b/dashboard/src/types/tree/Tree.tsx
@@ -44,6 +44,7 @@ export type TreeTableBody = BaseTree & AllTabCounts;
 export type Tree = BaseTree & Required<AllTabCounts>;
 
 export type TreeLatestResponse = {
+  tree_name: string;
   api_url: string;
   git_commit_hash: string;
   git_repository_url: string | null;


### PR DESCRIPTION
## Changes
Overrides the tree_name on all endpoints that return tree_name to use the tree_name on the trees-name.yaml file, which is retrieved by the git_repository_url

Special notes to the treeLatest endpoint (or the shortcut to a tree):
First, it will now retry the query in case the kcidb tree name is null but is not null on the file, allowing to search for a tree that doesn't have tree_name on kcidb (such as /tree/mainline/master?o=arm)
Secondly, it will also return the name from the file even if it exists on kcidb but is different. For example: if a tree has name A on kcidb but name B on trees-name.yaml, I can fetch /tree/A/branch and it will return me the treeDetails page but with tree name B; a breaking scenario could be if a tree _has_ the B name on kcidb when it shouldn't, in which case the shortcut /tree/A/branch will show the same _name_ as /tree/B/branch, but the pages will be different

There are also some trees, such as some chromiumos, which had their name on kcidb but could be changed to a new one following the trees-name.yaml file.

## How to test
Go to any tree page and check the tree name, especially for some trees which don't have tree_name, such as on origins other than maestro. Altering the trees-name.yaml file is also a way to better see the changes.

## Examples
[localhost 0dayci treeListing](http://localhost:5173/tree?o=0dayci) - [staging equivalent](https://staging.dashboard.kernelci.org:9000/tree?o=0dayci)
![image](https://github.com/user-attachments/assets/4c315f50-fae3-4ee2-b382-1129bc7b933a)
![image](https://github.com/user-attachments/assets/ed51831b-aa7d-4fde-8887-06d9720e7325)

[localhost chromiumos](http://localhost:5173/tree?ts=chromiumos) - staging equivalent
![image](https://github.com/user-attachments/assets/4a620cb7-ab3f-4657-accd-761bcd06212f)
![image](https://github.com/user-attachments/assets/b16c8603-f589-483d-a648-e39d34910f58)



Closes #1148 
Closes #1162 