### PR TITLE
Feat: improve issue counting

### DIFF
--- a/backend/kernelCI_app/helpers/detailsIssues.py
+++ b/backend/kernelCI_app/helpers/detailsIssues.py
@@ -1,5 +1,5 @@
 from kernelCI_app.typeModels.issues import Issue, IssueDict
-from kernelCI_app.utils import convert_issues_dict_to_list_typed, create_issue
+from kernelCI_app.utils import convert_issues_dict_to_list_typed, create_issue_typed
 
 
 def sanitize_details_issues_rows(*, rows) -> list[Issue]:
@@ -9,12 +9,13 @@ def sanitize_details_issues_rows(*, rows) -> list[Issue]:
         issue_version = row["version"]
         current_issue = result.get((issue_id, issue_version))
         if current_issue:
-            current_issue["incidents_info"]["incidentsCount"] += 1
+            current_issue.incidents_info.increment(row["status"])
         else:
-            result[(issue_id, issue_version)] = create_issue(
+            result[(issue_id, issue_version)] = create_issue_typed(
                 issue_id=issue_id,
                 issue_version=issue_version,
                 issue_comment=row["comment"],
                 issue_report_url=row["report_url"],
+                starting_count_status=row["status"],
             )
     return convert_issues_dict_to_list_typed(issues_dict=result)

--- a/backend/kernelCI_app/helpers/filters.py
+++ b/backend/kernelCI_app/helpers/filters.py
@@ -5,7 +5,6 @@ import re
 from kernelCI_app.constants.general import UNCATEGORIZED_STRING
 from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.typeModels.databases import (
-    PASS_STATUS,
     StatusValues,
     failure_status_list,
     build_fail_status_list,
@@ -129,14 +128,10 @@ def should_filter_test_issue(
     issue_id: Optional[str],
     issue_version: Optional[int],
     incident_test_id: Optional[str],
-    test_status: Optional[str],
 ) -> bool:
     has_issue_filter = len(issue_filters) > 0
     if not has_issue_filter:
         return False
-
-    if test_status == PASS_STATUS:
-        return True
 
     has_uncategorized_filter = UNCATEGORIZED_STRING in issue_filters
 
@@ -660,7 +655,6 @@ class FilterParams:
                 issue_id=issue_id,
                 issue_version=issue_version,
                 incident_test_id=incident_test_id,
-                test_status=status,
             )
             or (
                 len(self.filterPlatforms["boot"]) > 0
@@ -707,7 +701,6 @@ class FilterParams:
                 issue_id=issue_id,
                 issue_version=issue_version,
                 incident_test_id=incident_test_id,
-                test_status=status,
             )
             or (
                 len(self.filterPlatforms["test"]) > 0

--- a/backend/kernelCI_app/tests/unitTests/filters_test.py
+++ b/backend/kernelCI_app/tests/unitTests/filters_test.py
@@ -9,7 +9,6 @@ class TestShouldFilterTestIssue:
             issue_id=UNCATEGORIZED_STRING,
             issue_version=None,
             incident_test_id="incident_test_1",
-            test_status="FAIL",
         )
 
     def test_unknown_filter_with_exclusively_build_issue(self):
@@ -18,7 +17,6 @@ class TestShouldFilterTestIssue:
             issue_id="issue1",
             issue_version=1,
             incident_test_id="incident_test_1",
-            test_status="PASS",
         )
 
     def test_unknown_issue_but_not_from_test(self):
@@ -27,5 +25,4 @@ class TestShouldFilterTestIssue:
             issue_id="maestro:72697a4efbbd0eff7080781839b405bbf0902f79",
             issue_version=0,
             incident_test_id=None,
-            test_status="FAIL",
         )

--- a/backend/kernelCI_app/typeModels/common.py
+++ b/backend/kernelCI_app/typeModels/common.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from kernelCI_app.helpers.logger import log_message
+
+
+class StatusCount(BaseModel):
+    PASS: Optional[int] = 0
+    ERROR: Optional[int] = 0
+    FAIL: Optional[int] = 0
+    SKIP: Optional[int] = 0
+    MISS: Optional[int] = 0
+    DONE: Optional[int] = 0
+    NULL: Optional[int] = 0
+
+    def increment(self, status: Optional[str]) -> None:
+        if status is None:
+            status = "NULL"
+
+        try:
+            setattr(self, status.upper(), getattr(self, status.upper()) + 1)
+        except AttributeError:
+            log_message(f"Unknown status: {status}")

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Set, Union, Tuple, Any
 
 from pydantic import BaseModel, field_validator, Field
 from kernelCI_app.helpers.logger import log_message
+from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.issues import Issue
 from kernelCI_app.typeModels.databases import (
     EnvironmentMisc,
@@ -22,16 +23,6 @@ from kernelCI_app.typeModels.databases import (
     Checkout__GitRepositoryBranch,
 )
 from kernelCI_app.helpers.build import build_status_map
-
-
-class StatusCount(BaseModel):
-    PASS: Optional[int] = 0
-    ERROR: Optional[int] = 0
-    FAIL: Optional[int] = 0
-    SKIP: Optional[int] = 0
-    MISS: Optional[int] = 0
-    DONE: Optional[int] = 0
-    NULL: Optional[int] = 0
 
 
 class TestArchSummaryItem(BaseModel):

--- a/backend/kernelCI_app/typeModels/hardwareDetails.py
+++ b/backend/kernelCI_app/typeModels/hardwareDetails.py
@@ -173,4 +173,4 @@ class HardwareCommitHistoryResponse(BaseModel):
         }
 
 
-PossibleTestType = Literal["test", "boot"]
+type PossibleTestType = Literal["test", "boot"]

--- a/backend/kernelCI_app/typeModels/hardwareListing.py
+++ b/backend/kernelCI_app/typeModels/hardwareListing.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, BeforeValidator, Field
 from typing import Annotated
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
-from kernelCI_app.typeModels.commonDetails import StatusCount
+from kernelCI_app.typeModels.common import StatusCount
 
 
 class HardwareItem(BaseModel):

--- a/backend/kernelCI_app/typeModels/issues.py
+++ b/backend/kernelCI_app/typeModels/issues.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Literal, Optional, Set, Tuple, Annotated
 from pydantic import BaseModel, Field
 
+from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.databases import (
     Timestamp,
     Checkout__GitCommitHash,
@@ -23,7 +24,7 @@ class IssueKeys(BaseModel):
 class Issue(IssueKeys):
     comment: Optional[str]
     report_url: Optional[str]
-    incidents_info: IncidentInfo
+    incidents_info: StatusCount
 
 
 type IssueDict = Dict[Tuple[str, int], Issue]

--- a/backend/kernelCI_app/typeModels/treeCommits.py
+++ b/backend/kernelCI_app/typeModels/treeCommits.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, RootModel
 
-from kernelCI_app.typeModels.commonDetails import StatusCount
+from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.treeListing import TestStatusCount
 from kernelCI_app.typeModels.databases import (
     Checkout__GitCommitHash,

--- a/backend/kernelCI_app/typeModels/treeListing.py
+++ b/backend/kernelCI_app/typeModels/treeListing.py
@@ -1,5 +1,5 @@
 from typing import List
-from kernelCI_app.typeModels.commonDetails import StatusCount
+from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.databases import (
     Checkout__GitCommitHash,
     Checkout__GitCommitName,

--- a/backend/kernelCI_app/views/treeDetailsBootsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBootsView.py
@@ -1,8 +1,6 @@
-from typing import Dict, Tuple
 from http import HTTPStatus
 
 from drf_spectacular.utils import extend_schema
-from kernelCI_app.typeModels.issues import Issue
 from pydantic import ValidationError
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
@@ -24,9 +22,6 @@ from kernelCI_app.typeModels.commonDetails import (
     CommonDetailsBootsResponse,
     TestHistoryItem,
 )
-
-
-type IssueDict = Dict[Tuple[str, str], Issue]
 
 
 class TreeDetailsBoots(APIView):

--- a/backend/kernelCI_app/views/treeDetailsTestsView.py
+++ b/backend/kernelCI_app/views/treeDetailsTestsView.py
@@ -1,6 +1,4 @@
-from typing import Dict, Tuple
 from drf_spectacular.utils import extend_schema
-from kernelCI_app.typeModels.issues import Issue
 from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -23,9 +21,6 @@ from kernelCI_app.typeModels.commonDetails import (
     CommonDetailsTestsResponse,
     TestHistoryItem,
 )
-
-
-type IssueDict = Dict[Tuple[str, str], Issue]
 
 
 class TreeDetailsTests(APIView):

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -17,7 +17,6 @@ from kernelCI_app.helpers.treeDetails import (
     decide_if_is_test_filtered_out,
     get_build,
     get_current_row_data,
-    process_boots_issue,
     process_tree_url,
     is_test_boots_test,
     process_boots_summary,
@@ -35,9 +34,7 @@ from kernelCI_app.typeModels.commonDetails import (
     Summary,
     TestSummary,
 )
-from kernelCI_app.utils import (
-    convert_issues_dict_to_list,
-)
+from kernelCI_app.utils import convert_issues_dict_to_list_typed
 
 from collections import defaultdict
 
@@ -64,7 +61,6 @@ class TreeDetails(APIView):
         self.testFailReasons = {}
         self.test_arch_summary = {}
         self.testIssues: List[Issue] = []
-        self.testIssuesTable: IssueDict = {}
         self.testEnvironmentCompatible = defaultdict(lambda: defaultdict(int))
         self.testEnvironmentMisc = defaultdict(lambda: defaultdict(int))
         self.bootHistory = []
@@ -74,20 +70,22 @@ class TreeDetails(APIView):
         self.bootFailReasons = {}
         self.bootArchSummary = {}
         self.bootIssues: List[Issue] = []
-        self.bootsIssuesTable: IssueDict = {}
         self.bootEnvironmentCompatible = defaultdict(lambda: defaultdict(int))
         self.bootEnvironmentMisc = defaultdict(lambda: defaultdict(int))
         self.hardwareUsed = set()
-        self.failedTestsWithUnknownIssues = 0
-        self.failedBootsWithUnknownIssues = 0
+        self.failed_tests_with_unknown_issues = 0
+        self.failed_boots_with_unknown_issues = 0
         self.builds = []
         self.processed_builds = set()
         self.build_summary = {}
         self.build_issues: List[Issue] = []
         self.failed_builds_with_unknown_issues = 0
-        self.processed_build_issues: IssueDict = {}
         self.tree_url = ""
         self.git_commit_tags = []
+
+        self.build_issues_dict: IssueDict = {}
+        self.boot_issues_dict: IssueDict = {}
+        self.test_issues_dict: IssueDict = {}
 
         self.global_configs = set()
         self.global_architectures = set()
@@ -108,7 +106,7 @@ class TreeDetails(APIView):
         if decide_if_is_boot_filtered_out(self, row_data):
             return
 
-        process_boots_issue(self, row_data)
+        process_tests_issue(instance=self, row_data=row_data, is_boot=True)
 
         if test_id in self.processedTests:
             return
@@ -123,7 +121,7 @@ class TreeDetails(APIView):
         if decide_if_is_test_filtered_out(self, row_data):
             return
 
-        process_tests_issue(self, row_data)
+        process_tests_issue(instance=self, row_data=row_data)
 
         if test_id in self.processedTests:
             return
@@ -138,7 +136,7 @@ class TreeDetails(APIView):
         if decide_if_is_build_filtered_out(self, row_data):
             return
 
-        process_builds_issue(self, row_data)
+        process_builds_issue(instance=self, row_data=row_data)
 
         if build_id in self.processed_builds:
             return
@@ -178,10 +176,16 @@ class TreeDetails(APIView):
             else:
                 self._process_non_boots_test(row_data)
 
-        self.testIssues = convert_issues_dict_to_list(self.testIssuesTable)
-        self.bootIssues = convert_issues_dict_to_list(self.bootsIssuesTable)
         self.build_summary = create_details_build_summary(self.builds)
-        self.build_issues = convert_issues_dict_to_list(self.processed_build_issues)
+        self.build_issues = convert_issues_dict_to_list_typed(
+            issues_dict=self.build_issues_dict
+        )
+        self.bootIssues = convert_issues_dict_to_list_typed(
+            issues_dict=self.boot_issues_dict
+        )
+        self.testIssues = convert_issues_dict_to_list_typed(
+            issues_dict=self.test_issues_dict
+        )
 
     @extend_schema(
         responses=TreeDetailsFullResponse,
@@ -238,7 +242,7 @@ class TreeDetails(APIView):
                         architectures=list(self.bootArchSummary.values()),
                         configs=self.bootConfigs,
                         issues=self.bootIssues,
-                        unknown_issues=self.failedBootsWithUnknownIssues,
+                        unknown_issues=self.failed_boots_with_unknown_issues,
                         environment_compatible=self.bootEnvironmentCompatible,
                         environment_misc=self.bootEnvironmentMisc,
                         fail_reasons=self.bootFailReasons,
@@ -249,7 +253,7 @@ class TreeDetails(APIView):
                         architectures=list(self.test_arch_summary.values()),
                         configs=self.test_configs,
                         issues=self.testIssues,
-                        unknown_issues=self.failedTestsWithUnknownIssues,
+                        unknown_issues=self.failed_tests_with_unknown_issues,
                         environment_compatible=self.testEnvironmentCompatible,
                         environment_misc=self.testEnvironmentMisc,
                         fail_reasons=self.testFailReasons,

--- a/backend/kernelCI_app/views/treeView.py
+++ b/backend/kernelCI_app/views/treeView.py
@@ -4,7 +4,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.tree import get_tree_listing_data
-from kernelCI_app.typeModels.commonDetails import StatusCount
+from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.commonListing import ListingQueryParameters
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,

--- a/dashboard/src/components/Cards/IssuesList.tsx
+++ b/dashboard/src/components/Cards/IssuesList.tsx
@@ -38,6 +38,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 import { BranchBadge } from '@/components/Badge/BranchBadge';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
+import { GroupedTestStatus } from '@/components/Status/Status';
+
 interface IIssuesList {
   issues: TIssue[];
   failedWithUnknownIssues?: number;
@@ -159,6 +161,19 @@ const IssuesList = ({
 
         const first_seen = currentExtraDetailsId?.first_incident.first_seen;
 
+        const counts = issue.incidents_info;
+        const countElement = (
+          <GroupedTestStatus
+            pass={counts.PASS}
+            fail={counts.FAIL}
+            nullStatus={counts.NULL}
+            error={counts.ERROR}
+            done={counts.DONE}
+            miss={counts.MISS}
+            skip={counts.SKIP}
+          />
+        );
+
         return (
           <div
             key={`${issue.id}${issue.version}`}
@@ -172,15 +187,18 @@ const IssuesList = ({
                   diffFilter={diffFilter}
                 >
                   <span className="flex items-center text-sm">
-                    <ListingItem
-                      unknown={issue.incidents_info.incidentsCount}
-                      hasBottomBorder
-                      text={
-                        issue.comment ??
-                        formatMessage({ id: 'issue.uncategorized' })
-                      }
-                      tooltip={issue.comment}
-                    />
+                    <div className="flex gap-2">
+                      {countElement}
+                      <ListingItem
+                        showNumber={false}
+                        hasBottomBorder
+                        text={
+                          issue.comment ??
+                          formatMessage({ id: 'issue.uncategorized' })
+                        }
+                        tooltip={issue.comment}
+                      />
+                    </div>
                     {extraDetailsLoading ? (
                       <LoadingCircle className="mx-2" />
                     ) : (
@@ -225,7 +243,7 @@ const IssuesList = ({
           diffFilter={diffFilter}
         >
           <ListingItem
-            unknown={failedWithUnknownIssues}
+            errors={failedWithUnknownIssues}
             text={formatMessage({ id: 'issue.uncategorized' })}
           />
         </FilterLink>

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -14,6 +14,8 @@ import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import type { TIssue } from '@/types/issues';
 
+import { groupStatus } from '@/utils/status';
+
 import { IssueTooltip } from './IssueTooltip';
 
 const IssueSection = ({
@@ -30,6 +32,20 @@ const IssueSection = ({
   const issueList = useMemo(
     () =>
       data?.map(issue => {
+        const counts = issue.incidents_info;
+        const groupedCount = groupStatus({
+          passCount: counts.PASS,
+          failCount: counts.FAIL,
+          nullCount: counts.NULL,
+          errorCount: counts.ERROR,
+          missCount: counts.MISS,
+          doneCount: counts.DONE,
+          skipCount: counts.SKIP,
+        });
+        const totalCount =
+          groupedCount.successCount +
+          groupedCount.failedCount +
+          groupedCount.inconclusiveCount;
         return (
           <Link
             key={issue.id + issue.version}
@@ -43,7 +59,7 @@ const IssueSection = ({
             })}
           >
             <ListingItem
-              unknown={issue.incidents_info.incidentsCount}
+              unknown={totalCount}
               text={issue.comment ?? issue.id}
               tooltip={issue.id}
             />

--- a/dashboard/src/components/ListingItem/ListingItem.tsx
+++ b/dashboard/src/components/ListingItem/ListingItem.tsx
@@ -98,7 +98,7 @@ const ListingItem = ({
     return (
       <Tooltip>
         <div className="flex w-full">
-          <TooltipTrigger className="max-w-[200px] overflow-hidden md:max-w-[100px] lg:max-w-[325px] xl:max-w-[475px] 2xl:max-w-[700px]">
+          <TooltipTrigger className="max-w-[200px] overflow-hidden md:max-w-[100px] lg:max-w-[280px] xl:max-w-[475px] 2xl:max-w-[700px]">
             {children}
           </TooltipTrigger>
 

--- a/dashboard/src/types/issues.ts
+++ b/dashboard/src/types/issues.ts
@@ -1,4 +1,4 @@
-type IncidentsInfo = { incidentsCount: number };
+import type { RequiredStatusCount } from './general';
 
 export type IssueKeys = {
   id: string;
@@ -8,5 +8,5 @@ export type IssueKeys = {
 export type TIssue = IssueKeys & {
   comment?: string;
   report_url?: string;
-  incidents_info: IncidentsInfo;
+  incidents_info: RequiredStatusCount;
 };


### PR DESCRIPTION
## Changes
Changes the issue counting from a simple int to a status based dict, allowing for better distinction in the frontend
Makes the issue card group issues by status
Also refactors some functions to have stricter, correct typing

## How to test
Go to treeDetails and hardwareDetails pages that have issues and check the new layout
Pages that show a list of issues should all still work correctly, and when they showed a count the number should still be correct
Issue filters should also still work

### Examples
Before
![image](https://github.com/user-attachments/assets/d7e30cb5-9697-4381-a518-2b310756c3ed)

After
![image](https://github.com/user-attachments/assets/05be00d1-395c-4eee-a017-02c67ef48a2d)

[hardware details with boot issues](http://localhost:5173/hardware/acer-cp514-2h-1130g7-volteer?et=1744396200&p=bt&st=1743964200&tf%7Cb=a&tf%7Cbt=i&tf%7Ct=a)
[maestro tree details with boot issues and failed builds](http://localhost:5173/tree/660bd24947f57692061f1dd7011ae4c66aa0e79a?p=bt&ti%7Cc=amlogic-arm64-dt-for-v6.15-v2-24-g660bd24947f5&ti%7Cch=660bd24947f57692061f1dd7011ae4c66aa0e79a&ti%7Cgb=for-next&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Famlogic%2Flinux.git&ti%7Ct=amlogic)
[redhat tree details with issues on pass tests](http://localhost:5173/tree/0e433a6723bd3ce8056a943244f19db804e76eae?o=redhat&p=t&tf%7Cb=a&tf%7Cbt=f&tf%7Ct=a&ti%7Cc=kernel-6.15.0-0.rc1.900241a5cc15.19&ti%7Cch=0e433a6723bd3ce8056a943244f19db804e76eae&ti%7Cgb=ark-latest&ti%7Cgu=https%3A%2F%2Fgitlab.com%2Fcki-project%2Fkernel-ark.git&ti%7Ct=c10s)
[test details page](http://localhost:5173/test/maestro%3A67f8e696c98e04810d3015d9)

Closes #827