### PR TITLE
Fix: missing tree names in file

### DIFF
--- a/backend/data/trees-name.yaml
+++ b/backend/data/trees-name.yaml
@@ -59,10 +59,14 @@ trees:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/efi/efi.git
   gfs2:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/gfs2/linux-gfs2.git
+  git.linuxtv.org-media_stage:
+    url: https://git.linuxtv.org/media_stage.git
   gregkh-usb:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/usb.git
   hyperv:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/hyperv/linux.git
+  kernel-common-1:
+    url: https://android.googlesource.com/kernel/common.git
   khilman:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux.git
   krzysztof:
@@ -81,6 +85,10 @@ trees:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git
   linusw:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-gpio.git
+  linux-pci:
+    url: https://git.kernel.org/pub/scm/linux/kernel/git/pci/pci.git
+  lpieralisi-linux:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/lpieralisi/linux.git
   mainline:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
   media:
@@ -93,8 +101,14 @@ trees:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git
   netdev-testing:
     url: https://github.com/linux-netdev/testing.git
+  netfilter-nf:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/netfilter/nf.git
+  netfilter-nf-next:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/netfilter/nf-next.git
   next:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+  next-linux-next-1:
+    url: https://kernel.googlesource.com/pub/scm/linux/kernel/git/next/linux-next.git
   omap:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux-omap.git
   padovan:
@@ -111,6 +125,10 @@ trees:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/robh/linux.git
   rppt:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/rppt/memblock.git
+  rt-linux-rt-devel:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/rt/linux-rt-devel.git
+  sashal-linus-next-1:
+    url: https://kernel.googlesource.com/pub/scm/linux/kernel/git/sashal/linus-next.git
   sashal-next:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/sashal/linus-next.git
   scsi:
@@ -121,6 +139,10 @@ trees:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
   stable-linux-stable:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+  stable-linux-stable-1:
+    url: https://gitlab.com/Linaro/lkft/mirrors/stable/linux-stable
+  stable-linux-stable-rc:
+    url: https://kernel.googlesource.com/pub/scm/linux/kernel/git/stable/linux-stable-rc.git
   stable-linux-stable-rc-queues:
     url: https://gitlab.com/Linaro/lkft/mirrors/stable/linux-stable-rc-queues
   stable-rc:
@@ -139,19 +161,45 @@ trees:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/tnguy/net-queue.git
   tnguy-next:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/tnguy/next-queue.git
+  torvalds-linux:
+    url: https://kernel.googlesource.com/pub/scm/linux/kernel/git/torvalds/linux.git
   torvalds-linux-mainline:
     url: https://gitlab.com/Linaro/lkft/mirrors/torvalds/linux-mainline
   ulfh:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/ulfh/mmc.git
   upstream-arm-acpi:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/lpieralisi/linux.git
+  upstream-arm-next:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/arm64/linux.git
+  upstream-block:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/axboe/linux-block.git
+  upstream-gfs2:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/gfs2/linux-gfs2.git
+  upstream-kvm:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/virt/kvm/kvm.git
+  upstream-mainline:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/torvalds/linux.git
   upstream-nf:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/netfilter/nf.git
   upstream-nf-next:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/netfilter/nf-next.git
+  upstream-printk:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/printk/linux.git
   upstream-rt-devel:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-rt-devel.git
+  upstream-rt-stable:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/rt/linux-stable-rt.git
+  upstream-scsi:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/mkp/scsi.git
+  upstream-stable:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/stable/linux-stable-rc.git
+  upstream-tnguy-net:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/tnguy/net-queue.git
+  upstream-tnguy-next:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/linux/kernel/git/tnguy/next-queue.git
   upstream-xfs:
     url: https://git.kernel.org/pub/scm/fs/xfs/xfs-linux.git
   vireshk:
     url: https://git.kernel.org/pub/scm/linux/kernel/git/vireshk/linux.git
+  xfs-xfs-linux:
+    url: https://gitlab.com/redhat/red-hat-ci-tools/kernel/mirror/fs/xfs/xfs-linux.git

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -133,7 +133,7 @@ SPECTACULAR_SETTINGS = {
 # where "arg" is add, remove or show
 CRONJOBS = [
     ("0 * * * *", "kernelCI_app.tasks.update_checkout_cache"),
-    ("0 0 * * 0", "django.core.management.call_command", ["treeproof"]),
+    ("0 0 * * *", "django.core.management.call_command", ["treeproof"]),
     (
         "59 * * * *",
         "django.core.management.call_command",


### PR DESCRIPTION
## Explanation of solution
Some trees had the tree name present in the file but had a different url, that made them not be added to the file since their name was already in the list, which in turn meant that they weren't being added to the file but also that their url wasn't being considered. This was solved by first knowing that the url wasn't in the file, then, if the tree_name from kcidb is already in the file, get it from the url, then either if the tree_name was retrieved from kcidb or from the url, **adds a suffix to the tree_name as "-n" where n is an int** such that it's possible to add that url with a unique tree_name. This suffix is only incremented if it is already present.

## Changes
- Adds a suffix to existing tree_name but unexisting git_url in the file;
- Fixes a condition that made the file not update;
- Changes the cron job from running once a week to run once a day to make sure it's up to date.

## How to test
Check tree listings that didn't have tree names before, such as from the tuxsuite origin.
You can execute the command separately by running `poetry run ./manage.py treeproof` (optionally with `--verbosity 2` to see prints)

Closes #1171