### PR TITLE
Refactor: move queries to its folder

### DIFF
--- a/backend/kernelCI_app/helpers/detailsIssues.py
+++ b/backend/kernelCI_app/helpers/detailsIssues.py
@@ -2,7 +2,7 @@ from kernelCI_app.typeModels.issues import Issue, IssueDict
 from kernelCI_app.utils import convert_issues_dict_to_list_typed, create_issue_typed
 
 
-def sanitize_details_issues_rows(*, rows) -> list[Issue]:
+def sanitize_details_issues_rows(*, rows: list[dict]) -> list[Issue]:
     result: IssueDict = {}
     for row in rows:
         issue_id = row["id"]

--- a/backend/kernelCI_app/helpers/issueExtras.py
+++ b/backend/kernelCI_app/helpers/issueExtras.py
@@ -3,13 +3,13 @@ from typing import Dict, List, Set, Tuple
 
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.helpers.trees import get_tree_url_to_name_map
+from kernelCI_app.queries.issues import get_issue_first_seen_data, get_issue_trees_data
 from kernelCI_app.typeModels.issues import (
     IssueWithExtraInfo,
     ProcessedExtraDetailedIssues,
     TreeSetItem,
     FirstIncident,
 )
-from kernelCI_app.models import Incidents, Checkouts
 
 
 class TagUrls:
@@ -48,46 +48,7 @@ def assign_issue_first_seen(
         issue_id_list.append(issue_id)
         versions_per_issue[issue_id].add(issue_version)
 
-    # TODO: use '=' instead of 'IN' when the list has a single element
-    incident_records = Incidents.objects.raw(
-        """
-        WITH first_incident AS (
-            SELECT
-                IC.issue_id,
-                MIN(IC.issue_version) AS min_issue_version,
-                MIN(IC._timestamp) AS first_seen
-            FROM
-                incidents IC
-            WHERE
-                IC.issue_id IN ({0})
-            GROUP BY
-                IC.issue_id
-        )
-        SELECT
-            IC.id,
-            IC.issue_id,
-            IC._timestamp AS first_seen,
-            IC.issue_version,
-            C.git_commit_hash,
-            C.git_repository_url,
-            C.git_repository_branch,
-            C.git_commit_name,
-            C.tree_name
-        FROM
-            incidents IC
-        LEFT JOIN tests T ON IC.test_id = T.id
-        LEFT JOIN builds B ON (IC.build_id = B.id OR T.build_id = B.id)
-        LEFT JOIN checkouts C ON B.checkout_id = C.id
-        JOIN first_incident FI ON (
-            IC.issue_id = FI.issue_id
-            AND IC.issue_version = FI.min_issue_version
-            AND IC."_timestamp" = FI.first_seen
-        )
-        """.format(
-            ", ".join(["%s"] * len(issue_id_list))
-        ),
-        issue_id_list,
-    )
+    incident_records = get_issue_first_seen_data(issue_id_list=issue_id_list)
 
     tree_url_to_name = get_tree_url_to_name_map()
     for record in incident_records:
@@ -127,53 +88,10 @@ def assign_issue_first_seen(
 
 def assign_issue_trees(
     *,
-    issue_key_list: List[Tuple[str, int]],
+    issue_key_list: list[tuple[str, int]],
     processed_issues_table: ProcessedExtraDetailedIssues,
 ) -> None:
-    # TODO: use '=' instead of 'IN' when the list has a single element
-    tuple_param_list = []
-    params = {}
-
-    for index, key in enumerate(issue_key_list):
-        id_key = f"id{index}"
-        version_key = f"version{index}"
-
-        tuple_string = f"(%({id_key})s, %({version_key})s)"
-
-        tuple_param_list.append(tuple_string)
-        params[id_key] = key[0]
-        params[version_key] = key[1]
-    tuple_str = ", ".join(tuple_param_list)
-
-    trees_records = Checkouts.objects.raw(
-        f"""
-        SELECT DISTINCT
-          ON (
-            C.TREE_NAME,
-            C.GIT_REPOSITORY_URL,
-            C.GIT_REPOSITORY_BRANCH,
-            IC.ISSUE_ID,
-            IC.ISSUE_VERSION
-          )
-          C.ID,
-          C.TREE_NAME,
-          C.GIT_REPOSITORY_URL,
-          C.GIT_REPOSITORY_BRANCH,
-          IC.ISSUE_ID,
-          IC.ISSUE_VERSION
-        FROM
-          INCIDENTS IC
-          LEFT JOIN TESTS T ON IC.TEST_ID = T.ID
-          LEFT JOIN BUILDS B ON (
-            IC.BUILD_ID = B.ID
-            OR T.BUILD_ID = B.ID
-          )
-          JOIN CHECKOUTS C ON B.CHECKOUT_ID = C.ID
-        WHERE
-          (IC.ISSUE_ID, IC.ISSUE_VERSION) IN ({tuple_str})
-        """,
-        params,
-    )
+    trees_records = get_issue_trees_data(issue_key_list=issue_key_list)
 
     tree_url_to_name = get_tree_url_to_name_map()
     for record in trees_records:

--- a/backend/kernelCI_app/helpers/trees.py
+++ b/backend/kernelCI_app/helpers/trees.py
@@ -1,40 +1,14 @@
-from datetime import datetime
 import os
 
 from django.conf import settings
 import yaml
 from kernelCI_app.helpers.logger import log_message
-from kernelCI_app.models import Checkouts
 
 
 def make_tree_identifier_key(
     *, tree_name: str, git_repository_url: str, git_repository_branch: str
 ) -> str:
     return f"{tree_name}-{git_repository_url}-{git_repository_branch}"
-
-
-def get_tree_heads(origin: str, start_date: datetime, end_date: datetime):
-    tree_id_fields = [
-        "tree_name",
-        "git_repository_branch",
-        "git_repository_url",
-    ]
-
-    checkouts_subquery = (
-        Checkouts.objects.filter(
-            origin=origin,
-            start_time__gte=start_date,
-            start_time__lte=end_date,
-        )
-        .order_by(
-            *tree_id_fields,
-            "-start_time",
-        )
-        .distinct(*tree_id_fields)
-        .values_list("git_commit_hash", flat=True)
-    )
-
-    return checkouts_subquery
 
 
 def get_tree_url_to_name_map() -> dict[str, str]:

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -4,7 +4,7 @@ from django.db.utils import ProgrammingError
 from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.environment import DEFAULT_SCHEMA_VERSION, set_schema_version
 from kernelCI_app.helpers.logger import log_message
-from kernelCI_app.models import Issues
+from kernelCI_app.models import Checkouts, Incidents, Issues
 from kernelCI_app.helpers.build import (
     is_valid_does_not_exist_exception,
     valid_status_field,
@@ -227,3 +227,106 @@ def get_test_issues(*, test_id: str) -> list[dict]:
         rows = dict_fetchall(cursor=cursor)
 
     return rows
+
+
+def get_issue_first_seen_data(*, issue_id_list: list[str]):
+    """Retrieves the incident and checkout data
+    of the first incident of a list of issues
+    through a list of `issue_id`s."""
+
+    # TODO: use '=' instead of 'IN' when the list has a single element
+    records = Incidents.objects.raw(
+        """
+        WITH first_incident AS (
+            SELECT
+                IC.issue_id,
+                MIN(IC.issue_version) AS min_issue_version,
+                MIN(IC._timestamp) AS first_seen
+            FROM
+                incidents IC
+            WHERE
+                IC.issue_id IN ({0})
+            GROUP BY
+                IC.issue_id
+        )
+        SELECT
+            IC.id,
+            IC.issue_id,
+            IC._timestamp AS first_seen,
+            IC.issue_version,
+            C.git_commit_hash,
+            C.git_repository_url,
+            C.git_repository_branch,
+            C.git_commit_name,
+            C.tree_name
+        FROM
+            incidents IC
+        LEFT JOIN tests T ON IC.test_id = T.id
+        LEFT JOIN builds B ON (IC.build_id = B.id OR T.build_id = B.id)
+        LEFT JOIN checkouts C ON B.checkout_id = C.id
+        JOIN first_incident FI ON (
+            IC.issue_id = FI.issue_id
+            AND IC.issue_version = FI.min_issue_version
+            AND IC."_timestamp" = FI.first_seen
+        )
+        """.format(
+            ", ".join(["%s"] * len(issue_id_list))
+        ),
+        issue_id_list,
+    )
+
+    return records
+
+
+def get_issue_trees_data(*, issue_key_list: list[tuple[str, int]]):
+    """Retrieves the list of trees in which a list of issues appear
+    through a list of tuples `issue_id, issue_version`.\n
+    The return is a single list where each element contains
+    the checkout data and the issue_id and issue_version of the incident."""
+
+    tuple_param_list = []
+    params = {}
+
+    for index, key in enumerate(issue_key_list):
+        id_key = f"id{index}"
+        version_key = f"version{index}"
+
+        tuple_string = f"(%({id_key})s, %({version_key})s)"
+
+        tuple_param_list.append(tuple_string)
+        params[id_key] = key[0]
+        params[version_key] = key[1]
+    tuple_str = ", ".join(tuple_param_list)
+
+    # TODO: use '=' instead of 'IN' when the list has a single element
+    records = Checkouts.objects.raw(
+        f"""
+        SELECT DISTINCT
+            ON (
+                C.TREE_NAME,
+                C.GIT_REPOSITORY_URL,
+                C.GIT_REPOSITORY_BRANCH,
+                IC.ISSUE_ID,
+                IC.ISSUE_VERSION
+            )
+            C.ID,
+            C.TREE_NAME,
+            C.GIT_REPOSITORY_URL,
+            C.GIT_REPOSITORY_BRANCH,
+            IC.ISSUE_ID,
+            IC.ISSUE_VERSION
+        FROM
+            INCIDENTS IC
+            LEFT JOIN TESTS T ON IC.TEST_ID = T.ID
+            LEFT JOIN BUILDS B ON (
+                IC.BUILD_ID = B.ID
+                OR T.BUILD_ID = B.ID
+            )
+            JOIN CHECKOUTS C ON B.CHECKOUT_ID = C.ID
+        WHERE
+            (IC.ISSUE_ID, IC.ISSUE_VERSION) IN ({tuple_str})
+        """,
+        params,
+    )
+
+    return records

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -175,3 +175,55 @@ def get_issue_details(*, issue_id: str, version: int) -> Optional[dict]:
     )
 
     return query
+
+
+def get_build_issues(*, build_id: str) -> list[dict]:
+    """Retrieves the issues of a given build through a build_id"""
+
+    query = f"""
+        SELECT
+            incidents.id,
+            issues.id,
+            issues.version,
+            issues.comment,
+            issues.report_url,
+            builds.{valid_status_field()} AS status
+        FROM incidents
+        JOIN issues
+            ON incidents.issue_id = issues.id
+            AND incidents.issue_version = issues.version
+        JOIN builds
+            ON incidents.build_id = builds.id
+        WHERE incidents.build_id = %s
+        """
+    with connection.cursor() as cursor:
+        cursor.execute(query, [build_id])
+        rows = dict_fetchall(cursor=cursor)
+
+    return rows
+
+
+def get_test_issues(*, test_id: str) -> list[dict]:
+    """Retrieves the issues of a given test through a test_id"""
+
+    query = """
+        SELECT
+            incidents.id,
+            issues.id,
+            issues.version,
+            issues.comment,
+            issues.report_url,
+            tests.status AS status
+        FROM incidents
+        JOIN issues
+            ON incidents.issue_id = issues.id
+            AND incidents.issue_version = issues.version
+        JOIN tests
+            ON incidents.test_id = tests.id
+        WHERE incidents.test_id = %s
+        """
+    with connection.cursor() as cursor:
+        cursor.execute(query, [test_id])
+        rows = dict_fetchall(cursor=cursor)
+
+    return rows

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -621,3 +621,28 @@ def get_tree_commit_history(
             )
         else:
             raise
+
+
+def get_latest_tree(*, tree_name: str, branch: str, origin: str) -> Optional[dict]:
+    """Retrieves the most recent occurrence of the checkout of a tree with the given params."""
+
+    tree_fields = [
+        "git_commit_hash",
+        "git_commit_name",
+        "git_repository_url",
+        "tree_name",
+    ]
+
+    query = (
+        Checkouts.objects.values(*tree_fields)
+        .filter(
+            origin=origin,
+            tree_name=tree_name,
+            git_repository_branch=branch,
+            git_commit_hash__isnull=False,
+        )
+        .order_by("-field_timestamp")
+        .first()
+    )
+
+    return query

--- a/backend/kernelCI_app/views/buildIssuesView.py
+++ b/backend/kernelCI_app/views/buildIssuesView.py
@@ -1,49 +1,23 @@
-from django.db import connection
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 
-from kernelCI_app.helpers.build import valid_status_field
-from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.detailsIssues import sanitize_details_issues_rows
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from http import HTTPStatus
-from kernelCI_app.typeModels.issues import Issue
+from kernelCI_app.queries.issues import get_build_issues
 from kernelCI_app.typeModels.detailsIssuesView import DetailsIssuesResponse
 
 
 class BuildIssuesView(APIView):
-    def get_build_issues(self, build_id: str) -> list[Issue]:
-        query = f"""
-            SELECT
-                incidents.id,
-                issues.id,
-                issues.version,
-                issues.comment,
-                issues.report_url,
-                builds.{valid_status_field()} AS status
-            FROM incidents
-            JOIN issues
-                ON incidents.issue_id = issues.id
-                AND incidents.issue_version = issues.version
-            JOIN builds
-                ON incidents.build_id = builds.id
-            WHERE incidents.build_id = %s
-            """
-        with connection.cursor() as cursor:
-            cursor.execute(query, [build_id])
-            rows = dict_fetchall(cursor=cursor)
-
-        return rows
-
     @extend_schema(responses=DetailsIssuesResponse)
     def get(
         self,
         _request,
         build_id: str,
     ) -> Response:
-        records = self.get_build_issues(build_id)
+        records = get_build_issues(build_id=build_id)
         build_issues = sanitize_details_issues_rows(rows=records)
 
         if len(build_issues) == 0:

--- a/backend/kernelCI_app/views/hardwareDetailsBootsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBootsView.py
@@ -40,8 +40,6 @@ from kernelCI_app.helpers.errorHandling import create_api_error_response
 # supported in this project
 @method_decorator(csrf_exempt, name="dispatch")
 class HardwareDetailsBoots(APIView):
-    required_params_get = ["origin"]
-
     def __init__(self):
         self.origin: str = None
         self.start_datetime: datetime = None

--- a/backend/kernelCI_app/views/hardwareDetailsCommitHistoryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsCommitHistoryView.py
@@ -1,7 +1,5 @@
 from collections import defaultdict
-from django.db import connection
 import json
-from typing import Dict, List, TypedDict
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.logger import log_message
 from django.utils.decorators import method_decorator
@@ -11,8 +9,8 @@ from kernelCI_app.helpers.trees import (
     get_tree_url_to_name_map,
     make_tree_identifier_key,
 )
+from kernelCI_app.queries.hardware import get_hardware_commit_history
 from kernelCI_app.typeModels.hardwareDetails import (
-    CommitHead,
     CommitHistoryPostBody,
     CommitHistoryValidCheckout,
     HardwareCommitHistoryResponse,
@@ -24,39 +22,6 @@ from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema
 
 
-class GenerateQueryParamsResponse(TypedDict):
-    query_params: Dict[str, Dict[str, str]]
-    tuple_str: str
-
-
-def generate_query_params(
-    commit_heads: List[CommitHead],
-) -> GenerateQueryParamsResponse:
-    tuple_list = []
-    params = {}
-
-    for index, commit_head in enumerate(commit_heads):
-        tree_name_key = f"tree_name{index}"
-        git_repository_url_key = f"git_repository_url{index}"
-        git_repository_branch_key = f"git_repository_branch{index}"
-        git_commit_hash_key = f"git_commit_hash{index}"
-
-        tuple_string = (
-            f"(%({tree_name_key})s,"
-            f"%({git_repository_url_key})s, %({git_repository_branch_key})s,"
-            f"%({git_commit_hash_key})s)"
-        )
-
-        tuple_list.append(tuple_string)
-        params[tree_name_key] = commit_head.treeName
-        params[git_repository_url_key] = commit_head.repositoryUrl
-        params[git_repository_branch_key] = commit_head.branch
-        params[git_commit_hash_key] = commit_head.commitHash
-
-    tuple_str = ", ".join(tuple_list)
-    return {"tuple_str": f"({tuple_str})", "query_params": params}
-
-
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/
 # that protection is recommended for ‘unsafe’ methods (POST, PUT, and DELETE)
 # but we are using POST here just to follow the convention to use the request body
@@ -64,99 +29,11 @@ def generate_query_params(
 # supported in this project
 @method_decorator(csrf_exempt, name="dispatch")
 class HardwareDetailsCommitHistoryView(APIView):
-    required_params_get = ["origin"]
-    cache_key_get_tree_data = "hardwareDetailsTreeData"
-    cache_key_get_full_data = "hardwareDetailsFullData"
-
-    def __init__(self):
-        self.filterParams = None
-
-    def get_commit_history(
-        self,
-        *,
-        origin: str,
-        start_date: datetime,
-        end_date: datetime,
-        commit_heads: List[CommitHead],
-    ):
-        # We need a subquery because if we filter by any hardware, it will get the
-        # last head that has that hardware, but not the real head of the trees
-        relevant_commit = commit_heads[0] if commit_heads else None
-
-        if relevant_commit is None:
-            return
-
-        relevant_param_data = generate_query_params(commit_heads)
-
-        raw_query = f"""
-        WITH filtered_checkouts AS (
-            SELECT
-                DISTINCT ON	(tree_name,
-                git_repository_url,
-                git_repository_branch)
-                tree_name,
-                git_repository_url,
-                git_repository_branch,
-                start_time
-            FROM
-                checkouts c
-            WHERE
-                (c.tree_name,
-                c.git_repository_url,
-                c.git_repository_branch,
-                c.git_commit_hash) IN {relevant_param_data['tuple_str']}
-                AND c.origin = %(origin)s
-            ORDER BY
-                tree_name,
-                git_repository_url,
-                git_repository_branch,
-                c.start_time)
-            SELECT
-                fc.tree_name AS tree_name,
-                fc.git_repository_url AS git_repository_url,
-                fc.git_repository_branch AS git_repository_branch,
-                lateralus.git_commit_tags AS git_commit_tags,
-                lateralus.git_commit_name AS git_commit_name,
-                lateralus.git_commit_hash AS git_commit_hash,
-                lateralus.start_time AS start_time
-            FROM
-                filtered_checkouts fc,
-                LATERAL (
-                SELECT
-                    DISTINCT ON (c.git_commit_hash)
-                    c.git_commit_tags,
-                    c.git_commit_name,
-                    c.git_commit_hash,
-                    c.start_time
-                FROM
-                    checkouts c
-                WHERE
-                    c.tree_name = fc.tree_name
-                    AND c.git_repository_branch = fc.git_repository_branch
-                    AND c.git_repository_url = fc.git_repository_url
-                    AND c.start_time <= fc.start_time
-                    AND c.start_time >= %(start_date)s
-                    AND c.start_time <= %(end_date)s
-                ORDER BY c.git_commit_hash, c.start_time
-            ) AS lateralus;
-        """
-
-        with connection.cursor() as cursor:
-            cursor.execute(
-                raw_query,
-                {
-                    **relevant_param_data["query_params"],
-                    "origin": origin,
-                    "start_date": start_date,
-                    "end_date": end_date,
-                },
-            )
-            checkouts_query_set = cursor.fetchall()
-
+    def _sanitize_checkouts(self, rows):
         formatted_checkouts = defaultdict(list)
         tree_url_to_name = get_tree_url_to_name_map()
 
-        for checkout in checkouts_query_set:
+        for checkout in rows:
             dict_checkout = {
                 "tree_name": tree_url_to_name.get(checkout[1], checkout[0]),
                 "git_repository_url": checkout[1],
@@ -199,13 +76,10 @@ class HardwareDetailsCommitHistoryView(APIView):
             end_datetime = datetime.fromtimestamp(
                 int(post_body.endTimestampInSeconds), timezone.utc
             )
-
             start_datetime = datetime.fromtimestamp(
                 int(post_body.startTimestampInSeconds), timezone.utc
             )
-
             commit_heads = post_body.commitHeads
-
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
         except json.JSONDecodeError:
@@ -217,17 +91,19 @@ class HardwareDetailsCommitHistoryView(APIView):
                 error_message="startTimestampInSeconds and endTimestampInSeconds must be a Unix Timestamp"
             )
 
-        commit_history = self.get_commit_history(
+        commit_history_data = get_hardware_commit_history(
             origin=origin,
             start_date=start_datetime,
             end_date=end_datetime,
             commit_heads=commit_heads,
         )
 
-        if not commit_history:
+        if not commit_history_data:
             return create_api_error_response(
                 error_message="Commit history not found", status_code=HTTPStatus.OK
             )
+
+        commit_history = self._sanitize_checkouts(commit_history_data)
 
         try:
             valid_response = HardwareCommitHistoryResponse(

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -64,8 +64,6 @@ from typing import Dict, List, Set
 # supported in this project
 @method_decorator(csrf_exempt, name="dispatch")
 class HardwareDetailsSummary(APIView):
-    required_params_get = ["origin"]
-
     def __init__(self):
         self.origin: str = None
         self.start_datetime: datetime = None

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -66,8 +66,6 @@ from typing import Dict, List, Set
 # supported in this project
 @method_decorator(csrf_exempt, name="dispatch")
 class HardwareDetails(APIView):
-    required_params_get = ["origin"]
-
     def __init__(self):
         self.origin: str = None
         self.start_datetime: datetime = None

--- a/backend/kernelCI_app/views/testIssuesView.py
+++ b/backend/kernelCI_app/views/testIssuesView.py
@@ -1,48 +1,23 @@
-from django.db import connection
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 
-from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.detailsIssues import sanitize_details_issues_rows
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from http import HTTPStatus
-from kernelCI_app.typeModels.issues import Issue
+from kernelCI_app.queries.issues import get_test_issues
 from kernelCI_app.typeModels.detailsIssuesView import DetailsIssuesResponse
 
 
 class TestIssuesView(APIView):
-    def get_test_issues(self, test_id: str) -> list[Issue]:
-        query = """
-            SELECT
-                incidents.id,
-                issues.id,
-                issues.version,
-                issues.comment,
-                issues.report_url,
-                tests.status AS status
-            FROM incidents
-            JOIN issues
-                ON incidents.issue_id = issues.id
-                AND incidents.issue_version = issues.version
-            JOIN tests
-                ON incidents.test_id = tests.id
-            WHERE incidents.test_id = %s
-            """
-        with connection.cursor() as cursor:
-            cursor.execute(query, [test_id])
-            rows = dict_fetchall(cursor=cursor)
-
-        return rows
-
     @extend_schema(responses=DetailsIssuesResponse)
     def get(
         self,
         _request,
         test_id: str,
     ) -> Response:
-        records = self.get_test_issues(test_id)
+        records = get_test_issues(test_id=test_id)
         test_issues = sanitize_details_issues_rows(rows=records)
 
         if len(test_issues) == 0:

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -2142,15 +2142,6 @@ components:
       - platforms
       title: HardwareTestLocalFilters
       type: object
-    IncidentInfo:
-      properties:
-        incidentsCount:
-          title: Incidentscount
-          type: integer
-      required:
-      - incidentsCount
-      title: IncidentInfo
-      type: object
     Issue:
       properties:
         id:
@@ -2170,7 +2161,7 @@ components:
           - type: 'null'
           title: Report Url
         incidents_info:
-          $ref: '#/components/schemas/IncidentInfo'
+          $ref: '#/components/schemas/StatusCount'
       required:
       - id
       - version
@@ -3137,11 +3128,15 @@ components:
         api_url:
           title: Api Url
           type: string
+        tree_name:
+          title: Tree Name
+          type: string
       required:
       - git_repository_url
       - git_commit_hash
       - git_commit_name
       - api_url
+      - tree_name
       title: TreeLatestResponse
       type: object
     TreeListingFastResponse:


### PR DESCRIPTION
## Changes
Moves all the remaining queries from other files to the queries folder

## How to test
This is a refactor PR, so there are no additions. All the modified endpoints should still work the same as before.

Closes #1169