### PR TITLE
Feat: order treeListing with pinned trees first

### DIFF
--- a/dashboard/src/utils/constants/tables.ts
+++ b/dashboard/src/utils/constants/tables.ts
@@ -12,3 +12,10 @@ export type TableKeys =
   | 'issueDetailsTests'
   | 'issueDetailsBuilds'
   | 'issueListing';
+
+// Regexes to define pinned trees with "tree_name/git_repository_branch"
+export const PinnedTrees: RegExp[] = [
+  /^mainline\/master/,
+  /^next\/master/,
+  /^stable\/.*/,
+] as const;

--- a/dashboard/src/utils/trees.ts
+++ b/dashboard/src/utils/trees.ts
@@ -1,15 +1,19 @@
 interface TreeIdentifierParams {
   treeName: string;
-  gitRepositoryUrl: string;
+  gitRepositoryUrl?: string;
   gitRepositoryBranch: string;
+  separator?: string;
 }
 
 export const makeTreeIdentifierKey = ({
   treeName,
   gitRepositoryUrl,
   gitRepositoryBranch,
+  separator = '-',
 }: TreeIdentifierParams): string => {
-  return `${treeName}-${gitRepositoryUrl}-${gitRepositoryBranch}`;
+  return [treeName, gitRepositoryUrl, gitRepositoryBranch]
+    .filter(value => value !== undefined)
+    .join(separator);
 };
 
 export const getCommitTagOrHash = (


### PR DESCRIPTION
## Changes
- Adds a list to specify priority trees;
- Uses that list to order the treelisting data, putting the prioritized trees first.

This means that when there is _no sorting_, those trees will appear at the top. In the case of any sorting, the sorting will override the ordering, but it is possible to reset the sorting by clicking at the header (sorting goes as "unsorted" -> "sort ascending" -> "sort descending" -> "unsorted")
The priority trees are defined by a regex that describes the tree/branch key of a tree (the git_repository_url was not used since the tree_name is now retrieved by the trees_name file which is unique for each url already). Being a regex it allows for a tree with any branch name.
The current priority trees are mainline/master, next/master, and stable trees with any branch.

## How to test
Go to the tree listing page and check the ordering of the data, try sorting with the other columns, filtering by path and checking other origins.
You can also change the list of pinned trees to add/remove them.

## Examples

New first page of tree listing
![image](https://github.com/user-attachments/assets/6d10fb53-2276-472c-9272-a2db8b621c0c)

Second page
![image](https://github.com/user-attachments/assets/91f9e227-ab0a-4eb2-8f42-86e1c3544d10)


Closes #998