### PR TITLE
Fix: repeated trees

### DIFF
--- a/backend/kernelCI_app/typeModels/common.py
+++ b/backend/kernelCI_app/typeModels/common.py
@@ -22,3 +22,14 @@ class StatusCount(BaseModel):
             setattr(self, status.upper(), getattr(self, status.upper()) + 1)
         except AttributeError:
             log_message(f"Unknown status: {status}")
+
+    def __add__(self, other: "StatusCount") -> "StatusCount":
+        return StatusCount(
+            PASS=self.PASS + other.PASS,
+            ERROR=self.ERROR + other.ERROR,
+            FAIL=self.FAIL + other.FAIL,
+            SKIP=self.SKIP + other.SKIP,
+            MISS=self.MISS + other.MISS,
+            DONE=self.DONE + other.DONE,
+            NULL=self.NULL + other.NULL,
+        )

--- a/backend/kernelCI_app/typeModels/treeListing.py
+++ b/backend/kernelCI_app/typeModels/treeListing.py
@@ -25,6 +25,19 @@ class TestStatusCount(BaseModel):
     done_count: int = Field(alias="done")
     null_count: int = Field(alias="null")
 
+    def __add__(self, other: "TestStatusCount") -> "TestStatusCount":
+        return TestStatusCount(
+            **{
+                "pass": self.pass_count + other.pass_count,
+                "error": self.error_count + other.error_count,
+                "fail": self.fail_count + other.fail_count,
+                "skip": self.skip_count + other.skip_count,
+                "miss": self.miss_count + other.miss_count,
+                "done": self.done_count + other.done_count,
+                "null": self.null_count + other.null_count,
+            }
+        )
+
 
 class BaseCheckouts(BaseModel):
     git_repository_url: Checkout__GitRepositoryUrl
@@ -45,7 +58,28 @@ class Checkout(CommonCheckouts):
     test_status: TestStatusCount
     boot_status: TestStatusCount
     tree_name: Checkout__TreeName
-    git_commit_tags: List[Checkout__GitCommitTags]
+    git_commit_tags: list[Checkout__GitCommitTags]
+
+    def add_counts(
+        self,
+        build_status: StatusCount,
+        test_status: TestStatusCount,
+        boot_status: TestStatusCount,
+    ) -> None:
+        self.build_status += build_status
+        self.test_status += test_status
+        self.boot_status += boot_status
+
+    def combine_tags(self, tags: list[Checkout__GitCommitTags]) -> None:
+        if not tags:
+            return
+
+        existing_tags = set(self.git_commit_tags)
+
+        for tag in tags:
+            if tag not in existing_tags:
+                existing_tags.add(tag)
+                self.git_commit_tags.append(tag)
 
 
 class CheckoutFast(CommonCheckouts):

--- a/dashboard/src/components/IssueTable/IssueTable.tsx
+++ b/dashboard/src/components/IssueTable/IssueTable.tsx
@@ -65,6 +65,7 @@ const getLinkProps = (
       state: s => s,
       search: previousSearch => ({
         ...previousSearch,
+        origin: row.original.origin,
         treeInfo: {
           gitBranch: row.original.git_repository_branch,
           gitUrl: row.original.git_repository_url,
@@ -85,8 +86,8 @@ const getLinkProps = (
       id: row.original.id,
       from: RedirectFrom.Issues,
     }),
-    search: s => ({
-      origin: s.origin,
+    search: _ => ({
+      origin: row.original.origin,
       issueVersion: row.original.version,
     }),
   };

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -201,7 +201,7 @@ const getColumns = (origin: string): ColumnDef<TreeTableBody>[] => {
       },
     },
     {
-      accessorKey: 'buildStatus.valid',
+      accessorKey: 'build_status.PASS',
       header: ({ column }): JSX.Element => (
         <TableHeader
           column={column}
@@ -246,7 +246,7 @@ const getColumns = (origin: string): ColumnDef<TreeTableBody>[] => {
       },
     },
     {
-      accessorKey: 'bootStatus.pass',
+      accessorKey: 'boot_status.pass',
       header: ({ column }): JSX.Element => (
         <TableHeader
           column={column}
@@ -291,7 +291,7 @@ const getColumns = (origin: string): ColumnDef<TreeTableBody>[] => {
       },
     },
     {
-      accessorKey: 'testStatus.pass',
+      accessorKey: 'test_status.pass',
       header: ({ column }): JSX.Element => (
         <TableHeader
           column={column}


### PR DESCRIPTION
Fixes a bug where some trees were repeated in the treeListing.
This was caused because some trees have the same branch and url but different tree_name in kcidb, which meant that they were grouped separately but shown as the same tree_name (because of the same url).

The proposed solution groups those trees in a single element, adding up the counts and combining the commit tags.

## Changes
- Changes the set for adding checkouts for the treeView response;
- Adds helper methods for addition of status;
- (extra) fixes the sorting for status in the treeTable
- (extra) fixes a redirection from the issueListing table with different origins

## How to test
Go to a tree listing in which the above situation occurred (such as in origin redhat) and compare the [localhost](http://localhost:5173/tree?o=redhat) to [staging](https://staging.dashboard.kernelci.org:9000/tree?o=redhat).
The treeDetails and other treeListing functionalities should still be normal.

Closes #1177 