### PR TITLE
Fix: revert tree name file use

### DIFF
--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -333,14 +333,8 @@ def handle_test_history(
     *,
     record: Dict,
     task: List[HardwareTestHistoryItem],
-    tree_url_to_name: dict[str, str],
 ) -> None:
     create_record_test_platform(record=record)
-
-    defined_tree_name = tree_url_to_name.get(
-        record["build__checkout__git_repository_url"],
-        record["build__checkout__tree_name"],
-    )
 
     test_history_item = HardwareTestHistoryItem(
         id=record["id"],
@@ -354,7 +348,7 @@ def handle_test_history(
         architecture=record["build__architecture"],
         compiler=record["build__compiler"],
         environment_misc=EnvironmentMisc(platform=record["test_platform"]),
-        tree_name=defined_tree_name,
+        tree_name=record["build__checkout__tree_name"],
         git_repository_branch=record["build__checkout__git_repository_branch"],
     )
 
@@ -415,11 +409,8 @@ def handle_build_history(
     record: Dict,
     tree_idx: int,
     builds: List[HardwareBuildHistoryItem],
-    tree_url_to_name: dict[str, str],
 ) -> None:
     build = get_build_typed(record=record, tree_idx=tree_idx)
-    defined_tree_name = tree_url_to_name.get(build.git_repository_url, build.tree_name)
-    build.tree_name = defined_tree_name
     builds.append(build)
 
 

--- a/backend/kernelCI_app/helpers/issueExtras.py
+++ b/backend/kernelCI_app/helpers/issueExtras.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from typing import Dict, List, Set, Tuple
 
 from kernelCI_app.helpers.logger import log_message
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.issues import get_issue_first_seen_data, get_issue_trees_data
 from kernelCI_app.typeModels.issues import (
     IssueWithExtraInfo,
@@ -50,7 +49,6 @@ def assign_issue_first_seen(
 
     incident_records = get_issue_first_seen_data(issue_id_list=issue_id_list)
 
-    tree_url_to_name = get_tree_url_to_name_map()
     for record in incident_records:
         record_issue_id = record.issue_id
         first_seen = record.first_seen
@@ -58,11 +56,7 @@ def assign_issue_first_seen(
         first_git_repository_url = record.git_repository_url
         first_git_repository_branch = record.git_repository_branch
         first_git_commit_name = record.git_commit_name
-
-        defined_tree_name = tree_url_to_name.get(
-            record.git_repository_url, record.tree_name
-        )
-        first_tree_name = defined_tree_name
+        first_tree_name = record.tree_name
 
         processed_issue_from_id = processed_issues_table.get(record_issue_id)
         if processed_issue_from_id is None:
@@ -93,15 +87,11 @@ def assign_issue_trees(
 ) -> None:
     trees_records = get_issue_trees_data(issue_key_list=issue_key_list)
 
-    tree_url_to_name = get_tree_url_to_name_map()
     for record in trees_records:
         issue_id = record.issue_id
         issue_version = record.issue_version
         git_repository_url = record.git_repository_url
         git_repository_branch = record.git_repository_branch
-        defined_tree_name = tree_url_to_name.get(
-            record.git_repository_url, record.tree_name
-        )
 
         processed_issue_from_id = processed_issues_table.get(issue_id)
         if processed_issue_from_id is None:
@@ -115,7 +105,7 @@ def assign_issue_trees(
 
         current_detailed_issue.trees.append(
             TreeSetItem(
-                tree_name=defined_tree_name,
+                tree_name=record.tree_name,
                 git_repository_branch=git_repository_branch,
             )
         )

--- a/backend/kernelCI_app/helpers/trees.py
+++ b/backend/kernelCI_app/helpers/trees.py
@@ -1,4 +1,5 @@
 import os
+import typing_extensions
 
 from django.conf import settings
 import yaml
@@ -24,6 +25,10 @@ def get_tree_file_data() -> dict[str, dict[str, str]]:
     return {}
 
 
+@typing_extensions.deprecated(
+    "Only use this function when the trees-name.yaml file is solidified and ready to be used.",
+    category=None,
+)
 def get_tree_url_to_name_map() -> dict[str, str]:
     """Returns a dictionary mapping tree URLs to their tree names
     from the tree names file."""

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -625,11 +625,10 @@ def get_tree_commit_history(
 
 def get_latest_tree(
     *,
-    tree_name: Optional[str] = None,
+    tree_name: str,
     branch: str,
     origin: str,
     git_commit_hash: Optional[str] = None,
-    git_repository_url: Optional[str] = None,
 ) -> Optional[dict]:
     """Retrieves the most recent occurrence of the checkout of a tree with the given params."""
 
@@ -643,13 +642,8 @@ def get_latest_tree(
     query = Checkouts.objects.values(*tree_fields).filter(
         origin=origin,
         git_repository_branch=branch,
+        tree_name=tree_name,
     )
-
-    if tree_name is not None:
-        query = query.filter(tree_name=tree_name)
-
-    if git_repository_url is not None:
-        query = query.filter(git_repository_url=git_repository_url)
 
     if git_commit_hash is not None:
         query = query.filter(git_commit_hash=git_commit_hash)

--- a/backend/kernelCI_app/tests/integrationTests/treeLatest_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeLatest_test.py
@@ -26,7 +26,7 @@ client = TreeClient()
             "agross",
             "for-next",
             {},
-            False,
+            True,
         ),  # No agross tree in kcidb, only in trees-name.yaml
         (
             "android",

--- a/backend/kernelCI_app/views/buildDetailsView.py
+++ b/backend/kernelCI_app/views/buildDetailsView.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.typeModels.buildDetails import BuildDetailsResponse
 from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
@@ -19,12 +18,6 @@ class BuildDetails(APIView):
                 error_message="Build not found",
                 status_code=HTTPStatus.OK,
             )
-
-        tree_url_to_name = get_tree_url_to_name_map()
-        defined_name = tree_url_to_name.get(
-            records[0]["git_repository_url"], records[0]["tree_name"]
-        )
-        records[0]["tree_name"] = defined_name
 
         try:
             valid_response = BuildDetailsResponse(**records[0])

--- a/backend/kernelCI_app/views/hardwareDetailsBootsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBootsView.py
@@ -14,7 +14,6 @@ from kernelCI_app.helpers.hardwareDetails import (
     is_test_processed,
     unstable_parse_post_body,
 )
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
@@ -50,8 +49,6 @@ class HardwareDetailsBoots(APIView):
 
         self.boots: List[HardwareTestHistoryItem] = []
 
-        self.tree_url_to_name_map = get_tree_url_to_name_map()
-
     def _process_test(self, record: Dict) -> None:
         is_record_boot = is_boot(record["path"])
         if not is_record_boot:
@@ -74,7 +71,6 @@ class HardwareDetailsBoots(APIView):
             handle_test_history(
                 record=record,
                 task=self.boots,
-                tree_url_to_name=self.tree_url_to_name_map,
             )
             self.processed_tests.add(record["id"])
 

--- a/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
@@ -21,7 +21,6 @@ from kernelCI_app.helpers.hardwareDetails import (
     handle_build_history,
     unstable_parse_post_body,
 )
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
@@ -53,8 +52,6 @@ class HardwareDetailsBuilds(APIView):
         self.processed_builds: Set[str] = set()
         self.builds: List[HardwareBuildHistoryItem] = []
 
-        self.tree_url_to_name_map = get_tree_url_to_name_map()
-
     def _process_build(self, *, record: dict, tree_index: int) -> None:
         build = get_build_typed(record, tree_index)
 
@@ -71,7 +68,6 @@ class HardwareDetailsBuilds(APIView):
                 record=record,
                 tree_idx=tree_index,
                 builds=self.builds,
-                tree_url_to_name=self.tree_url_to_name_map,
             )
 
     def _sanitize_records(

--- a/backend/kernelCI_app/views/hardwareDetailsCommitHistoryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsCommitHistoryView.py
@@ -5,10 +5,7 @@ from kernelCI_app.helpers.logger import log_message
 from django.utils.decorators import method_decorator
 from datetime import datetime, timezone
 from django.views.decorators.csrf import csrf_exempt
-from kernelCI_app.helpers.trees import (
-    get_tree_url_to_name_map,
-    make_tree_identifier_key,
-)
+from kernelCI_app.helpers.trees import make_tree_identifier_key
 from kernelCI_app.queries.hardware import get_hardware_commit_history
 from kernelCI_app.typeModels.hardwareDetails import (
     CommitHistoryPostBody,
@@ -31,11 +28,10 @@ from drf_spectacular.utils import extend_schema
 class HardwareDetailsCommitHistoryView(APIView):
     def _sanitize_checkouts(self, rows):
         formatted_checkouts = defaultdict(list)
-        tree_url_to_name = get_tree_url_to_name_map()
 
         for checkout in rows:
             dict_checkout = {
-                "tree_name": tree_url_to_name.get(checkout[1], checkout[0]),
+                "tree_name": checkout[0],
                 "git_repository_url": checkout[1],
                 "git_repository_branch": checkout[2],
                 "git_commit_tags": checkout[3],

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -30,7 +30,6 @@ from kernelCI_app.helpers.hardwareDetails import (
     format_issue_summary_for_response,
     unstable_parse_post_body,
 )
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
@@ -318,16 +317,6 @@ class HardwareDetailsSummary(APIView):
             set_trees_status_summary(
                 trees=trees, tree_status_summary=self.tree_status_summary
             )
-
-            # The change in tree_name happens here so that the filters works unchanged before.
-            # The selection of commits works based on a comparison between the record tree_name
-            # and the selected_trees tree_name, and is assigned to trees using the index
-            tree_url_to_name_map = get_tree_url_to_name_map()
-            for tree in trees:
-                defined_tree_name = tree_url_to_name_map.get(
-                    tree.git_repository_url, tree.tree_name
-                )
-                tree.tree_name = defined_tree_name
 
             valid_response = HardwareDetailsSummaryResponse(
                 summary=Summary(

--- a/backend/kernelCI_app/views/hardwareDetailsTestsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsTestsView.py
@@ -14,7 +14,6 @@ from kernelCI_app.helpers.hardwareDetails import (
     is_test_processed,
     unstable_parse_post_body,
 )
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
@@ -50,8 +49,6 @@ class HardwareDetailsTests(APIView):
 
         self.tests: List[HardwareTestHistoryItem] = []
 
-        self.tree_url_to_name_map = get_tree_url_to_name_map()
-
     def _process_test(self, record: Dict) -> None:
         is_record_boot = is_boot(record["path"])
         if is_record_boot:
@@ -74,7 +71,6 @@ class HardwareDetailsTests(APIView):
             handle_test_history(
                 record=record,
                 task=self.tests,
-                tree_url_to_name=self.tree_url_to_name_map,
             )
             self.processed_tests.add(record["id"])
 

--- a/backend/kernelCI_app/views/issueDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/issueDetailsBuildsView.py
@@ -3,7 +3,6 @@ from typing import Optional
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.typeModels.issueDetails import (
     IssueBuildsResponse,
     IssueDetailsPathParameters,
@@ -34,13 +33,6 @@ class IssueDetailsBuilds(APIView):
         builds_data = get_issue_builds(
             issue_id=path_params.issue_id, version=query_params.version
         )
-
-        tree_url_to_name = get_tree_url_to_name_map()
-        for build in builds_data:
-            defined_tree_name = tree_url_to_name.get(
-                build["git_repository_url"], build["tree_name"]
-            )
-            build["tree_name"] = defined_tree_name
 
         if not builds_data:
             return create_api_error_response(

--- a/backend/kernelCI_app/views/issueDetailsTestsView.py
+++ b/backend/kernelCI_app/views/issueDetailsTestsView.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from django.http import HttpRequest
 from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.issues import get_issue_tests
 from kernelCI_app.typeModels.issueDetails import (
     IssueDetailsPathParameters,
@@ -39,13 +38,6 @@ class IssueDetailsTests(APIView):
             return create_api_error_response(
                 error_message="No tests found for this issue", status_code=HTTPStatus.OK
             )
-
-        tree_url_to_name = get_tree_url_to_name_map()
-        for test in tests_data:
-            defined_tree_name = tree_url_to_name.get(
-                test["git_repository_url"], test["tree_name"]
-            )
-            test["tree_name"] = defined_tree_name
 
         try:
             valid_response = IssueTestsResponse(tests_data)

--- a/backend/kernelCI_app/views/testDetailsView.py
+++ b/backend/kernelCI_app/views/testDetailsView.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.test import get_test_details_data
 from kernelCI_app.typeModels.testDetails import (
     TestDetailsResponse,
@@ -22,12 +21,6 @@ class TestDetails(APIView):
             return create_api_error_response(
                 error_message="Test not found", status_code=HTTPStatus.OK
             )
-
-        tree_url_to_name = get_tree_url_to_name_map()
-        defined_name = tree_url_to_name.get(
-            response[0]["git_repository_url"], response[0]["tree_name"]
-        )
-        response[0]["tree_name"] = defined_name
 
         try:
             valid_response = TestDetailsResponse(**response[0])

--- a/backend/kernelCI_app/views/treeViewFast.py
+++ b/backend/kernelCI_app/views/treeViewFast.py
@@ -1,7 +1,6 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema
-from kernelCI_app.helpers.trees import get_tree_url_to_name_map
 from kernelCI_app.queries.tree import get_tree_listing_fast
 from kernelCI_app.typeModels.commonListing import ListingQueryParameters
 from http import HTTPStatus
@@ -45,15 +44,11 @@ class TreeViewFast(APIView):
 
         response_data: list[CheckoutFast] = []
 
-        tree_url_to_name = get_tree_url_to_name_map()
-
         for checkout in checkouts:
             response_data.append(
                 CheckoutFast(
                     id=checkout.id,
-                    tree_name=tree_url_to_name.get(
-                        checkout.git_repository_url, checkout.tree_name
-                    ),
+                    tree_name=checkout.tree_name,
                     git_repository_branch=checkout.git_repository_branch,
                     git_repository_url=checkout.git_repository_url,
                     git_commit_hash=checkout.git_commit_hash,


### PR DESCRIPTION
## Changes
Rolls back the substitution of tree names with the file, as well as the use of the file for the treeLatest endpoint, removing the use of the url for the query

## How to test
The tree names should be the same as the names in the production dashboard, as they were unchanged there. All endpoints should be working normally.

Closes #1189