### PR TITLE
Feat: change hardware listing to be platform based

### DIFF
--- a/backend/kernelCI_app/tests/utils/fields/hardware.py
+++ b/backend/kernelCI_app/tests/utils/fields/hardware.py
@@ -1,5 +1,5 @@
 hardware_listing_fields = [
-    "hardware_name",
+    "hardware",
     "platform",
     "test_status_summary",
     "boot_status_summary",

--- a/backend/kernelCI_app/typeModels/hardwareListing.py
+++ b/backend/kernelCI_app/typeModels/hardwareListing.py
@@ -1,20 +1,20 @@
 from datetime import datetime
 from pydantic import BaseModel, BeforeValidator, Field
-from typing import Annotated
+from typing import Annotated, Optional, Union
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.typeModels.common import StatusCount
 
 
 class HardwareItem(BaseModel):
-    hardware_name: str
-    platform: str | set[str]
+    hardware: Optional[Union[str, set[str]]]
+    platform: str
     test_status_summary: StatusCount
     boot_status_summary: StatusCount
     build_status_summary: StatusCount
 
 
-class HardwareResponse(BaseModel):
+class HardwareListingResponse(BaseModel):
     hardware: list[HardwareItem]
 
 

--- a/backend/requests/hardware-listing.sh
+++ b/backend/requests/hardware-listing.sh
@@ -1,2 +1,112 @@
 http 'http://localhost:8000/api/hardware/?startTimestampInSeconds=1736510400&endTimestampInSeconds=1736942400&origin=maestro'
 
+# HTTP/1.1 200 OK
+# Allow: GET, HEAD, OPTIONS
+# Cache-Control: max-age=0
+# Content-Length: 19624
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Thu, 24 Apr 2025 16:41:49 GMT
+# Expires: Thu, 24 Apr 2025 16:41:49 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "hardware": [
+#         {
+#             "boot_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 0,
+#                 "FAIL": 48,
+#                 "MISS": 0,
+#                 "NULL": 1,
+#                 "PASS": 390,
+#                 "SKIP": 0
+#             },
+#             "build_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 0,
+#                 "FAIL": 0,
+#                 "MISS": 0,
+#                 "NULL": 0,
+#                 "PASS": 90,
+#                 "SKIP": 0
+#             },
+#             "hardware": null,
+#             "platform": "acer-cb317-1h-c3z6-dedede",
+#             "test_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 3,
+#                 "FAIL": 4975,
+#                 "MISS": 16,
+#                 "NULL": 1,
+#                 "PASS": 3298,
+#                 "SKIP": 213
+#             }
+#         },
+#         {
+#             "boot_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 0,
+#                 "FAIL": 60,
+#                 "MISS": 0,
+#                 "NULL": 1,
+#                 "PASS": 355,
+#                 "SKIP": 0
+#             },
+#             "build_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 0,
+#                 "FAIL": 0,
+#                 "MISS": 0,
+#                 "NULL": 0,
+#                 "PASS": 90,
+#                 "SKIP": 0
+#             },
+#             "hardware": null,
+#             "platform": "acer-cbv514-1h-34uz-brya",
+#             "test_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 0,
+#                 "FAIL": 4966,
+#                 "MISS": 31,
+#                 "NULL": 3,
+#                 "PASS": 3186,
+#                 "SKIP": 203
+#             }
+#         },
+#         {
+#             "boot_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 0,
+#                 "FAIL": 46,
+#                 "MISS": 1,
+#                 "NULL": 1,
+#                 "PASS": 398,
+#                 "SKIP": 0
+#             },
+#             "build_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 0,
+#                 "FAIL": 0,
+#                 "MISS": 0,
+#                 "NULL": 0,
+#                 "PASS": 90,
+#                 "SKIP": 0
+#             },
+#             "hardware": null,
+#             "platform": "acer-chromebox-cxi4-puff",
+#             "test_status_summary": {
+#                 "DONE": 0,
+#                 "ERROR": 14,
+#                 "FAIL": 4965,
+#                 "MISS": 17,
+#                 "NULL": 3,
+#                 "PASS": 3823,
+#                 "SKIP": 212
+#             }
+#         },
+        ...

--- a/dashboard/src/components/Checkbox/Checkbox.tsx
+++ b/dashboard/src/components/Checkbox/Checkbox.tsx
@@ -2,7 +2,14 @@ import cls from 'classnames';
 
 import type { JSX } from 'react';
 
-import { isUrl, truncateBigText, truncateUrl } from '@/lib/string';
+import {
+  isUrl,
+  shouldTruncate,
+  truncateBigText,
+  truncateUrl,
+} from '@/lib/string';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 
 interface ICheckbox {
   onToggle: () => void;
@@ -14,7 +21,7 @@ interface ICheckbox {
 const containerClass =
   'min-w-[300px] p-4 border-[2px] border-dark-gray rounded-sm cursor-pointer text-dim-gray';
 
-const maxCheckboxLength = 30;
+const maxCheckboxLength = 29;
 
 const Checkbox = ({
   text,
@@ -23,10 +30,13 @@ const Checkbox = ({
   isChecked = false,
 }: ICheckbox): JSX.Element => {
   let truncatedText = text;
-  if (isUrl(text)) {
-    truncatedText = truncateUrl(text);
-  } else {
-    truncatedText = truncateBigText(text, maxCheckboxLength);
+  const shouldTruncateResult = shouldTruncate(text, maxCheckboxLength);
+  if (shouldTruncateResult) {
+    if (isUrl(text)) {
+      truncatedText = truncateUrl(text);
+    } else {
+      truncatedText = truncateBigText(text, maxCheckboxLength);
+    }
   }
 
   return (
@@ -36,7 +46,16 @@ const Checkbox = ({
       })}
     >
       <input type="checkbox" checked={isChecked} onChange={onToggle} />
-      <span className="ml-4">{truncatedText}</span>
+      {shouldTruncateResult ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="ml-4">{truncatedText}</span>
+          </TooltipTrigger>
+          <TooltipContent>{text}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <span className="ml-4">{truncatedText}</span>
+      )}
     </label>
   );
 };

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -168,7 +168,6 @@ export const messages = {
     'globalTable.test': 'Test Status',
     'globalTable.tree': 'Tree',
     'hardware.details': 'Hardware Details',
-    'hardware.multiplePlatforms': 'Multiple Platforms',
     'hardware.path': 'Hardware',
     'hardware.searchPlaceholder':
       'Search by hardware name or platform with a regex',

--- a/dashboard/src/pages/Hardware/HardwareListingPage.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPage.tsx
@@ -7,7 +7,7 @@ import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 
 import { Toaster } from '@/components/ui/toaster';
 
-import type { HardwareTableItem } from '@/types/hardware';
+import type { HardwareItem } from '@/types/hardware';
 
 import { useHardwareListing } from '@/api/hardware';
 
@@ -74,7 +74,7 @@ const HardwareListingPage = ({
     endTimestampInSeconds,
   );
 
-  const listItems: HardwareTableItem[] = useMemo(() => {
+  const listItems: HardwareItem[] = useMemo(() => {
     if (!data || error) {
       return [];
     }
@@ -84,11 +84,11 @@ const HardwareListingPage = ({
     return currentData
       .filter(hardware => {
         return (
-          matchesRegexOrIncludes(hardware.hardware_name, inputFilter) ||
-          includesInAnStringOrStringArray(hardware.platform, inputFilter)
+          matchesRegexOrIncludes(hardware.platform, inputFilter) ||
+          includesInAnStringOrStringArray(hardware.hardware ?? '', inputFilter)
         );
       })
-      .map((hardware): HardwareTableItem => {
+      .map((hardware): HardwareItem => {
         const buildCount: RequiredStatusCount = {
           PASS: hardware.build_status_summary?.PASS,
           FAIL: hardware.build_status_summary?.FAIL,
@@ -120,14 +120,14 @@ const HardwareListingPage = ({
         };
 
         return {
-          hardware_name: hardware.hardware_name ?? '',
-          platform: hardware.platform ?? '',
+          hardware: hardware.hardware,
+          platform: hardware.platform,
           build_status_summary: buildCount,
           test_status_summary: testStatusCount,
           boot_status_summary: bootStatusCount,
         };
       })
-      .sort((a, b) => a.hardware_name.localeCompare(b.hardware_name));
+      .sort((a, b) => a.platform.localeCompare(b.platform));
   }, [data, error, inputFilter]);
 
   return (

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -49,8 +49,6 @@ export const createFilter = (
   const buildIssue: TFilterValues = {};
   const bootIssue: TFilterValues = {};
   const testIssue: TFilterValues = {};
-  const bootPlatform: TFilterValues = {};
-  const testPlatform: TFilterValues = {};
 
   const configs: TFilterValues = {};
   const archs: TFilterValues = {};
@@ -112,12 +110,6 @@ export const createFilter = (
       testIssue[UNCATEGORIZED_STRING] = false;
     }
 
-    (data.filters.boots.platforms ?? []).forEach(
-      p => (bootPlatform[p] = false),
-    );
-    (data.filters.tests.platforms ?? []).forEach(
-      p => (testPlatform[p] = false),
-    );
     data.common.compatibles.forEach(c => (compatibles[c] = false));
   }
 
@@ -133,8 +125,6 @@ export const createFilter = (
     buildIssue,
     bootIssue,
     testIssue,
-    bootPlatform,
-    testPlatform,
     hardware: compatibles,
   };
 };
@@ -169,16 +159,6 @@ const sectionHardware: ISectionItem[] = [
     title: 'filter.testIssue',
     subtitle: 'filter.issueSubtitle',
     sectionKey: 'testIssue',
-  },
-  {
-    title: 'filter.bootPlatform',
-    subtitle: 'filter.platformSubtitle',
-    sectionKey: 'bootPlatform',
-  },
-  {
-    title: 'filter.testPlatform',
-    subtitle: 'filter.platformSubtitle',
-    sectionKey: 'testPlatform',
   },
   {
     title: 'global.configs',

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useCallback, useMemo, type JSX } from 'react';
+import { useCallback, type JSX } from 'react';
 
 import type { LinkProps } from '@tanstack/react-router';
 
@@ -29,9 +29,6 @@ import {
 import { MemoizedStatusCard } from '@/components/Tabs/StatusCard';
 import MemoizedConfigList from '@/components/Tabs/Tests/ConfigsList';
 import MemoizedErrorsSummary from '@/components/Tabs/Tests/ErrorsSummary';
-import { MemoizedPlatformsCard } from '@/components/Cards/PlatformsCard';
-
-import { sanitizePlatforms } from '@/utils/utils';
 
 import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph';
 import { RedirectFrom, type TFilterObjectsKeys } from '@/types/general';
@@ -133,11 +130,6 @@ const BootsTab = ({
     [navigate],
   );
 
-  const platformItems = useMemo(
-    () => sanitizePlatforms(bootsSummary.platforms),
-    [bootsSummary.platforms],
-  );
-
   return (
     <div className="flex flex-col gap-8 pt-4">
       <DesktopGrid>
@@ -164,11 +156,6 @@ const BootsTab = ({
             configStatusCounts={bootsSummary.configs}
             diffFilter={diffFilter}
           />
-          <MemoizedPlatformsCard
-            platforms={platformItems}
-            issueFilterSection="bootPlatform"
-            diffFilter={diffFilter}
-          />
         </div>
         <MemoizedIssuesList
           title={<FormattedMessage id="global.issues" />}
@@ -193,11 +180,6 @@ const BootsTab = ({
             <MemoizedConfigList
               title={<FormattedMessage id="bootsTab.configs" />}
               configStatusCounts={bootsSummary.configs}
-              diffFilter={diffFilter}
-            />
-            <MemoizedPlatformsCard
-              platforms={platformItems}
-              issueFilterSection="bootPlatform"
               diffFilter={diffFilter}
             />
             <MemoizedErrorsSummary

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useCallback, useMemo, type JSX } from 'react';
+import { useCallback, type JSX } from 'react';
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
@@ -28,10 +28,7 @@ import { MemoizedStatusCard } from '@/components/Tabs/StatusCard';
 import MemoizedConfigList from '@/components/Tabs/Tests/ConfigsList';
 import MemoizedErrorsSummary from '@/components/Tabs/Tests/ErrorsSummary';
 import HardwareCommitNavigationGraph from '@/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph';
-import { MemoizedPlatformsCard } from '@/components/Cards/PlatformsCard';
 import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
-
-import { sanitizePlatforms } from '@/utils/utils';
 
 import { RedirectFrom, type TFilterObjectsKeys } from '@/types/general';
 
@@ -118,11 +115,6 @@ const TestsTab = ({
     [navigate],
   );
 
-  const platformItems = useMemo(
-    () => sanitizePlatforms(testsSummary.platforms),
-    [testsSummary.platforms],
-  );
-
   return (
     <div className="flex flex-col gap-8 pt-4">
       <DesktopGrid>
@@ -149,11 +141,6 @@ const TestsTab = ({
             configStatusCounts={testsSummary.configs}
             diffFilter={diffFilter}
           />
-          <MemoizedPlatformsCard
-            platforms={platformItems}
-            issueFilterSection="testPlatform"
-            diffFilter={diffFilter}
-          />
         </div>
         <MemoizedIssuesList
           title={<FormattedMessage id="global.issues" />}
@@ -178,11 +165,6 @@ const TestsTab = ({
             <MemoizedConfigList
               title={<FormattedMessage id="bootsTab.configs" />}
               configStatusCounts={testsSummary.configs}
-              diffFilter={diffFilter}
-            />
-            <MemoizedPlatformsCard
-              platforms={platformItems}
-              issueFilterSection="testPlatform"
               diffFilter={diffFilter}
             />
             <MemoizedErrorsSummary

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -152,8 +152,6 @@ export const zFilterObjectsKeys = z.enum([
   'testStatus',
   'hardware',
   'trees',
-  'bootPlatform',
-  'testPlatform',
   'testPath',
   'bootPath',
   'buildIssue',
@@ -194,8 +192,6 @@ export const zDiffFilter = z
       testDurationMax: zFilterNumberValue,
       hardware: zFilterBoolValue,
       trees: zFilterBoolValue,
-      bootPlatform: zFilterBoolValue,
-      testPlatform: zFilterBoolValue,
       buildIssue: zFilterBoolValue,
       bootIssue: zFilterBoolValue,
       testIssue: zFilterBoolValue,
@@ -269,8 +265,6 @@ const requestFilters = {
     'build.issue',
     'test.issue',
     'boot.issue',
-    'boot.platform',
-    'test.platform',
     'build.status',
   ],
 } as const;
@@ -303,8 +297,6 @@ export const filterFieldMap = {
   'build.issue': 'buildIssue',
   'boot.issue': 'bootIssue',
   'test.issue': 'testIssue',
-  'boot.platform': 'bootPlatform',
-  'test.platform': 'testPlatform',
   'build.status': 'buildStatus',
 } as const satisfies Record<TRequestFiltersValues, TFilterKeys>;
 

--- a/dashboard/src/types/hardware.ts
+++ b/dashboard/src/types/hardware.ts
@@ -1,17 +1,13 @@
 import type { RequiredStatusCount, StatusCount } from './general';
 
-export interface HardwareItem {
-  hardware_name: string;
-  platform: string | string[];
+export type HardwareItem = {
+  hardware?: string[];
+  platform: string;
   build_status_summary: RequiredStatusCount;
   test_status_summary: StatusCount;
   boot_status_summary: StatusCount;
-}
-
-export type HardwareListingItem = HardwareItem;
+};
 
 export interface HardwareListingResponse {
-  hardware: HardwareListingItem[];
+  hardware: HardwareItem[];
 }
-
-export type HardwareTableItem = HardwareItem;

--- a/dashboard/src/utils/search.ts
+++ b/dashboard/src/utils/search.ts
@@ -188,8 +188,6 @@ const diffFilterMinifiedParams: Record<TFilterKeys, string> = {
   testDurationMin: 'tdf',
   hardware: 'h',
   trees: 't',
-  bootPlatform: 'btpf',
-  testPlatform: 'tpf',
   buildIssue: 'bi',
   bootIssue: 'bti',
   testIssue: 'ti',

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -10,7 +10,6 @@ import type {
   BuildsTabBuild,
   BuildsTableBuild,
   RequiredStatusCount,
-  StatusCount,
 } from '@/types/general';
 import type { ISummaryItem } from '@/components/Tabs/Summary';
 import type { Status } from '@/types/database';
@@ -83,36 +82,6 @@ export const sanitizeConfigs = (
   }
 
   return Object.entries(configs).map(([key, value]) => {
-    const { successCount, failedCount, inconclusiveCount } = groupStatus({
-      doneCount: value.DONE,
-      errorCount: value.ERROR,
-      failCount: value.FAIL,
-      missCount: value.MISS,
-      passCount: value.PASS,
-      skipCount: value.SKIP,
-      nullCount: value.NULL,
-    });
-
-    return {
-      text: key,
-      errors: failedCount,
-      success: successCount,
-      unknown: inconclusiveCount,
-    };
-  });
-};
-
-export const sanitizePlatforms = (
-  platforms:
-    | Record<string, RequiredStatusCount>
-    | Record<string, StatusCount>
-    | undefined,
-): IListingItem[] => {
-  if (!platforms) {
-    return [];
-  }
-
-  return Object.entries(platforms).map(([key, value]) => {
     const { successCount, failedCount, inconclusiveCount } = groupStatus({
       doneCount: value.DONE,
       errorCount: value.ERROR,


### PR DESCRIPTION
## Changes
- Reformats and refactors hardware listing query to group by platform first and not unnest hardware;
- Changes typing accordingly to consider hardware as optional and platform as single string;
- Adds compatibles to frontend table as badges;
- Removes unnecessary filters and card from boots/tests tab for hardware/platform details.

Note: the change in the query for the hardware listing data was made such that the hardware are not unnested now, and from business requirements a platform should always be associated with the same array of compatibles, and in that way it is possible to group by platform and hardware without having more than one row repeating a platform.

## How to test
Go to the hardware listing page and see the listing based on platforms now.
- Check the search and sorting of the hardware table to see that they still work normally;
- Check if the counting between listing and details to see if they match;
- Compare with the staging hardware listing to see if the list of compatibles makes sense, you can also mannually go to a hardware details page on staging with the platform name and access the "PlatformDetails" from there (just remember to still have the startTimestamp and endTimestamp) in the search parameters

New hardware listing:
![image](https://github.com/user-attachments/assets/9b4c6bde-24f6-4af3-888a-ea0db3aeb2f8)

Old hardware listing:
![image](https://github.com/user-attachments/assets/008847b9-da44-40fc-be16-54bba1e4e1ad)



Closes #1184