### PR TITLE
Feat: add status counts to checkout summary email notification

### DIFF
--- a/backend/kernelCI_app/management/commands/templates/summary.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/summary.txt.j2
@@ -29,13 +29,17 @@ Hello,
 Status summary for {{ checkout["tree_name"] }}/{{ checkout["git_repository_branch"] }}
 
 Dashboard:
-https://d.kernelci.org/tree/{{ checkout["git_commit_hash"] }}?ti%7Cc={{ checkout["git_commit_name"] }}&ti%7Cch={{ checkout["git_commit_hash"] }}&ti%7Cgb={{ checkout["git_repository_branch"] }}&ti%7Cgu={{ checkout["giturl_safe"] }}&ti%7Ct={{ checkout["tree_name"] }}
+https://d.kernelci.org/tree/{{ checkout["git_commit_hash"] }}?ti%7Cc={{ checkout["git_commit_name"] }}&ti%7Cch={{ checkout["git_commit_hash"] }}&ti%7Cgb={{ checkout["git_repository_branch"] }}&ti%7Cgu={{ git_url_safe }}&ti%7Ct={{ checkout["tree_name"] }}
 
 giturl: {{ checkout["git_repository_url"] }}
 branch: {{ checkout["git_repository_branch"] }}
 commit hash: {{ checkout["git_commit_hash"] }}
 origin: {{ checkout["origin"] }}
 test start time: {{ checkout["_timestamp"] }}
+
+Builds: {{ build_status_group["success"]}} Pass, {{ build_status_group["failed"] }} Fail, {{ build_status_group["inconclusive"] }} Other status
+Boots: {{ boot_status_group["success"]}} Pass, {{ boot_status_group["failed"] }} Fail, {{ boot_status_group["inconclusive"] }} Other status
+Tests: {{ test_status_group["success"]}} Pass, {{ test_status_group["failed"] }} Fail, {{ test_status_group["inconclusive"] }} Other status
 
 ### POSSIBLE REGRESSIONS
 {%- if new_issues %}

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -218,6 +218,7 @@ def get_tree_listing_fast(
             SELECT
                 id,
                 tree_name,
+                origin,
                 git_repository_branch,
                 git_repository_url,
                 git_commit_hash,
@@ -637,6 +638,7 @@ def get_latest_tree(
         "git_commit_name",
         "git_repository_url",
         "tree_name",
+        "origin",
     ]
 
     query = Checkouts.objects.values(*tree_fields).filter(

--- a/backend/kernelCI_app/typeModels/common.py
+++ b/backend/kernelCI_app/typeModels/common.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, TypedDict
 
 from pydantic import BaseModel
 
@@ -33,3 +33,9 @@ class StatusCount(BaseModel):
             DONE=self.DONE + other.DONE,
             NULL=self.NULL + other.NULL,
         )
+
+
+class GroupedStatus(TypedDict):
+    success: int
+    failed: int
+    inconclusive: int

--- a/backend/kernelCI_app/typeModels/treeListing.py
+++ b/backend/kernelCI_app/typeModels/treeListing.py
@@ -11,6 +11,7 @@ from kernelCI_app.typeModels.databases import (
     Checkout__GitRepositoryUrl,
     Checkout__OriginBuildsFinishTime,
     Checkout__OriginTestsFinishTime,
+    Origin,
     Timestamp,
 )
 from pydantic import BaseModel, Field, RootModel
@@ -43,6 +44,7 @@ class BaseCheckouts(BaseModel):
     git_repository_url: Checkout__GitRepositoryUrl
     git_commit_hash: Checkout__GitCommitHash
     git_commit_name: Checkout__GitCommitName
+    origin: Origin
 
 
 class CommonCheckouts(BaseCheckouts):

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -5,9 +5,10 @@ from datetime import timedelta
 
 from kernelCI_app.constants.general import DEFAULT_INTERVAL_IN_DAYS
 from kernelCI_app.helpers.logger import log_message
-from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.common import GroupedStatus, StatusCount
 from kernelCI_app.typeModels.databases import DatabaseStatusValues
 from kernelCI_app.typeModels.issues import Issue, IssueDict
+from kernelCI_app.typeModels.treeListing import TestStatusCount
 
 DEFAULT_QUERY_TIME_INTERVAL = {"days": DEFAULT_INTERVAL_IN_DAYS}
 
@@ -91,3 +92,26 @@ def validate_str_to_dict(value):
     if isinstance(value, str):
         return json.loads(value)
     return value
+
+
+def group_status(count: Union[StatusCount, TestStatusCount]) -> GroupedStatus:
+    result: GroupedStatus = {"success": 0, "failed": 0, "inconclusive": 0}
+    if isinstance(count, StatusCount):
+        result["success"] = count.PASS
+        result["failed"] = count.FAIL
+        result["inconclusive"] = (
+            count.ERROR + count.SKIP + count.MISS + count.DONE + count.NULL
+        )
+    elif isinstance(count, TestStatusCount):
+        result["success"] = count.pass_count
+        result["failed"] = count.fail_count
+        result["inconclusive"] = (
+            count.error_count
+            + count.skip_count
+            + count.miss_count
+            + count.done_count
+            + count.null_count
+        )
+    else:
+        log_message("group_status only accepts StatusCount or TestStatusCount types")
+    return result

--- a/backend/kernelCI_app/views/treeView.py
+++ b/backend/kernelCI_app/views/treeView.py
@@ -1,9 +1,8 @@
-import json
 from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from kernelCI_app.helpers.trees import sanitize_tree
 from kernelCI_app.queries.tree import get_tree_listing_data
-from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.commonListing import ListingQueryParameters
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
@@ -20,55 +19,6 @@ from kernelCI_cache.queries.tree import get_cached_tree_listing_data
 
 
 class TreeView(APIView):
-    def _sanitize_tree(
-        self,
-        checkout: dict,
-    ) -> Checkout:
-        build_status = StatusCount(
-            PASS=checkout["pass_builds"],
-            FAIL=checkout["fail_builds"],
-            NULL=checkout["null_builds"],
-            ERROR=checkout["error_builds"],
-            MISS=checkout["miss_builds"],
-            DONE=checkout["done_builds"],
-            SKIP=checkout["skip_builds"],
-        )
-
-        test_status = {
-            "pass": checkout["pass_tests"],
-            "fail": checkout["fail_tests"],
-            "null": checkout["null_tests"],
-            "error": checkout["error_tests"],
-            "miss": checkout["miss_tests"],
-            "done": checkout["done_tests"],
-            "skip": checkout["skip_tests"],
-        }
-
-        boot_status = {
-            "pass": checkout["pass_boots"],
-            "fail": checkout["fail_boots"],
-            "null": checkout["null_boots"],
-            "error": checkout["error_boots"],
-            "miss": checkout["miss_boots"],
-            "done": checkout["done_boots"],
-            "skip": checkout["skip_boots"],
-        }
-
-        if isinstance(checkout.get("git_commit_tags"), str):
-            try:
-                checkout["git_commit_tags"] = json.loads(checkout["git_commit_tags"])
-                if not isinstance(checkout["git_commit_tags"], list):
-                    checkout["git_commit_tags"] = []
-            except json.JSONDecodeError:
-                checkout["git_commit_tags"] = []
-
-        return Checkout(
-            **checkout,
-            build_status=build_status,
-            boot_status=boot_status,
-            test_status=test_status
-        )
-
     @extend_schema(
         responses=TreeListingResponse,
         parameters=[ListingQueryParameters],
@@ -128,7 +78,7 @@ class TreeView(APIView):
             )
             if kcidb_identifier not in unique_trees:
                 unique_trees.add(kcidb_identifier)
-                typed_checkout = self._sanitize_tree(checkout=checkout)
+                typed_checkout = sanitize_tree(checkout=checkout)
                 checkouts.append(typed_checkout)
 
         try:

--- a/backend/kernelCI_app/views/treeViewFast.py
+++ b/backend/kernelCI_app/views/treeViewFast.py
@@ -49,6 +49,7 @@ class TreeViewFast(APIView):
                 CheckoutFast(
                     id=checkout.id,
                     tree_name=checkout.tree_name,
+                    origin=checkout.origin,
                     git_repository_branch=checkout.git_repository_branch,
                     git_repository_url=checkout.git_repository_url,
                     git_commit_hash=checkout.git_commit_hash,


### PR DESCRIPTION
In the current state, there are two queries for every tree in the checkout summary notification. This PR changes it such that there is a single query to get the basic checkout information of all trees at once, and then get the specific test data for each tree as before.
The query that replaces the current one for the checkout information is closely related to the tree listing query, which means that it will get the status count for all selected trees, and this is then added to the checkout summary email notification.

## Changes
- Replaces "latest checkout" query in the email notifications with a query similar to tree listing to get status count for all the trees in the yaml file;
- Changes the jinja template such that all fields from "checkout" are fields from kcidb, and also adds the counting for a tree;
- Refactors some tree queries and functions such that they are more reusable;

## How to test
These changes affect mostly the notifications. To test them, either set up the gmail api token or comment the lines that set up the service and send emails and mock the msg_id for the storage of checkout notifications. Then, run the command
```poetry run ./manage.py notifications --ignore-recipients --update-storage --action="summary"```

With the refactor of some tree-related functions, the tree listing and tree details should still be working normally

Closes #1202 