### PR TITLE
Fix: new issues ignoring stored issues

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -173,7 +173,7 @@ CRONJOBS = [
     ),
 ]
 
-GMAIL_API_TOKEN = get_json_env_var("GMAIL_API_TOKEN", "")
+GMAIL_API_TOKEN = get_json_env_var("GMAIL_API_TOKEN", "gmail_api_token.json")
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases

--- a/backend/kernelCI_cache/queries/issues.py
+++ b/backend/kernelCI_cache/queries/issues.py
@@ -60,4 +60,5 @@ def get_all_issue_keys() -> list[IssueKeyTuple]:
     except ValueError as e:
         log_message(f"Validation error when getting all issue keys: {e}")
         return []
-    return valid_results
+
+    return results

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
             - DEBUG=False
             - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
             - REDIS_HOST=redis
+            - GMAIL_API_TOKEN=gmail_api_token.json
         volumes:
             - db-data:/backend/data
 


### PR DESCRIPTION
When adding a type validation to the query, the return became `[IssueKeyTuple(str, int)]` instead of a simple list of tuples, so when comparing a tuple with the result, it was comparing a tuple with an IssueKeyTuple object, which was always false and therefore new issues were skipping the stored issues.

This PR also has a small change to fix the default gmail api file, such that we have a default fallback if we don't explicitly pass it to run the notification command.

## How to test
Check your local sqlite database, then erase the data to make it simpler to compare
Run the new issues command,
```
poetry run ./manage.py notifications --ignore-recipients --update-storage --send --action="new_issues"
```
Check the database and see that the issues are stored there as unsent
Run the new issues command again. There should be no new issues (previously there would be the same new issues again)

Closes #1213