### PR TITLE
Feat: update docker volume files from local

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update \
         libc-dev \
         libpq-dev \
         postgresql \
+        rsync \
     && python3 -m venv $POETRY_HOME \
     && $POETRY_HOME/bin/pip install poetry==1.8.3 \
     && ln -s $POETRY_HOME/bin/poetry /bin/poetry
@@ -24,6 +25,14 @@ FROM backend-base
 COPY . /backend
 COPY ./utils/docker/entrypoint.sh /entrypoint.sh
 WORKDIR /backend
+
+# Since the volume mount will overlay the local folder,
+# if there is any local change that we want to update we have to copy it to
+# a temporary folder that we then will sync back again to the docker volume
+# (that is, copy the local files that don't exist in the volume
+# and keep intact the ones that are already present in the volume)
+RUN mkdir -p /tmp/backend_data_backup && \
+    cp -r /backend/data/. /tmp/backend_data_backup/
 
 RUN poetry install --no-interaction --only main
 
@@ -43,5 +52,8 @@ EXPOSE 8000
 
 VOLUME ["/backend/data"]
 
-CMD ["--workers=5", "--forwarded-allow-ips=*", "--bind=0.0.0.0:8000", "--timeout=240"]
+# gunicorn is added here but is run at the end of the entrypoint.
+# This was done here such that we can run a custom command
+# in the backend container without using gunicorn
+CMD ["gunicorn", "kernelCI.wsgi:application", "--workers=5", "--forwarded-allow-ips=*", "--bind=0.0.0.0:8000", "--timeout=240"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -24,13 +24,14 @@ export DB_DEFAULT="{
     }
 }"
 ```
-Attention to <DB-USER> and <DB-PASSWORD> placeholders
+Attention to \<DB-USER\> and \<DB-PASSWORD\> placeholders
 
 After connecting to Google Cloud, execute the server with:
 
 ```sh
 poetry run python3 manage.py runserver
 ```
+
 
 ## Running unit tests
 The backend includes unit tests covering some parts of the source code. To run the tests, use the following command:
@@ -64,6 +65,7 @@ poetry run pytest --run-all
 The command above is also executed in our CI system, and every pull request must pass the tests before
 it can be merged.
 
+
 ## Cron jobs
 
 We have support for cron jobs using django-crontab. To set up cron jobs, edit the `CRONJOBS` variable in /backend/kernelCI/settings.py
@@ -80,7 +82,7 @@ or
 ```docker exec -it dashboard-backend-1 poetry run ./manage.py crontab show```
 
 
-# Deploy instructions
+## Deploy instructions
 
 To check if it is ready for a deploy you can run 
 ```sh
@@ -100,18 +102,26 @@ export DJANGO_SECRET_KEY=$(openssl rand -base64 22)
 We are not using sessions or anything like that right now, so changing the secret key won't be a big deal.
 
 
-# Requests
-In the `/requests` directory we have scripts that execute requests to endpoints using [httpie](https://httpie.io/)
+## Requests
+
+In the `/requests` directory we have scripts that execute requests to endpoints using [httpie](https://httpie.io/). They serve as examples of how you could use the API, and what responses you can expect. If you are contributing to some endpoint and change any of the responses, please remember to update those files.
 
 
-# Debug
+## Debug
 
 For debugging we have two env variables
 
 `DEBUG` and `DEBUG_SQL_QUERY` that can be set to `True` to enable debugging. The reason `DEBUG_SQL_QUERY` is separated is that it can be very verbose.
 
+
 ## Open API generate
+
 You can update the OpenAPI schema by running the `generate-schema.sh` script
+
+
+## SQLite migrations
+
+Besides KCIDB, we also have a sqlite that stores cached data and other custom data. You can update it by running the `migrate-cache-db.sh` script
 
 
 ## Discord Webhook Integration
@@ -124,7 +134,14 @@ For an introduction on discord webhooks, visit https://support.discord.com/hc/en
 
 For more detailed developer resources, visit https://discord.com/developers/docs/resources/webhook.
 
-## IDE Specific:
+
+## Email notifications
+
+The email notification system is used with cron jobs to be able to send regular updates about specific actions to the relevant recipients. You can check more information about it on ~/docs/notifications.md
+
+
+## IDE Specific
+
 You are free to use whichever tool you would like, but here are tips for specific IDEs
 
 

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -185,7 +185,7 @@ DATABASES = {
         "DB_DEFAULT",
         {
             "ENGINE": "django.db.backends.postgresql",
-            "NAME": "kernelci",
+            "NAME": "kcidb",
             "USER": "kernelci",
             "PASSWORD": "kernelci-db-password",
             "HOST": "127.0.0.1",

--- a/backend/utils/docker/entrypoint.sh
+++ b/backend/utils/docker/entrypoint.sh
@@ -46,6 +46,11 @@ if [ "$SETUP_DJANGO" = 1 ]; then
     exit 0
 fi
 
+# Bring back new local files from backend to the docker volume
+echo "Copying backend data backup to volume"
+rsync -av --ignore-existing /tmp/backend_data_backup/. /backend/data/
+rm -rf /tmp/backend_data_backup
+
 # Add and start cronjobs
 poetry run ./manage.py crontab add
 crond start
@@ -55,4 +60,4 @@ chmod +x ./migrate-cache-db.sh
 ./migrate-cache-db.sh
 
 
-exec gunicorn kernelCI.wsgi:application "$@"
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 volumes:
-    db-data:
+    backend-data:
     runtime-data:
     static-data:
 
@@ -61,7 +61,7 @@ services:
             - REDIS_HOST=redis
             - GMAIL_API_TOKEN=gmail_api_token.json
         volumes:
-            - db-data:/backend/data
+            - backend-data:/backend/data
 
     dashboard:
         build: ./dashboard

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -4,11 +4,15 @@
 
 The `notifications` management command provides a flexible tool for generating and sending various types of email notifications related to issue reporting and summaries. It supports multiple actions and offers extensive configuration options.
 
+
 ## Command Syntax
 
 ```bash
 poetry run ./manage.py notifications --action=<action> [options]
 ```
+
+If you are running the project in a docker container, you should add a `docker compose run --rm backend` to get a container of the backend running separately in order to use environment variables and existing connections to the database and be able to send notifications.
+
 
 ## Actions
 


### PR DESCRIPTION
## Changes
Adds the behavior that when a file is added locally to backend/data it is also synced to the docker volume. This is made because the docker volume is mounted on top of backend/data, making local changes inaccessible. The solution made was to copy local files to a temporary folder, then mount the volume, then sync back files from the temporary folder to the volume (adds files that didn't exist, ignores existing ones), the temporary folder is then removed.

Also moves the `gunicorn` comand to the dockerfile, such that when running backend notification commands from docker the arguments are passed only to the notification command, and not gunicorn.

Reiterating that existing files are skipped, meaning that _changes_ to local files are still not passed to the volume. This was kept this way because the cache that exists on staging and production will always be larger to the local due to the length of time that the cron job has been running there.

## How to test
Run docker compose to up the project, then add a local file or folder to backend/data.
Before this PR, the file would not appear in the volume, now it does.

Closes #1222