### PR TITLE
Feat: add community dashboards

### DIFF
--- a/dashboard/src/components/Button/CopyButton.tsx
+++ b/dashboard/src/components/Button/CopyButton.tsx
@@ -2,8 +2,9 @@ import { MdOutlineCopyAll } from 'react-icons/md';
 
 import { useCallback, useState, type JSX } from 'react';
 
-import { AlertDialog, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import { cn } from '@/lib/utils';
+
+import { Button } from '@/components/ui/button';
 
 interface CopyButtonProps {
   value?: string;
@@ -20,19 +21,19 @@ const CopyButton = ({ value }: CopyButtonProps): JSX.Element => {
   const onAnimationEnd = useCallback(() => setCopied(false), [setCopied]);
 
   return (
-    <AlertDialog>
-      <AlertDialogTrigger
-        onClick={handleClick}
-        className={cn(
-          'ml-2 h-[20px] w-[20px] p-[2px] align-middle text-base',
-          copied ? 'animate-[ping_0.2s_cubic-bezier(0,0,0.2,1)_1]' : '',
-        )}
-        onAnimationEnd={onAnimationEnd}
-        disabled={copied}
-      >
-        <MdOutlineCopyAll />
-      </AlertDialogTrigger>
-    </AlertDialog>
+    <Button
+      variant={'ghost'}
+      onClick={handleClick}
+      className={cn(
+        'ml-2 h-[20px] w-[20px] p-[2px] align-middle text-base',
+        copied ? 'animate-[ping_0.2s_cubic-bezier(0,0,0.2,1)_1]' : '',
+      )}
+      onAnimationEnd={onAnimationEnd}
+      disabled={copied}
+      type="button"
+    >
+      <MdOutlineCopyAll />
+    </Button>
   );
 };
 

--- a/dashboard/src/components/Dialog/CustomDialog.tsx
+++ b/dashboard/src/components/Dialog/CustomDialog.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode, JSX } from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import type { MessagesKey } from '@/locales/messages';
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface ActionLinkBase {
+  href: string;
+  target?: string;
+  rel?: string;
+  icon?: JSX.Element;
+}
+
+interface ActionLinkWithIntl extends ActionLinkBase {
+  intlId: MessagesKey;
+  label?: never;
+}
+
+interface ActionLinkWithLabel extends ActionLinkBase {
+  intlId?: never;
+  label: string;
+}
+
+export type ActionLink = ActionLinkWithIntl | ActionLinkWithLabel;
+
+export interface CustomDialogProps {
+  trigger: ReactNode;
+  titleIntlId: MessagesKey;
+  descriptionIntlId: MessagesKey;
+  footerClassName?: string;
+  actionLinks?: ActionLink[];
+  showCancel?: boolean;
+}
+
+export const CustomDialog = ({
+  trigger,
+  titleIntlId,
+  descriptionIntlId,
+  footerClassName,
+  actionLinks = [],
+  showCancel = true,
+}: CustomDialogProps): JSX.Element => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="leading-normal tracking-normal">
+            <FormattedMessage id={titleIntlId} />
+          </DialogTitle>
+          <DialogDescription>
+            <FormattedMessage id={descriptionIntlId} />
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className={footerClassName}>
+          {actionLinks.map((actionLink, index) => (
+            <Button key={index} asChild>
+              <a
+                href={actionLink.href}
+                target={actionLink.target ?? '_blank'}
+                rel={actionLink.rel ?? 'noreferrer'}
+              >
+                {actionLink.intlId ? (
+                  <FormattedMessage id={actionLink.intlId} />
+                ) : (
+                  actionLink.label
+                )}
+                {actionLink.icon}
+              </a>
+            </Button>
+          ))}
+          {showCancel && (
+            <DialogClose asChild>
+              <Button variant={'outline'}>
+                <FormattedMessage id="global.cancel" />
+              </Button>
+            </DialogClose>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/dashboard/src/components/Icons/ExternalLink.tsx
+++ b/dashboard/src/components/Icons/ExternalLink.tsx
@@ -1,0 +1,10 @@
+import type { HTMLProps, JSX } from 'react';
+import { HiOutlineExternalLink } from 'react-icons/hi';
+
+export const ExternalLinkIcon = ({
+  className,
+}: {
+  className?: HTMLProps<HTMLElement>['className'];
+}): JSX.Element => {
+  return <HiOutlineExternalLink className={className} />;
+};

--- a/dashboard/src/components/SideMenu/NavLink.tsx
+++ b/dashboard/src/components/SideMenu/NavLink.tsx
@@ -7,21 +7,37 @@ import type { JSX } from 'react';
 
 import type { MessagesKey } from '@/locales/messages';
 
+import { cn } from '@/lib/utils';
+
 import { NavigationMenuLink } from '../ui/navigation-menu';
 
-type INavLink = LinkProps & {
-  idIntl: MessagesKey;
-  icon: JSX.Element;
+type INavLinkBase = LinkProps & {
+  icon?: JSX.Element;
   href?: string;
   asTag?: string;
   selected?: boolean;
+  linkClassName?: string;
 };
+
+type INavLinkWithIntl = INavLinkBase & {
+  idIntl: MessagesKey;
+  label?: never;
+};
+
+type INavLinkWithLabel = INavLinkBase & {
+  idIntl?: never;
+  label: string;
+};
+
+type INavLink = INavLinkWithIntl | INavLinkWithLabel;
 
 const NavLink = ({
   selected = false,
   icon,
   idIntl,
+  label,
   asTag,
+  linkClassName,
   ...props
 }: INavLink): JSX.Element => {
   const LinkElement = asTag ?? Link;
@@ -37,12 +53,16 @@ const NavLink = ({
   return (
     <NavigationMenuLink asChild>
       <LinkElement
-        className={`${baseClassName} ${selected ? selectedItemClassName : notSelectedItemClassName}`}
+        className={cn(
+          baseClassName,
+          selected ? selectedItemClassName : notSelectedItemClassName,
+          linkClassName,
+        )}
         {...props}
       >
-        <span className="mr-3">{icon}</span>
+        {icon && <span className="mr-3">{icon}</span>}
         <span className="text-center text-sm">
-          <FormattedMessage id={idIntl} />
+          {label ?? <FormattedMessage id={idIntl} />}
         </span>
       </LinkElement>
     </NavigationMenuLink>

--- a/dashboard/src/components/SideMenu/SendFeedback.tsx
+++ b/dashboard/src/components/SideMenu/SendFeedback.tsx
@@ -1,21 +1,12 @@
 import { MdOutlineFeedback } from 'react-icons/md';
-import { FormattedMessage } from 'react-intl';
 
 import { useEffect, useMemo, useState, type JSX } from 'react';
 
 import { useLocation } from '@tanstack/react-router';
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
+import { LiaGithub } from 'react-icons/lia';
+
+import { HiOutlineMail } from 'react-icons/hi';
 
 import {
   FEEDBACK_ISSUE_URL,
@@ -23,6 +14,9 @@ import {
 } from '@/utils/constants/general';
 
 import { NavigationMenuItem } from '@/components/ui/navigation-menu';
+
+import type { ActionLink } from '@/components/Dialog/CustomDialog';
+import { CustomDialog } from '@/components/Dialog/CustomDialog';
 
 import NavLink from './NavLink';
 
@@ -40,63 +34,50 @@ const SendFeedback = (
     setFullLocation(newUrl);
   }, [location]);
 
-  const github_href = useMemo(() => {
-    const github_body = encodeURIComponent(`# Feedback Description:
+  const actionLinks: ActionLink[] = useMemo(() => {
+    const github_body = encodeURIComponent(
+      `# Feedback Description:
   
 ## URL used to send feedback:
-${fullLocation}
-    `);
+${fullLocation}`,
+    );
 
-    return `${FEEDBACK_ISSUE_URL}&body=${github_body}`;
-  }, [fullLocation]);
-
-  const email_href = useMemo(() => {
-    const subject = 'Dashboard Feedback';
-    const email_body = encodeURIComponent(`Feedback Description:
+    const email_subject = 'Dashboard Feedback';
+    const email_body = encodeURIComponent(
+      `Feedback Description:
   
 URL used to send feedback:
-${fullLocation}
-      `);
+${fullLocation}`,
+    );
 
-    return `mailto:${FEEDBACK_EMAIL_TO}?body=${email_body}&subject=${subject}`;
+    return [
+      {
+        href: `${FEEDBACK_ISSUE_URL}&body=${github_body}`,
+        label: 'Github',
+        icon: <LiaGithub className="ml-2 size-5" />,
+      },
+      {
+        href: `mailto:${FEEDBACK_EMAIL_TO}?body=${email_body}&subject=${email_subject}`,
+        intlId: 'global.email',
+        icon: <HiOutlineMail className="ml-2 size-5" />,
+      },
+    ];
   }, [fullLocation]);
 
   return (
     <NavigationMenuItem {...props}>
-      <AlertDialog>
-        <AlertDialogTrigger>
+      <CustomDialog
+        trigger={
           <NavLink
             asTag="a"
             icon={<MdOutlineFeedback />}
-            idIntl="routes.sendFeedback"
+            idIntl="sidemenu.sendFeedback"
           />
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              <FormattedMessage id="routes.sendFeedback" />
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              <FormattedMessage id="routes.sendFeedbackMsg" />
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogAction asChild>
-              <a href={github_href} target="_blank" rel="noreferrer">
-                <FormattedMessage id="global.github" />
-              </a>
-            </AlertDialogAction>
-            <AlertDialogAction asChild>
-              <a href={email_href} target="_blank" rel="noreferrer">
-                <FormattedMessage id="global.email" />
-              </a>
-            </AlertDialogAction>
-            <AlertDialogCancel>
-              <FormattedMessage id="global.cancel" />
-            </AlertDialogCancel>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        }
+        titleIntlId="sidemenu.sendFeedback"
+        descriptionIntlId="sidemenu.sendFeedbackMsg"
+        actionLinks={actionLinks}
+      />
     </NavigationMenuItem>
   );
 };

--- a/dashboard/src/components/SideMenu/SideMenu.tsx
+++ b/dashboard/src/components/SideMenu/SideMenu.tsx
@@ -9,6 +9,8 @@ import { HiOutlineDocumentSearch } from 'react-icons/hi';
 
 import { useLocation } from '@tanstack/react-router';
 
+import { FormattedMessage } from 'react-intl';
+
 import type { MessagesKey } from '@/locales/messages';
 
 import { DOCUMENTATION_URL } from '@/utils/constants/general';
@@ -22,6 +24,10 @@ import {
 import { Separator } from '@/components/ui/separator';
 
 import type { PossibleMonitorPath } from '@/types/general';
+
+import { ExternalLinkIcon } from '@/components/Icons/ExternalLink';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 
 import SendFeedback from './SendFeedback';
 
@@ -40,11 +46,31 @@ type LinkMenuItems = {
   icon: JSX.Element;
 };
 
+type LinkStringItems = {
+  url: string;
+  label: string;
+};
+
 const linkItems: LinkMenuItems[] = [
   {
     url: DOCUMENTATION_URL,
     idIntl: 'global.documentation',
     icon: <HiOutlineDocumentSearch />,
+  },
+];
+
+const dashboardItems: LinkStringItems[] = [
+  {
+    url: 'https://kdevops.org/',
+    label: 'kdevops',
+  },
+  {
+    url: 'https://netdev.bots.linux.dev/contest.html',
+    label: 'netdev-CI',
+  },
+  {
+    url: 'https://grafana.kernelci.org/d/home',
+    label: 'Grafana',
   },
 ];
 
@@ -110,6 +136,22 @@ const SideMenu = (): JSX.Element => {
     [],
   );
 
+  const dashboardElements = useMemo(
+    () =>
+      dashboardItems.map(item => (
+        <NavigationMenuItem key={item.label} className="w-full">
+          <NavLink
+            asTag="a"
+            icon={<ExternalLinkIcon />}
+            label={item.label}
+            href={item.url}
+            target="_blank"
+          />
+        </NavigationMenuItem>
+      )),
+    [],
+  );
+
   return (
     <NavigationMenu
       className="bg-bg-secondary min-h-screen flex-col justify-start pt-6"
@@ -121,13 +163,27 @@ const SideMenu = (): JSX.Element => {
 
       <Separator className="bg-on-secondary-10 my-4" />
 
-      <NavigationMenuList className="w-52 flex-col space-y-4 space-x-0">
+      <NavigationMenuList className="w-56 flex-col space-y-4 space-x-0">
         {routeItems.map(item => (
-          <SideMenuItem item={item} key={item.idIntl}></SideMenuItem>
+          <SideMenuItem item={item} key={item.idIntl} />
         ))}
         <Separator className="bg-on-secondary-10 my-4" />
         {linksItemElements}
         <SendFeedback className="w-full" />
+        <Separator className="bg-on-secondary-10 my-4" />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex items-center gap-2 text-white">
+              <FormattedMessage id={'sidemenu.communityDashboards'} />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-[450px]">
+            <FormattedMessage id={'sidemenu.communityDashboardsMsg'} />
+          </TooltipContent>
+        </Tooltip>
+        <div className="flex w-full flex-col space-y-0">
+          {dashboardElements}
+        </div>
       </NavigationMenuList>
     </NavigationMenu>
   );

--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -104,7 +104,7 @@ const TopBar = (): JSX.Element => {
   const basePath = redirectFrom ?? splitPath;
 
   return (
-    <div className="fixed top-0 z-10 mx-52 flex h-20 w-full bg-white px-16">
+    <div className="fixed top-0 z-10 ml-56 flex h-20 w-full bg-white px-16">
       <div className="flex flex-row items-center justify-between">
         <span className="mr-14 text-2xl">
           <TitleName basePath={basePath} />

--- a/dashboard/src/components/ui/dialog.tsx
+++ b/dashboard/src/components/ui/dialog.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
@@ -65,6 +67,20 @@ const DialogHeader = ({
 );
 DialogHeader.displayName = 'DialogHeader';
 
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
@@ -80,6 +96,18 @@ const DialogTitle = React.forwardRef<
 ));
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-slate-500 dark:text-slate-400', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
 export {
   Dialog,
   DialogPortal,
@@ -88,5 +116,7 @@ export {
   DialogTrigger,
   DialogContent,
   DialogHeader,
+  DialogFooter,
   DialogTitle,
+  DialogDescription,
 };

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { FEEDBACK_EMAIL_TO } from '@/utils/constants/general';
 
-import { LOCALES } from '../constants';
+import { LOCALES } from '@/locales/constants';
 /*eslint sort-keys: "error"*/
 
 export const formattedBreakLineValue = { br: React.createElement('br') };
@@ -113,7 +113,6 @@ export const messages = {
     'global.fails': 'Fails',
     'global.filters': 'Filters',
     'global.fullLogs': 'Full logs',
-    'global.github': 'GitHub',
     'global.hardware': 'Hardware',
     'global.id': 'Id',
     'global.inconclusive': 'Inconclusive',
@@ -229,12 +228,12 @@ export const messages = {
     'routes.hardwareMonitor': 'Hardware',
     'routes.issueDetails': 'Issue',
     'routes.issueMonitor': 'Issues',
-    'routes.sendFeedback': 'Send us Feedback',
-    'routes.sendFeedbackMsg':
-      'Thank you for your feedback!\nWe greatly appreciate your input. You are welcome to send us the feedback via email or by creating an issue on our GitHub repository.',
     'routes.testDetails': 'Test',
     'routes.treeMonitor': 'Trees',
     'routes.unknown': 'Unknown',
+    'sidemenu.sendFeedback': 'Send us Feedback',
+    'sidemenu.sendFeedbackMsg':
+      'Thank you for your feedback!\nWe greatly appreciate your input. You are welcome to send us the feedback via email or by creating an issue on our GitHub repository.',
     'tab.findOnPreviousCheckoutsTooltip':
       'You may still find {tab} on previous checkouts',
     'tab.name': 'Name',

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -231,6 +231,9 @@ export const messages = {
     'routes.testDetails': 'Test',
     'routes.treeMonitor': 'Trees',
     'routes.unknown': 'Unknown',
+    'sidemenu.communityDashboards': 'Community Dashboards',
+    'sidemenu.communityDashboardsMsg':
+      'Across the Linux kernel community, there are other dashboards available that you might find useful for exploring different kernel testing data and perspectives.',
     'sidemenu.sendFeedback': 'Send us Feedback',
     'sidemenu.sendFeedbackMsg':
       'Thank you for your feedback!\nWe greatly appreciate your input. You are welcome to send us the feedback via email or by creating an issue on our GitHub repository.',


### PR DESCRIPTION
## Changes

- Adds another entry to the sidebar to link to other community dashboards: kdevops, netdev-CI, and Grafana.
- Adds icons to the sidemenu dialog buttons
- Updates Dialog from shadcn to include DialogFooter and DialogDescription
- Adds a CustomDialog component to make it easily reusable
- Substitutes use of AlertDialog for Dialog in sidebar, so that a user can close the dialog by clicking outside of it
- Removes unnecessary use of AlertDialog in CopyButton for a more correct use of Button

## How to test
Go to any page in the dashboard that has the sidemenu, click on "Community Dashboards" and check the component and its links
Other sidemenu items should still work normally
Other dialogs should still work normally

## Comparison
Send us feedback Before / After
![image](https://github.com/user-attachments/assets/015fb5c3-41e7-485a-b6c4-777a26f405a6)
![image](https://github.com/user-attachments/assets/9f694609-103e-41cb-8cb6-b8e5d44f7cec)

Sidebar
| Before | After |
|--------|---------|
| ![image](https://github.com/user-attachments/assets/8a8e973c-714e-4f84-99f4-745be6d6b953)| ![image](https://github.com/user-attachments/assets/81c82054-2566-4ee5-82de-ce00ea8d7352) |

Closes #1220 
