### PR TITLE
Refactor: allow more filters for issue listing

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -179,8 +179,9 @@ GMAIL_API_TOKEN = get_json_env_var("GMAIL_API_TOKEN", "gmail_api_token.json")
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
-# If running on docker it won't build without this variable, so we don't need to pass a default value here
-BACKEND_VOLUME_DIR = get_json_env_var("BACKEND_VOLUME_DIR", "")
+# When running on docker it won't build without this variable,
+# the default value here is for when running locally
+BACKEND_VOLUME_DIR = get_json_env_var("BACKEND_VOLUME_DIR", "volume_data")
 
 DATABASE_ROUTERS = ["kernelCI_app.routers.disableMigrateRouter.DisableMigrateRouter"]
 

--- a/backend/kernelCI_app/tests/integrationTests/issues_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/issues_test.py
@@ -17,23 +17,24 @@ from http import HTTPStatus
 client = IssueClient()
 
 CULPRIT_CODE = {
-    "culpritCode": True,
+    "filters": {"issue.culprit": "code"},
     "excludes_fields": ["culprit_tool", "culprit_harness"],
 }
 
 CULPRIT_TOOL = {
-    "culpritTool": True,
+    "filters": {"issue.culprit": "tool"},
     "excludes_fields": ["culprit_code", "culprit_harness"],
 }
 
 CULPRIT_HARNESS = {
-    "culpritHarness": True,
+    "filters": {"issue.culprit": "harness"},
     "excludes_fields": ["culprit_code", "culprit_tool"],
 }
 
 CULPRIT_CODE_AND_TOOL = {
-    "culpritCode": True,
-    "culpritTool": True,
+    "filters": {
+        "issue.culprit": ["code", "tool"],
+    },
     "excludes_fields": ["culprit_harness"],
 }
 
@@ -58,9 +59,8 @@ def pytest_generate_tests(metafunc):
 
 def test_list(pytestconfig, issue_listing_input):
     interval_in_day, culprit_data, status_code, has_error_body = issue_listing_input
-    response = client.get_issues_list(
-        interval_in_days=interval_in_day, culprit_data=culprit_data
-    )
+    filters = culprit_data.get("filters") if culprit_data else None
+    response = client.get_issues_list(interval_in_days=interval_in_day, filters=filters)
     content = string_to_json(response.content.decode())
     assert_status_code_and_error_response(
         response=response,

--- a/backend/kernelCI_app/tests/utils/client/baseClient.py
+++ b/backend/kernelCI_app/tests/utils/client/baseClient.py
@@ -17,25 +17,23 @@ class BaseClient(ABC):
         url = urljoin(self.base_url, path)
 
         query_string = ""
-        if query is not None:
-            if filters:
-                query = self.join_query(query=query, filters=filters)
+        string_parts = []
 
+        if query is not None:
             # When a value has None value, the urlencode function change it into a string.
             # This logic remove None values from the query dict
             query = {k: v for k, v in query.items() if v is not None}
-            query_string = f"?{urlencode(query)}"
-        elif filters is not None:
-            query_string = f"?{urlencode(self.get_filters(filters=filters))}"
+            string_parts.append(urlencode(query))
+        if filters is not None:
+            filters = {k: v for k, v in filters.items() if v is not None}
+            mapped_filters = self.get_filters(filters=filters)
+            string_parts.append(urlencode(mapped_filters, doseq=True))
+
+        query_string = f"?{"&".join(string_parts)}" if string_parts else ""
+
         url = f"{url}{query_string}"
         return url
 
     def get_filters(self, *, filters: dict[FilterFields, Any]) -> dict[str, Any]:
         prefix = "filter_"
         return {f"{prefix}{key}": value for key, value in filters.items()}
-
-    def join_query(
-        self, *, query: dict[str, Any], filters: dict[FilterFields, Any]
-    ) -> dict[str, Any]:
-        filters = self.get_filters(filters=filters)
-        return dict(query, **filters)

--- a/backend/kernelCI_app/tests/utils/client/issueClient.py
+++ b/backend/kernelCI_app/tests/utils/client/issueClient.py
@@ -1,18 +1,21 @@
+from typing import Any
 import requests
 from django.urls import reverse
 import json
+from kernelCI_app.helpers.filters import FilterFields
 from kernelCI_app.tests.utils.client.baseClient import BaseClient
 
 
 class IssueClient(BaseClient):
     def get_issues_list(
-        self, *, interval_in_days: int | None, culprit_data: dict | None
+        self,
+        *,
+        interval_in_days: int | None,
+        filters: dict[FilterFields, Any] | None = None,
     ) -> requests.Response:
         path = reverse("issue")
-        if culprit_data is None:
-            culprit_data = {}
-        query = {"intervalInDays": interval_in_days, **culprit_data}
-        url = self.get_endpoint(path=path, query=query)
+        query = {"intervalInDays": interval_in_days}
+        url = self.get_endpoint(path=path, query=query, filters=filters)
         return requests.get(url)
 
     def get_issues_details(

--- a/backend/kernelCI_app/typeModels/issues.py
+++ b/backend/kernelCI_app/typeModels/issues.py
@@ -78,3 +78,12 @@ type ProcessedExtraDetailedIssues = Annotated[
 
 class IssueExtraDetailsResponse(BaseModel):
     issues: ProcessedExtraDetailedIssues
+
+
+CULPRIT_CODE = "code"
+CULPRIT_HARNESS = "harness"
+CULPRIT_TOOL = "tool"
+
+POSSIBLE_CULPRITS = [CULPRIT_CODE, CULPRIT_HARNESS, CULPRIT_TOOL]
+
+type PossibleIssueCulprits = Literal["code", "harness", "tool"]

--- a/backend/kernelCI_app/views/issueView.py
+++ b/backend/kernelCI_app/views/issueView.py
@@ -1,5 +1,6 @@
-from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
+from typing import Optional
+from django.http import HttpRequest
 from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -8,20 +9,61 @@ from pydantic import ValidationError
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
+from kernelCI_app.helpers.filters import FilterParams
 from kernelCI_app.helpers.issueExtras import assign_issue_first_seen
 from kernelCI_app.queries.issues import get_issue_listing_data
 from kernelCI_app.typeModels.issueListing import (
     IssueListingResponse,
     IssueListingQueryParameters,
 )
-from kernelCI_app.typeModels.issues import FirstIncident, ProcessedExtraDetailedIssues
+from kernelCI_app.typeModels.issues import (
+    CULPRIT_CODE,
+    CULPRIT_HARNESS,
+    CULPRIT_TOOL,
+    FirstIncident,
+    PossibleIssueCulprits,
+    ProcessedExtraDetailedIssues,
+)
 
 
 class IssueView(APIView):
     def __init__(self):
-        self.issue_records: list[dict[str]] = []
         self.processed_extra_issue_details: ProcessedExtraDetailedIssues = {}
         self.first_incidents: dict[str, FirstIncident] = {}
+
+        self.filters: Optional[FilterParams] = None
+
+    def _should_discard_issue_by_culprit(
+        self, *, culprit_filters: set[PossibleIssueCulprits], record: dict
+    ) -> bool:
+        """Returns true if the record should be discarted from the resulting set of records"""
+
+        if not culprit_filters:
+            return False
+
+        if record["culprit_code"] is True and CULPRIT_CODE in culprit_filters:
+            return False
+        if record["culprit_harness"] is True and CULPRIT_HARNESS in culprit_filters:
+            return False
+        if record["culprit_tool"] is True and CULPRIT_TOOL in culprit_filters:
+            return False
+
+        return True  # Discards if has filter but all the culprits are None
+
+    def _filter_base_records(self, *, issue_records: list[dict]) -> list[dict]:
+        """Filters the base list of issue records using self.filters"""
+        culprit_filters = self.filters.filter_issue_culprits
+
+        result: list[dict] = []
+        for issue in issue_records:
+            if self._should_discard_issue_by_culprit(
+                culprit_filters=culprit_filters, record=issue
+            ):
+                continue
+
+            result.append(issue)
+
+        return result
 
     def _format_processing_for_response(self) -> None:
         for (
@@ -35,42 +77,29 @@ class IssueView(APIView):
         responses=IssueListingResponse,
         methods=["GET"],
     )
-    def get(self, _request) -> Response:
+    def get(self, _request: HttpRequest) -> Response:
         try:
             request_params = IssueListingQueryParameters(
                 interval_in_days=_request.GET.get("intervalInDays"),
-                culprit_code=_request.GET.get("culpritCode"),
-                culprit_harness=_request.GET.get("culpritHarness"),
-                culprit_tool=_request.GET.get("culpritTool"),
             )
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
 
         interval_in_days = request_params.interval_in_days
-        culprit_code = request_params.culprit_code
-        culprit_harness = request_params.culprit_harness
-        culprit_tool = request_params.culprit_tool
 
-        interval_date = datetime.now(timezone.utc) - timedelta(days=interval_in_days)
-        interval_param = interval_date.replace(
-            hour=0, minute=0, second=0, microsecond=0
+        issue_records: list[dict] = get_issue_listing_data(
+            interval=f"{interval_in_days} days",
         )
 
-        self.issue_records = get_issue_listing_data(
-            interval_date=interval_param,
-            culprit_code=culprit_code,
-            culprit_harness=culprit_harness,
-            culprit_tool=culprit_tool,
-        )
-
-        if len(self.issue_records) == 0:
+        if len(issue_records) == 0:
             return create_api_error_response(
                 error_message="No issues found", status_code=HTTPStatus.OK
             )
 
-        issue_key_list = [
-            (issue["id"], issue["version"]) for issue in self.issue_records
-        ]
+        self.filters = FilterParams(_request)
+        filtered_records = self._filter_base_records(issue_records=issue_records)
+
+        issue_key_list = [(issue["id"], issue["version"]) for issue in filtered_records]
         assign_issue_first_seen(
             issue_key_list=issue_key_list,
             processed_issues_table=self.processed_extra_issue_details,
@@ -79,7 +108,7 @@ class IssueView(APIView):
         try:
             self._format_processing_for_response()
             valid_data = IssueListingResponse(
-                issues=self.issue_records, extras=self.first_incidents
+                issues=filtered_records, extras=self.first_incidents
             )
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/backend/requests/issue-listing-get.sh
+++ b/backend/requests/issue-listing-get.sh
@@ -1,13 +1,13 @@
-http 'localhost:8000/api/issue/?&intervalInDays=1&culpritCode=true'
+http 'localhost:8000/api/issue/?intervalInDays=1&filter_issue.culprit=code'
 
 # HTTP/1.1 200 OK
 # Allow: GET, HEAD, OPTIONS
 # Cache-Control: max-age=0
-# Content-Length: 27282
+# Content-Length: 8648
 # Content-Type: application/json
 # Cross-Origin-Opener-Policy: same-origin
-# Date: Thu, 20 Feb 2025 11:51:56 GMT
-# Expires: Thu, 20 Feb 2025 11:51:56 GMT
+# Date: Mon, 26 May 2025 13:35:53 GMT
+# Expires: Mon, 26 May 2025 13:35:53 GMT
 # Referrer-Policy: same-origin
 # Server: WSGIServer/0.2 CPython/3.12.7
 # Vary: Accept, Cookie, origin
@@ -15,63 +15,224 @@ http 'localhost:8000/api/issue/?&intervalInDays=1&culpritCode=true'
 # X-Frame-Options: DENY
 
 # {
-#     "issues":[
-#        {
-#           "field_timestamp":"2025-03-21T05:50:33.654300Z",
-#           "id":"maestro:cd18b383b75d152345cbe08983013da942678433",
-#           "comment":" NULL pointer dereference at virtual address 0000000000000030 [logspec:generic_linux_boot,linux.kernel.null_pointer_dereference]",
-#           "origin":"maestro",
-#           "version":1,
-#           "culprit_code":true,
-#           "culprit_tool":false,
-#           "culprit_harness":false
-#        },
-#        {
-#           "field_timestamp":"2025-03-20T19:02:01.275697Z",
-#           "id":"redhat:issue_3652",
-#           "comment":"networking/netfilter/upstream_test/nftables  upstream-binary-nftables-tests-shell kernel warning net/core/flow_dissector.c",
-#           "origin":"redhat",
-#           "version":1742488543,
-#           "culprit_code":true,
-#           "culprit_tool":false,
-#           "culprit_harness":false
-#        },
-#        {
-#           "field_timestamp":"2025-03-21T11:22:57.073931Z",
-#           "id":"redhat:issue_3585",
-#           "comment":"[RHEL10] [internal-testsuite] perf-pipe-recording-and-injection-test FAIL",
-#           "origin":"redhat",
-#           "version":1741311124,
-#           "culprit_code":true,
-#           "culprit_tool":false,
-#           "culprit_harness":false
-#        },
-       
-#     ],
-#     "extras":{
-#        "redhat:issue_3492":{
-#           "first_seen":"2025-02-12T13:00:01.018238Z",
-#           "git_commit_hash":null,
-#           "git_repository_url":null,
-#           "git_repository_branch":null,
-#           "git_commit_name":null,
-#           "tree_name":null
-#        },
-#        "maestro:e602fca280d85d8e603f7c0aff68363bb0cd7993":{
-#           "first_seen":"2025-01-21T00:24:05.705873Z",
-#           "git_commit_hash":"d73a4602e973e9e922f00c537a4643907a547ade",
-#           "git_repository_url":"https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git",
-#           "git_repository_branch":"main",
-#           "git_commit_name":"pm-6.13-rc8-1598-gd73a4602e973",
-#           "tree_name":"net-next"
-#        },
-#        "maestro:da694c56147298d223ee432ad8d6a8ee311b773a":{
-#           "first_seen":"2025-01-21T00:22:10.827866Z",
-#           "git_commit_hash":"d73a4602e973e9e922f00c537a4643907a547ade",
-#           "git_repository_url":"https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git",
-#           "git_repository_branch":"main",
-#           "git_commit_name":"pm-6.13-rc8-1598-gd73a4602e973",
-#           "tree_name":"net-next"
-#        }
-#     }
-#  }
+#     "extras": {
+#         "maestro:0d3cbb147d638deb60ed276f06896eef38fcf2a0": {
+#             "first_seen": "2025-04-16T17:36:54.942971Z",
+#             "git_commit_hash": "c62f4b82d57155f35befb5c8bbae176614b87623",
+#             "git_commit_name": "v6.15-rc2-48-gc62f4b82d5715",
+#             "git_repository_branch": "master",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+#             "tree_name": "mainline"
+#         },
+#         "maestro:1ec0ababeee988e6d6392eedfbe6a035ed2dfd6d": {
+#             "first_seen": "2025-05-26T09:19:39.257435Z",
+#             "git_commit_hash": "3be1a7a31fbda82f3604b6c31e4f390110de1b46",
+#             "git_commit_name": "next-20250526",
+#             "git_repository_branch": "master",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git",
+#             "tree_name": "next"
+#         },
+#         "maestro:3e57cb725c9d3e8acaf42a61e15b3c07c0e4ca60": {
+#             "first_seen": "2025-04-16T23:27:17.553063Z",
+#             "git_commit_hash": "c1336865c4c90fcc649df0435a7c86c30030a723",
+#             "git_commit_name": "v6.15-rc2-55-gc1336865c4c90",
+#             "git_repository_branch": "master",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+#             "tree_name": "mainline"
+#         },
+#         "maestro:441ce4ab6a1945cc42c0233e47d2f95614fb58a5": {
+#             "first_seen": "2025-04-16T17:55:11.571263Z",
+#             "git_commit_hash": "c62f4b82d57155f35befb5c8bbae176614b87623",
+#             "git_commit_name": "v6.15-rc2-48-gc62f4b82d5715",
+#             "git_repository_branch": "master",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+#             "tree_name": "mainline"
+#         },
+#         "maestro:66a7d9a1dc10e7ffafe798f2bca0a593dbd23eaf": {
+#             "first_seen": "2025-04-16T07:47:16.133431Z",
+#             "git_commit_hash": "f660850bc246fef15ba78c81f686860324396628",
+#             "git_commit_name": "next-20250416",
+#             "git_repository_branch": "master",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git",
+#             "tree_name": "next"
+#         },
+#         "maestro:721516cb40a17ba5aaddc2e6e410d3eec5c49fc6": {
+#             "first_seen": "2025-01-21T00:44:16.494094Z",
+#             "git_commit_hash": "d73a4602e973e9e922f00c537a4643907a547ade",
+#             "git_commit_name": "pm-6.13-rc8-1598-gd73a4602e973",
+#             "git_repository_branch": "main",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git",
+#             "tree_name": "net-next"
+#         },
+#         "maestro:7c81c13ebf1e0b7efda9125b328de6a02b01a813": {
+#             "first_seen": "2025-02-18T22:36:01.533999Z",
+#             "git_commit_hash": "33aeeccfa4c78060c7135794ff33b4df378e32d4",
+#             "git_commit_name": "v6.6.70-6982-g33aeeccfa4c78",
+#             "git_repository_branch": "chromeos-6.6",
+#             "git_repository_url": "https://chromium.googlesource.com/chromiumos/third_party/kernel",
+#             "tree_name": "chromiumos"
+#         },
+#         "maestro:ab940af48ff006abcf41620daba4d0fe959116f9": {
+#             "first_seen": "2024-11-21T03:28:01.079277Z",
+#             "git_commit_hash": "fd0bf47f6276a13190b907eb46f5707526494dcc",
+#             "git_commit_name": "ASB-2024-11-05_11-5.4-14-gfd0bf47f6276",
+#             "git_repository_branch": "android11-5.4",
+#             "git_repository_url": "https://android.googlesource.com/kernel/common",
+#             "tree_name": "android"
+#         },
+#         "maestro:bd048bdc8156ad24e3a5903c41c0424edc532371": {
+#             "first_seen": "2025-05-13T10:07:42.224250Z",
+#             "git_commit_hash": "9610ed5f00dc3dc63655a10cbabf7c6429c2886e",
+#             "git_commit_name": "ASB-2025-05-05_13-5.10-2-g9610ed5f00dc",
+#             "git_repository_branch": "android13-5.10",
+#             "git_repository_url": "https://android.googlesource.com/kernel/common",
+#             "tree_name": "android"
+#         },
+#         "maestro:d9c9973aa170e504ca712710292ace4050b7a4de": {
+#             "first_seen": "2025-03-14T01:37:01.590750Z",
+#             "git_commit_hash": "8ba2d538033ce80fc41ddd355fde50424ea10c66",
+#             "git_commit_name": "v5.10.234-26066-g8ba2d538033ce",
+#             "git_repository_branch": "chromeos-5.10",
+#             "git_repository_url": "https://chromium.googlesource.com/chromiumos/third_party/kernel",
+#             "tree_name": "chromiumos"
+#         },
+#         "maestro:da694c56147298d223ee432ad8d6a8ee311b773a": {
+#             "first_seen": "2025-01-21T00:22:10.827866Z",
+#             "git_commit_hash": "d73a4602e973e9e922f00c537a4643907a547ade",
+#             "git_commit_name": "pm-6.13-rc8-1598-gd73a4602e973",
+#             "git_repository_branch": "main",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git",
+#             "tree_name": "net-next"
+#         },
+#         "maestro:e602fca280d85d8e603f7c0aff68363bb0cd7993": {
+#             "first_seen": "2025-01-21T00:24:05.705873Z",
+#             "git_commit_hash": "d73a4602e973e9e922f00c537a4643907a547ade",
+#             "git_commit_name": "pm-6.13-rc8-1598-gd73a4602e973",
+#             "git_repository_branch": "main",
+#             "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git",
+#             "tree_name": "net-next"
+#         }
+#     },
+#     "issues": [
+#         {
+#             "comment": " WARNING at mm/early_ioremap.c:90 check_early_ioremap_leak+0x39/0x50 [logspec:generic_linux_boot,linux.kernel.warning]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T01:33:59.673657Z",
+#             "id": "maestro:441ce4ab6a1945cc42c0233e47d2f95614fb58a5",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " WARNING at mm/early_ioremap.c:90 check_early_ioremap_leak+0x38/0x50 [logspec:generic_linux_boot,linux.kernel.warning]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T03:20:21.745175Z",
+#             "id": "maestro:0d3cbb147d638deb60ed276f06896eef38fcf2a0",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " in vmlinux (Makefile:1215) [logspec:kbuild,kbuild.other]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T05:05:33.073167Z",
+#             "id": "maestro:d9c9973aa170e504ca712710292ace4050b7a4de",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " incompatible pointer to integer conversion returning 'void *' from a function with result type 'int' [-Wint-conversion] in drivers/media/platform/camx/cam_sensor_module/cam_eeprom/cam_eeprom_dev.o (drivers/media/platform/camx/cam_sensor_module/cam_eeprom/cam_eeprom_dev.c) [logspec:kbuild,kbuild.compiler.error]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T05:13:24.843369Z",
+#             "id": "maestro:7c81c13ebf1e0b7efda9125b328de6a02b01a813",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " ‘SOCK_COREDUMP’ undeclared (first use in this function); did you mean ‘SOCK_RDM’? in net/unix/af_unix.o (net/unix/af_unix.c) [logspec:kbuild,kbuild.compiler.error]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T09:43:10.311911Z",
+#             "id": "maestro:1ec0ababeee988e6d6392eedfbe6a035ed2dfd6d",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " WARNING at mm/early_ioremap.c:90 check_early_ioremap_leak+0x48/0x68 [logspec:generic_linux_boot,linux.kernel.warning]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T10:49:58.828888Z",
+#             "id": "maestro:66a7d9a1dc10e7ffafe798f2bca0a593dbd23eaf",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " WARNING: Unclean boot. Reached prompt but marked as failed. [logspec:generic_linux_boot,maestro.linux.kernel.boot]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T10:49:58.828888Z",
+#             "id": "maestro:721516cb40a17ba5aaddc2e6e410d3eec5c49fc6",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " error: relocation R_386_32 cannot be used against local symbol; recompile with -fPIC in arch/x86/boot/compressed/vmlinux (arch/x86/boot/compressed/Makefile:124) [logspec:kbuild,kbuild.compiler.linker_error]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T11:17:18.919021Z",
+#             "id": "maestro:ab940af48ff006abcf41620daba4d0fe959116f9",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " ‘input’ is a pointer; did you mean to use ‘->’? in drivers/gpu/drm/amd/amdgpu/../display/dc/calcs/dcn_calcs.o (drivers/gpu/drm/amd/amdgpu/../display/dc/calcs/dcn_calcs.c) [logspec:kbuild,kbuild.compiler.error]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T12:11:59.483340Z",
+#             "id": "maestro:bd048bdc8156ad24e3a5903c41c0424edc532371",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " stack frame size (2336) exceeds limit (2048) in 'curve25519_generic' [-Werror,-Wframe-larger-than] in lib/crypto/curve25519-hacl64.o (lib/crypto/curve25519-hacl64.c) [logspec:kbuild,kbuild.compiler.error]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T12:56:17.456762Z",
+#             "id": "maestro:3e57cb725c9d3e8acaf42a61e15b3c07c0e4ca60",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " Bootloader did not finish or kernel did not start. [logspec:generic_linux_boot,maestro.linux.kernel.boot]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T13:00:50.659846Z",
+#             "id": "maestro:e602fca280d85d8e603f7c0aff68363bb0cd7993",
+#             "origin": "maestro",
+#             "version": 1
+#         },
+#         {
+#             "comment": " Bootloader did not finish or kernel did not start. [logspec:generic_linux_boot,maestro.linux.kernel.boot]",
+#             "culprit_code": true,
+#             "culprit_harness": false,
+#             "culprit_tool": false,
+#             "field_timestamp": "2025-05-26T13:18:38.434375Z",
+#             "id": "maestro:da694c56147298d223ee432ad8d6a8ee311b773a",
+#             "origin": "maestro",
+#             "version": 1
+#         }
+#     ]
+# }

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1453,6 +1453,8 @@ components:
           $ref: '#/components/schemas/Checkout__GitCommitHash'
         git_commit_name:
           $ref: '#/components/schemas/Checkout__GitCommitName'
+        origin:
+          $ref: '#/components/schemas/Origin'
         git_repository_branch:
           $ref: '#/components/schemas/Checkout__GitRepositoryBranch'
         start_time:
@@ -1480,6 +1482,7 @@ components:
       - git_repository_url
       - git_commit_hash
       - git_commit_name
+      - origin
       - git_repository_branch
       - start_time
       - origin_builds_finish_time
@@ -1500,6 +1503,8 @@ components:
           $ref: '#/components/schemas/Checkout__GitCommitHash'
         git_commit_name:
           $ref: '#/components/schemas/Checkout__GitCommitName'
+        origin:
+          $ref: '#/components/schemas/Origin'
         git_repository_branch:
           $ref: '#/components/schemas/Checkout__GitRepositoryBranch'
         start_time:
@@ -1520,6 +1525,7 @@ components:
       - git_repository_url
       - git_commit_hash
       - git_commit_name
+      - origin
       - git_repository_branch
       - start_time
       - origin_builds_finish_time
@@ -3164,6 +3170,8 @@ components:
           $ref: '#/components/schemas/Checkout__GitCommitHash'
         git_commit_name:
           $ref: '#/components/schemas/Checkout__GitCommitName'
+        origin:
+          $ref: '#/components/schemas/Origin'
         api_url:
           title: Api Url
           type: string
@@ -3174,6 +3182,7 @@ components:
       - git_repository_url
       - git_commit_hash
       - git_commit_name
+      - origin
       - api_url
       - tree_name
       title: TreeLatestResponse

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -7,13 +7,15 @@ import type {
   CommitHistoryTable,
   HardwareDetailsSummary,
   THardwareDetails,
-  THardwareDetailsFilter,
   TTreeCommits,
 } from '@/types/hardware/hardwareDetails';
 import type { BuildsTabBuild, TestHistory, TFilter } from '@/types/general';
 import { getTargetFilter } from '@/types/general';
 
-import { isEmptyObject } from '@/utils/utils';
+import {
+  isEmptyObject,
+  mapFiltersKeysToBackendCompatible,
+} from '@/utils/utils';
 
 import { RequestData } from './commonRequest';
 
@@ -42,26 +44,6 @@ const mapIndexesToSelectedTrees = (
   });
 
   return selectedTrees;
-};
-
-// TODO: remove this function to combine with the solution for the same function in utils.ts
-const mapFiltersKeysToBackendCompatible = (
-  filter: THardwareDetailsFilter | Record<string, never>,
-): Record<string, string[]> => {
-  const filterParam: { [key: string]: string[] } = {};
-
-  Object.keys(filter).forEach(key => {
-    const filterList = filter[key as keyof THardwareDetailsFilter];
-    filterList?.forEach(value => {
-      if (!filterParam[`filter_${key}`]) {
-        filterParam[`filter_${key}`] = [value.toString()];
-      } else {
-        filterParam[`filter_${key}`].push(value.toString());
-      }
-    });
-  });
-
-  return filterParam;
 };
 
 type HardwareDetailsVariants =

--- a/dashboard/src/components/IssueTable/IssueTable.tsx
+++ b/dashboard/src/components/IssueTable/IssueTable.tsx
@@ -188,12 +188,7 @@ export const IssueTable = ({ issueListing }: IIssueTable): JSX.Element => {
   const { listingSize } = useSearch({ from: '/_main/issues' });
   const navigate = useNavigate({ from: '/issues' });
 
-  const [sorting, setSorting] = useState<SortingState>([
-    {
-      id: 'first_seen',
-      desc: true,
-    },
-  ]);
+  const [sorting, setSorting] = useState<SortingState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     culprit: false,
   });

--- a/dashboard/src/components/Tabs/Filters.tsx
+++ b/dashboard/src/components/Tabs/Filters.tsx
@@ -54,7 +54,8 @@ export const mapFilterToReq = (filter: TFilter): TFilter => {
             filterMapped[reqField] = [];
           }
 
-          if (reqField.includes('issue')) {
+          if (reqField.endsWith('issue')) {
+            // combines the issue filter itself as "<issue_id>,<issue_version>"
             let issue_id = UNCATEGORIZED_STRING;
             let issue_version = null;
 

--- a/dashboard/src/components/Tabs/tabsUtils.ts
+++ b/dashboard/src/components/Tabs/tabsUtils.ts
@@ -14,7 +14,7 @@ export const cleanFalseFilters = (diffFilter: TFilter): TFilter => {
         const currentSection = cleanedFilter[filterSectionKey];
         Object.entries(filterSectionValue).forEach(
           ([filterKey, filterValue]) => {
-            if (currentSection) {
+            if (currentSection && filterValue) {
               currentSection[filterKey] = filterValue;
             }
           },

--- a/dashboard/src/pages/IssueListing/IssueListingPage.tsx
+++ b/dashboard/src/pages/IssueListing/IssueListingPage.tsx
@@ -14,6 +14,8 @@ import { matchesRegexOrIncludes } from '@/lib/string';
 import type { IssueListingResponse } from '@/types/issueListing';
 import { useSearchStore } from '@/hooks/store/useSearchStore';
 
+import { mapFilterToReq } from '@/components/Tabs/Filters';
+
 interface IIssueListingPage {
   inputFilter: string;
 }
@@ -21,8 +23,12 @@ interface IIssueListingPage {
 export const IssueListingPage = ({
   inputFilter,
 }: IIssueListingPage): JSX.Element => {
-  const { data, status, error, isLoading } = useIssueListing();
   const searchParams = useSearch({ from: '/_main/issues' });
+  const { diffFilter } = searchParams;
+  const requestFilters = mapFilterToReq(diffFilter);
+
+  const { data, status, error, isLoading } = useIssueListing(requestFilters);
+
   const updatePreviousSearch = useSearchStore(s => s.updatePreviousSearch);
 
   useEffect(

--- a/dashboard/src/routes/_main/issues/route.tsx
+++ b/dashboard/src/routes/_main/issues/route.tsx
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import {
   makeZIntervalInDays,
+  zDiffFilter,
   zListingSize,
   type SearchSchema,
 } from '@/types/general';
@@ -12,22 +13,24 @@ import {
   REDUCED_TIME_SEARCH,
 } from '@/utils/constants/general';
 
+const DEFAULT_ISSUE_LISTING_DIFFFILTER = {
+  issueCulprits: {
+    code: true,
+  },
+};
+
 export const issueListingDefaultValues = {
   intervalInDays: REDUCED_TIME_SEARCH,
   issueSearch: '',
   listingSize: DEFAULT_LISTING_ITEMS,
-  culpritCode: true,
-  culpritTool: false,
-  culpritHarness: false,
+  diffFilter: DEFAULT_ISSUE_LISTING_DIFFFILTER,
 };
 
 export const issueListingSearchSchema = z.object({
   intervalInDays: makeZIntervalInDays(REDUCED_TIME_SEARCH),
   issueSearch: z.string().catch(''),
   listingSize: zListingSize,
-  culpritCode: z.boolean().catch(true),
-  culpritTool: z.boolean().catch(false),
-  culpritHarness: z.boolean().catch(false),
+  diffFilter: zDiffFilter.default(DEFAULT_ISSUE_LISTING_DIFFFILTER),
 } satisfies SearchSchema);
 
 export const Route = createFileRoute('/_main/issues')({

--- a/dashboard/src/utils/search.ts
+++ b/dashboard/src/utils/search.ts
@@ -151,9 +151,6 @@ const generalMinifiedParams: Record<SearchParamsKeys, string> = {
   endTimestampInSeconds: 'et',
   issueVersion: 'iv',
   logOpen: 'l',
-  culpritCode: 'cc',
-  culpritHarness: 'ch',
-  culpritTool: 'ct',
 } as const;
 
 const treeInfoMinifiedParams: Record<keyof TTreeInformation, string> = {
@@ -190,6 +187,7 @@ const diffFilterMinifiedParams: Record<TFilterKeys, string> = {
   buildIssue: 'bi',
   bootIssue: 'bti',
   testIssue: 'ti',
+  issueCulprits: 'icu',
 };
 
 type MinifiedParams = Record<

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -1,10 +1,7 @@
 import { format } from 'date-fns';
 
 import type { IListingItem } from '@/components/ListingItem/ListingItem';
-import type {
-  AccordionItemBuilds,
-  TTreeDetailsFilter,
-} from '@/types/tree/TreeDetails';
+import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
 import type {
   Architecture,
   BuildsTabBuild,
@@ -158,22 +155,32 @@ export const sanitizeBuildsSummary = (
     ? buildsSummary
     : { FAIL: 0, NULL: 0, PASS: 0, ERROR: 0, MISS: 0, DONE: 0, SKIP: 0 };
 
-// TODO, remove this function, is just a step further towards the final implementation
-export const mapFiltersKeysToBackendCompatible = (
-  filter: TTreeDetailsFilter | Record<string, never>,
+/**
+ * Maps an object (Record or another class) from {"key": "value"} or {"key": ["value"]} to {"filter_key": ["value"]}
+ *
+ * @param instance - the object to make compatible with backend filters
+ *
+ * @returns a formatted Record<string, string[]> where the keys start with "filter_" and the values are an array of strings
+ */
+export const mapFiltersKeysToBackendCompatible = <T extends object>(
+  instance: T,
 ): Record<string, string[]> => {
-  const filterParam: { [key: string]: string[] } = {};
+  const filterParam: Record<string, string[]> = {};
 
-  Object.keys(filter).forEach(key => {
-    const filterList = filter[key as keyof TTreeDetailsFilter];
-    filterList?.forEach(value => {
-      if (!filterParam[`filter_${key}`]) {
-        filterParam[`filter_${key}`] = [value.toString()];
-      } else {
-        filterParam[`filter_${key}`].push(value.toString());
-      }
-    });
-  });
+  for (const [key, value] of Object.entries(instance)) {
+    const filterKey = `filter_${key}`;
+    if (!filterParam[filterKey]) {
+      filterParam[filterKey] = [];
+    }
+
+    if (!Array.isArray(value)) {
+      filterParam[filterKey] = [String(value)];
+    } else {
+      value.forEach(entry => {
+        filterParam[filterKey].push(String(entry));
+      });
+    }
+  }
 
   return filterParam;
 };


### PR DESCRIPTION
Refactors issue listing to remove the old culprit system and allow for a more expansive approach with `diffFilter`, allowing future changes to add more filters.
The issue culprits are separate fields in the database, but since they are about the same idea, they can be grouped inside of diffFilter, which sends groups of filters to the backend.

## Changes
- Swaps django query constructor for SQL raw query in issueListing endpoint
- Changes filtering from query layer to python layer
- Changes frontend query parameter structure from individual culprit fields to `diffFilter`
- (piggybacking) fixing a one-line problem that the cache database was always being created as an unstaged file in the backend root directory when running locally

## How to test
The default hardcoded filter by culprit code is still being applied, so going to the issue listing page should show the same result as the production issue listing page.
It is possible to filter by other culprits by adding `?df|icu|tool=true` or `?df|icu|harness=true` in the url or through the api by adding `filter_issue.culprit=tool` or `filter_issue.culprit=harness`. It is also possible to combine those filters.

Closes #1235 
Part of #1074 