### PR TITLE
notifications: add info for all Maestro trees

### DIFF
--- a/backend/data/notifications/subscriptions/amlogic.yaml
+++ b/backend/data/notifications/subscriptions/amlogic.yaml
@@ -2,4 +2,3 @@ amlogic:
   url: https://git.kernel.org/pub/scm/linux/kernel/git/amlogic/linux.git
   default_recipients:
     - linux-amlogic@lists.infradead.org
-

--- a/backend/data/notifications/subscriptions/amlogic.yaml
+++ b/backend/data/notifications/subscriptions/amlogic.yaml
@@ -1,0 +1,5 @@
+amlogic:
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/amlogic/linux.git
+  default_recipients:
+    - linux-amlogic@lists.infradead.org
+

--- a/backend/data/notifications/subscriptions/ardb.yaml
+++ b/backend/data/notifications/subscriptions/ardb.yaml
@@ -1,0 +1,4 @@
+ardb:
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/ardb/linux.git
+  default_recipients:
+    - ardb@kernel.org

--- a/backend/data/notifications/subscriptions/arm64.yaml
+++ b/backend/data/notifications/subscriptions/arm64.yaml
@@ -1,6 +1,8 @@
 arm64:
   url: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
-  
+  default_recipients:
+    - will@kernel.org
+    - linux-arm-kernel@lists.infradead.org
   reports:
     - default:
       branch: for-kernelci

--- a/backend/data/notifications/subscriptions/arnd.yaml
+++ b/backend/data/notifications/subscriptions/arnd.yaml
@@ -1,0 +1,4 @@
+arnd:
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/arnd/playground.git
+  default_recipients:
+    - arnd@arndb.de

--- a/backend/data/notifications/subscriptions/broonie-misc.yaml
+++ b/backend/data/notifications/subscriptions/broonie-misc.yaml
@@ -1,0 +1,4 @@
+broonie-misc:
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/broonie/misc.git
+  default_recipients:
+    - broonie@kernel.org

--- a/backend/data/notifications/subscriptions/broonie-regmap.yaml
+++ b/backend/data/notifications/subscriptions/broonie-regmap.yaml
@@ -1,0 +1,4 @@
+broonie-regmap:
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/broonie/regmap.git
+  default_recipients:
+    - broonie@kernel.org

--- a/backend/data/notifications/subscriptions/chrome-platform.yaml
+++ b/backend/data/notifications/subscriptions/chrome-platform.yaml
@@ -1,5 +1,5 @@
 chrome-platform:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/linux.git
   default_recipients:
     - chrome-platform@lists.linux.dev
     - tzungbi@kernel.org

--- a/backend/data/notifications/subscriptions/chrome-platform.yaml
+++ b/backend/data/notifications/subscriptions/chrome-platform.yaml
@@ -1,0 +1,5 @@
+chrome-platform:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/linux.git"
+  default_recipients:
+    - chrome-platform@lists.linux.dev
+    - tzungbi@kernel.org

--- a/backend/data/notifications/subscriptions/chromiumos.yaml
+++ b/backend/data/notifications/subscriptions/chromiumos.yaml
@@ -1,5 +1,5 @@
 chromiumos:
-  url: "https://chromium.googlesource.com/chromiumos/third_party/kernel.git"
+  url: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
   default_recipients:
     - laura.nao@collabora.com
     - shreeya.patel@collabora.com

--- a/backend/data/notifications/subscriptions/chromiumos.yaml
+++ b/backend/data/notifications/subscriptions/chromiumos.yaml
@@ -1,5 +1,5 @@
 chromiumos:
-  url: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
+  url: "https://chromium.googlesource.com/chromiumos/third_party/kernel.git"
   default_recipients:
     - laura.nao@collabora.com
     - shreeya.patel@collabora.com

--- a/backend/data/notifications/subscriptions/cip.yaml
+++ b/backend/data/notifications/subscriptions/cip.yaml
@@ -1,0 +1,4 @@
+cip:
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git
+  default_recipients:
+    - cip-dev@lists.cip-project.org

--- a/backend/data/notifications/subscriptions/clk.yaml
+++ b/backend/data/notifications/subscriptions/clk.yaml
@@ -1,0 +1,5 @@
+clk:
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/clk/linux.git
+  default_recipients:
+    - linux-clk@vger.kernel.org
+    - sboyd@kernel.org

--- a/backend/data/notifications/subscriptions/efi.yaml
+++ b/backend/data/notifications/subscriptions/efi.yaml
@@ -1,4 +1,4 @@
 efi:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/efi/efi.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/efi/efi.git
   default_recipients:
     - ardb@kernel.org

--- a/backend/data/notifications/subscriptions/efi.yaml
+++ b/backend/data/notifications/subscriptions/efi.yaml
@@ -1,0 +1,4 @@
+efi:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/efi/efi.git"
+  default_recipients:
+    - ardb@kernel.org

--- a/backend/data/notifications/subscriptions/khilman.yaml
+++ b/backend/data/notifications/subscriptions/khilman.yaml
@@ -1,4 +1,4 @@
 khilman:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux.git
   default_recipients:
     - khilman@kernel.org

--- a/backend/data/notifications/subscriptions/khilman.yaml
+++ b/backend/data/notifications/subscriptions/khilman.yaml
@@ -1,0 +1,4 @@
+khilman:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/khilman/linux.git"
+  default_recipients:
+    - khilman@kernel.org

--- a/backend/data/notifications/subscriptions/krzysztof.yaml
+++ b/backend/data/notifications/subscriptions/krzysztof.yaml
@@ -1,0 +1,4 @@
+krzysztof:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/krzk/linux.git"
+  default_recipients:
+    - krzk@kernel.org

--- a/backend/data/notifications/subscriptions/krzysztof.yaml
+++ b/backend/data/notifications/subscriptions/krzysztof.yaml
@@ -1,4 +1,4 @@
 krzysztof:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/krzk/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/krzk/linux.git
   default_recipients:
     - krzk@kernel.org

--- a/backend/data/notifications/subscriptions/kselftest.yaml
+++ b/backend/data/notifications/subscriptions/kselftest.yaml
@@ -1,0 +1,4 @@
+kselftest:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git"
+  default_recipients:
+    - shuah@kernel.org

--- a/backend/data/notifications/subscriptions/kselftest.yaml
+++ b/backend/data/notifications/subscriptions/kselftest.yaml
@@ -1,4 +1,4 @@
 kselftest:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/shuah/linux-kselftest.git
   default_recipients:
     - shuah@kernel.org

--- a/backend/data/notifications/subscriptions/lee-backlight.yaml
+++ b/backend/data/notifications/subscriptions/lee-backlight.yaml
@@ -1,4 +1,4 @@
 lee-backlight:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/backlight.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/lee/backlight.git
   default_recipients:
     - lee@kernel.org

--- a/backend/data/notifications/subscriptions/lee-backlight.yaml
+++ b/backend/data/notifications/subscriptions/lee-backlight.yaml
@@ -1,0 +1,4 @@
+lee-backlight:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/backlight.git"
+  default_recipients:
+    - lee@kernel.org

--- a/backend/data/notifications/subscriptions/lee-mfd.yaml
+++ b/backend/data/notifications/subscriptions/lee-mfd.yaml
@@ -1,0 +1,4 @@
+lee-mfd:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git"
+  default_recipients:
+    - lee@kernel.org

--- a/backend/data/notifications/subscriptions/lee-mfd.yaml
+++ b/backend/data/notifications/subscriptions/lee-mfd.yaml
@@ -1,4 +1,4 @@
 lee-mfd:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/lee/mfd.git
   default_recipients:
     - lee@kernel.org

--- a/backend/data/notifications/subscriptions/linux-pci.yaml
+++ b/backend/data/notifications/subscriptions/linux-pci.yaml
@@ -1,4 +1,4 @@
 linux-pci:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/pci/pci.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/pci/pci.git
   default_recipients:
     - linux-pci@vger.kernel.org

--- a/backend/data/notifications/subscriptions/linux-pci.yaml
+++ b/backend/data/notifications/subscriptions/linux-pci.yaml
@@ -1,0 +1,4 @@
+linux-pci:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/pci/pci.git"
+  default_recipients:
+    - linux-pci@vger.kernel.org

--- a/backend/data/notifications/subscriptions/media-committers.yaml
+++ b/backend/data/notifications/subscriptions/media-committers.yaml
@@ -1,6 +1,8 @@
 media-committers:
   url: https://gitlab.freedesktop.org/linux-media/media-committers.git
-  
+  default_recipients:
+    - linux-media@vger.kernel.org
+
   reports:
     - fixes:
       branch: fixes

--- a/backend/data/notifications/subscriptions/media.yaml
+++ b/backend/data/notifications/subscriptions/media.yaml
@@ -1,4 +1,4 @@
 media:
-  url: "https://git.linuxtv.org/media.git"
+  url: https://git.linuxtv.org/media.git
   default_recipients:
     - media@linuxtv.org

--- a/backend/data/notifications/subscriptions/media.yaml
+++ b/backend/data/notifications/subscriptions/media.yaml
@@ -1,0 +1,4 @@
+media:
+  url: "https://git.linuxtv.org/media.git"
+  default_recipients:
+    - media@linuxtv.org

--- a/backend/data/notifications/subscriptions/next.yaml
+++ b/backend/data/notifications/subscriptions/next.yaml
@@ -1,11 +1,4 @@
 next:
   url: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-  
-  reports:
-    - default:
-      branch: master
-      always: True
-    
-    - microsoft:
-      branch: master
-      origin: microsoft
+  default_recipients:
+    - linux-next@vger.kernel.org

--- a/backend/data/notifications/subscriptions/padovan.yaml
+++ b/backend/data/notifications/subscriptions/padovan.yaml
@@ -1,4 +1,4 @@
 padovan:
-  url: "https://github.com/padovan/linux.git"
+  url: https://github.com/padovan/linux.git
   default_recipients:
     - padovan@kernel.org

--- a/backend/data/notifications/subscriptions/padovan.yaml
+++ b/backend/data/notifications/subscriptions/padovan.yaml
@@ -1,0 +1,4 @@
+padovan:
+  url: "https://github.com/padovan/linux.git"
+  default_recipients:
+    - padovan@kernel.org

--- a/backend/data/notifications/subscriptions/pm.yaml
+++ b/backend/data/notifications/subscriptions/pm.yaml
@@ -1,4 +1,4 @@
 pm:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git
   default_recipients:
     - rafael@kernel.org

--- a/backend/data/notifications/subscriptions/pm.yaml
+++ b/backend/data/notifications/subscriptions/pm.yaml
@@ -1,0 +1,4 @@
+pm:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/rafael/linux-pm.git"
+  default_recipients:
+    - rafael@kernel.org

--- a/backend/data/notifications/subscriptions/qcom.yaml
+++ b/backend/data/notifications/subscriptions/qcom.yaml
@@ -1,5 +1,5 @@
 qcom:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git
   default_recipients:
     - linux-arm-msm@vger.kernel.org
     - Bjorn Andersson <andersson@kernel.org>

--- a/backend/data/notifications/subscriptions/qcom.yaml
+++ b/backend/data/notifications/subscriptions/qcom.yaml
@@ -1,0 +1,5 @@
+qcom:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/qcom/linux.git"
+  default_recipients:
+    - linux-arm-msm@vger.kernel.org
+    - Bjorn Andersson <andersson@kernel.org>

--- a/backend/data/notifications/subscriptions/renesas.yaml
+++ b/backend/data/notifications/subscriptions/renesas.yaml
@@ -1,4 +1,4 @@
 renesas:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git
   default_recipients:
     - linux-renesas-soc@vger.kernel.org

--- a/backend/data/notifications/subscriptions/renesas.yaml
+++ b/backend/data/notifications/subscriptions/renesas.yaml
@@ -1,0 +1,4 @@
+renesas:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/geert/renesas-devel.git"
+  default_recipients:
+    - linux-renesas-soc@vger.kernel.org

--- a/backend/data/notifications/subscriptions/riscv.yaml
+++ b/backend/data/notifications/subscriptions/riscv.yaml
@@ -1,0 +1,4 @@
+riscv:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux.git"
+  default_recipients:
+    - linux-riscv@lists.infradead.org

--- a/backend/data/notifications/subscriptions/riscv.yaml
+++ b/backend/data/notifications/subscriptions/riscv.yaml
@@ -1,4 +1,4 @@
 riscv:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/riscv/linux.git
   default_recipients:
     - linux-riscv@lists.infradead.org

--- a/backend/data/notifications/subscriptions/robh.yaml
+++ b/backend/data/notifications/subscriptions/robh.yaml
@@ -1,5 +1,5 @@
 robh:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/robh/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/robh/linux.git
   default_recipients:
     - robh@kernel.org
     - devicetree@vger.kernel.org

--- a/backend/data/notifications/subscriptions/robh.yaml
+++ b/backend/data/notifications/subscriptions/robh.yaml
@@ -1,0 +1,5 @@
+robh:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/robh/linux.git"
+  default_recipients:
+    - robh@kernel.org
+    - devicetree@vger.kernel.org

--- a/backend/data/notifications/subscriptions/rppt.yaml
+++ b/backend/data/notifications/subscriptions/rppt.yaml
@@ -1,0 +1,5 @@
+rppt:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/rppt/memblock.git"
+  default_recipients:
+    - rppt@kernel.org
+    - linux-mm@kvack.org

--- a/backend/data/notifications/subscriptions/rppt.yaml
+++ b/backend/data/notifications/subscriptions/rppt.yaml
@@ -1,5 +1,5 @@
 rppt:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/rppt/memblock.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/rppt/memblock.git
   default_recipients:
     - rppt@kernel.org
     - linux-mm@kvack.org

--- a/backend/data/notifications/subscriptions/soc.yaml
+++ b/backend/data/notifications/subscriptions/soc.yaml
@@ -1,4 +1,4 @@
 soc:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/soc/soc.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/soc/soc.git
   default_recipients:
     - soc@lists.linux.dev

--- a/backend/data/notifications/subscriptions/soc.yaml
+++ b/backend/data/notifications/subscriptions/soc.yaml
@@ -1,0 +1,4 @@
+soc:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/soc/soc.git"
+  default_recipients:
+    - soc@lists.linux.dev

--- a/backend/data/notifications/subscriptions/stable-rc.yaml
+++ b/backend/data/notifications/subscriptions/stable-rc.yaml
@@ -1,0 +1,4 @@
+stable-rc:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git"
+  default_recipients:
+    - stable-rc@kernel.org

--- a/backend/data/notifications/subscriptions/stable-rc.yaml
+++ b/backend/data/notifications/subscriptions/stable-rc.yaml
@@ -1,4 +1,4 @@
 stable-rc:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git
   default_recipients:
     - stable-rc@kernel.org

--- a/backend/data/notifications/subscriptions/stable-rt.yaml
+++ b/backend/data/notifications/subscriptions/stable-rt.yaml
@@ -1,7 +1,9 @@
 # Note: do not confuse with stable-rc
 stable-rt:
   url: https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git
-  
+  default_recipients:
+    - linux-rt-devel@lists.linux.dev
+
   reports:
     - v5.4-rt:
       branch: v5.4-rt

--- a/backend/data/notifications/subscriptions/tegra.yaml
+++ b/backend/data/notifications/subscriptions/tegra.yaml
@@ -1,0 +1,4 @@
+tegra:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/tegra/linux.git"
+  default_recipients:
+    - linux-tegra@vger.kernel.org

--- a/backend/data/notifications/subscriptions/tegra.yaml
+++ b/backend/data/notifications/subscriptions/tegra.yaml
@@ -1,4 +1,4 @@
 tegra:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/tegra/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/tegra/linux.git
   default_recipients:
     - linux-tegra@vger.kernel.org

--- a/backend/data/notifications/subscriptions/thermal.yaml
+++ b/backend/data/notifications/subscriptions/thermal.yaml
@@ -1,4 +1,4 @@
 thermal:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/thermal/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/thermal/linux.git
   default_recipients:
     - linux-pm@vger.kernel.org

--- a/backend/data/notifications/subscriptions/thermal.yaml
+++ b/backend/data/notifications/subscriptions/thermal.yaml
@@ -1,0 +1,4 @@
+thermal:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/thermal/linux.git"
+  default_recipients:
+    - linux-pm@vger.kernel.org

--- a/backend/data/notifications/subscriptions/tip.yaml
+++ b/backend/data/notifications/subscriptions/tip.yaml
@@ -1,4 +1,4 @@
 tip:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
   default_recipients:
     - tip@kernel.org

--- a/backend/data/notifications/subscriptions/tip.yaml
+++ b/backend/data/notifications/subscriptions/tip.yaml
@@ -1,0 +1,4 @@
+tip:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git"
+  default_recipients:
+    - tip@kernel.org

--- a/backend/data/notifications/subscriptions/ulfh.yaml
+++ b/backend/data/notifications/subscriptions/ulfh.yaml
@@ -1,0 +1,4 @@
+ulfh:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/ulfh/mmc.git"
+  default_recipients:
+    - linux-mmc@vger.kernel.org

--- a/backend/data/notifications/subscriptions/ulfh.yaml
+++ b/backend/data/notifications/subscriptions/ulfh.yaml
@@ -1,4 +1,4 @@
 ulfh:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/ulfh/mmc.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/ulfh/mmc.git
   default_recipients:
     - linux-mmc@vger.kernel.org

--- a/backend/data/notifications/subscriptions/vireshk.yaml
+++ b/backend/data/notifications/subscriptions/vireshk.yaml
@@ -1,4 +1,4 @@
 vireshk:
-  url: "https://git.kernel.org/pub/scm/linux/kernel/git/vireshk/linux.git"
+  url: https://git.kernel.org/pub/scm/linux/kernel/git/vireshk/linux.git
   default_recipients:
     - vireshk@kernel.org

--- a/backend/data/notifications/subscriptions/vireshk.yaml
+++ b/backend/data/notifications/subscriptions/vireshk.yaml
@@ -1,0 +1,4 @@
+vireshk:
+  url: "https://git.kernel.org/pub/scm/linux/kernel/git/vireshk/linux.git"
+  default_recipients:
+    - vireshk@kernel.org


### PR DESCRIPTION
We need to set the recipients for all trees, so notifications can reach to the right people.

Continuation of PR #1233 