### PR TITLE
Refactor: move build tests up in the page

### DIFF
--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -263,12 +263,6 @@ const BuildDetails = ({
     treeDetailsLink,
   ]);
 
-  const sectionsData: ISection[] = useMemo(() => {
-    return [...generalSections, filesSection, miscSection].filter(
-      section => section !== undefined,
-    );
-  }, [generalSections, miscSection, filesSection]);
-
   const buildDetailsTabTitle: string = useMemo(() => {
     const buildTitle = `${data?.tree_name} ${data?.git_commit_name}`;
     return formatMessage(
@@ -297,20 +291,25 @@ const BuildDetails = ({
       >
         <ErrorBoundary FallbackComponent={UnexpectedError}>
           <Sheet open={logOpen} onOpenChange={logOpenChange}>
-            {breadcrumb}
-
-            <SectionGroup sections={sectionsData} />
-            <BuildDetailsTestSection
-              buildId={buildId ?? ''}
-              onClickFilter={onClickFilter}
-              tableFilter={tableFilter}
-              getRowLink={getTestTableRowLink}
-            />
-            <IssueSection
-              data={issueData}
-              status={issueStatus}
-              error={issueError?.message}
-            />
+            <div className="flex flex-col gap-4 pb-8">
+              {breadcrumb}
+              <SectionGroup sections={generalSections} />
+              <BuildDetailsTestSection
+                buildId={buildId ?? ''}
+                onClickFilter={onClickFilter}
+                tableFilter={tableFilter}
+                getRowLink={getTestTableRowLink}
+              />
+              {miscSection && <SectionGroup sections={[miscSection]} />}
+              {issueData && (
+                <IssueSection
+                  data={issueData}
+                  status={issueStatus}
+                  error={issueError?.message}
+                />
+              )}
+              {filesSection && <SectionGroup sections={[filesSection]} />}
+            </div>
             <LogOrJsonSheetContent
               type={sheetType}
               jsonContent={jsonContent}

--- a/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetailsTestSection.tsx
@@ -35,11 +35,11 @@ const BuildDetailsTestSection = ({
   const { data, error, status, isLoading } = useBuildTests(buildId);
 
   return (
-    <>
+    <div>
       <span className="text-2xl font-bold">
         {intl.formatMessage({ id: 'buildDetails.testResults' })}
       </span>
-      <Separator className="bg-dark-gray my-6" />
+      <Separator className="bg-dark-gray my-4" />
       <QuerySwitcher
         skeletonClassname="h-[100px]"
         status={status}
@@ -62,7 +62,7 @@ const BuildDetailsTestSection = ({
           />
         </div>
       </QuerySwitcher>
-    </>
+    </div>
   );
 };
 

--- a/dashboard/src/components/Issue/IssueSection.tsx
+++ b/dashboard/src/components/Issue/IssueSection.tsx
@@ -49,7 +49,7 @@ const IssueSection = ({
         return (
           <Link
             key={issue.id + issue.version}
-            className="mb-16 flex not-last:mb-2 not-last:border-b not-last:pb-2"
+            className="mb-12 flex not-last:mb-2 not-last:border-b not-last:pb-2"
             to="/issue/$issueId"
             params={{ issueId: issue.id }}
             state={s => s}
@@ -71,7 +71,7 @@ const IssueSection = ({
 
   return (
     <div>
-      <div className="mb-3 flex items-center gap-4 border-b border-gray-300 pb-3">
+      <div className="mb-3 flex items-center gap-4 border-b border-gray-300 pb-4">
         <h2 className="text-2xl font-semibold">
           <FormattedMessage id="global.issues" />
         </h2>


### PR DESCRIPTION
## Changes
- Rearranges the sections to put the test table right after the general information section, misc data right after, and then issue data, leaving the artifacts at the bottom;
- Makes it so that the issue section is not shown if a build has no issues;
- Also slightly changes the spacing to standardize it through the page.

## How to test
Go to a build details page and check the section rearrangement, comparing it to staging.

## Visual comparison
Old ([staging link](https://staging.dashboard.kernelci.org:9000/build/maestro%3A68342ef5fb37369f44a86dc9?iv=1))
![image](https://github.com/user-attachments/assets/d15d295d-7170-4e17-bdc2-9c86219cd5bb)

New ([localhost link](http://localhost:5173/build/maestro%3A68342ef5fb37369f44a86dc9?iv=1))
![image](https://github.com/user-attachments/assets/0d25702e-0e39-4c1a-97e4-8501b1334b95)


Closes #1245