### PR TITLE
messages: improve explanation when we have no results

### DIFF
--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -311,7 +311,7 @@ export const messages = {
     'treeDetails.inconclusiveBuilds': 'Inconclusive Builds',
     'treeDetails.inconclusiveTests': 'Inconclusive Tests',
     'treeDetails.invalidBuilds': 'Failed builds',
-    'treeDetails.notFound': 'Tree checkout not found',
+    'treeDetails.notFound': 'No results available for this tree/branch/commit',
     'treeDetails.successBoots': 'Success boots',
     'treeDetails.testsFailed': 'Failed tests',
     'treeDetails.testsHistory': 'Tests History',


### PR DESCRIPTION
We need to give clear message to the user if there is no results for a given tree/branch/commit.