### PR TITLE
Feat: show tests from all origins in treeDetails

### DIFF
--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -165,11 +165,6 @@ def get_hardware_filter(row_data: dict) -> Any:
     return hardware_filter
 
 
-def is_test_boots_test(row_data: dict) -> bool:
-    test_path = row_data["test_path"]
-    return is_boot(test_path)
-
-
 def get_build(row_data: dict) -> BuildHistoryItem:
     return BuildHistoryItem(
         id=row_data["build_id"],

--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -247,6 +247,7 @@ def query_records(
                 """
                 SELECT
                     tests.id,
+                    tests.origin AS test__origin,
                     tests.environment_misc,
                     tests.path,
                     tests.comment,
@@ -266,6 +267,7 @@ def query_records(
                     builds.duration AS build__duration,
                     builds.log_url AS build__log_url,
                     builds.start_time AS build__start_time,
+                    builds.origin AS build__origin,
                     checkouts.git_repository_url AS build__checkout__git_repository_url,
                     checkouts.git_repository_branch AS build__checkout__git_repository_branch,
                     checkouts.git_commit_name AS build__checkout__git_commit_name,

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -366,7 +366,7 @@ def get_tree_details_data(
         query = f"""
         SELECT
                 tests.id AS tests_id,
-                tests.origin AS tests_origin,
+                tests.origin,
                 tests.environment_comment AS tests_environment_comment,
                 tests.environment_misc AS tests_environment_misc,
                 tests.path AS tests_path,
@@ -390,6 +390,7 @@ def get_tree_details_data(
             (
                 SELECT
                     builds.id AS builds_id,
+                    builds.origin,
                     builds.comment AS builds_comment,
                     builds.start_time AS builds_start_time,
                     builds.duration AS builds_duration,
@@ -420,8 +421,6 @@ def get_tree_details_data(
                     ) AS tree_head
                 LEFT JOIN builds
                     ON tree_head.checkout_id = builds.checkout_id
-                WHERE
-                    tree_head.checkouts_origin = %(origin_param)s
             ) AS builds_filter
         LEFT JOIN tests
             ON builds_filter.builds_id = tests.build_id
@@ -431,9 +430,6 @@ def get_tree_details_data(
         LEFT JOIN issues
             ON incidents.issue_id = issues.id
             AND incidents.issue_version = issues.version
-        WHERE
-            tests.origin = %(origin_param)s OR
-            tests.origin IS NULL
         ORDER BY
             issues."_timestamp" DESC
         """

--- a/backend/kernelCI_app/tests/integrationTests/hardwareDetailsSummary_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/hardwareDetailsSummary_test.py
@@ -413,6 +413,7 @@ def test_filter_issues(issues_input):
 def test_invalid_filters(invalid_filters_input):
     empty_test = {
         "architectures": [],
+        "origins": {},
         "configs": {},
         "environment_compatible": None,
         "environment_misc": None,
@@ -434,6 +435,7 @@ def test_invalid_filters(invalid_filters_input):
 
     empty_build = {
         "architectures": {},
+        "origins": {},
         "configs": {},
         "issues": [],
         "status": {

--- a/backend/kernelCI_app/tests/integrationTests/treeDetailsSummary_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeDetailsSummary_test.py
@@ -386,6 +386,7 @@ def test_filter_issues(issues_input):
 def test_invalid_filters(invalid_filters_input):
     empty_test = {
         "architectures": [],
+        "origins": {},
         "configs": {},
         "environment_compatible": {},
         "environment_misc": {},
@@ -407,6 +408,7 @@ def test_invalid_filters(invalid_filters_input):
 
     empty_build = {
         "architectures": {},
+        "origins": {},
         "configs": {},
         "issues": [],
         "status": {

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -21,6 +21,7 @@ from kernelCI_app.typeModels.databases import (
     Build__Duration,
     Checkout__GitRepositoryUrl,
     Checkout__GitRepositoryBranch,
+    Origin,
 )
 from kernelCI_app.helpers.build import build_status_map
 
@@ -37,6 +38,7 @@ class BuildArchitectures(StatusCount):
 
 class TestHistoryItem(BaseModel):
     id: str
+    origin: Origin
     status: Optional[str]
     duration: Optional[Union[int, float]]
     path: Optional[str]
@@ -51,6 +53,7 @@ class TestHistoryItem(BaseModel):
 
 class BuildHistoryItem(BaseModel):
     id: Build__Id
+    origin: Origin
     architecture: Build__Architecture
     config_name: Build__ConfigName
     misc: Build__Misc
@@ -85,6 +88,7 @@ class BuildHistoryItem(BaseModel):
 
 class TestSummary(BaseModel):
     status: StatusCount
+    origins: dict[str, StatusCount]
     architectures: List[TestArchSummaryItem]
     configs: Dict[str, StatusCount]
     issues: List[Issue]
@@ -98,6 +102,7 @@ class TestSummary(BaseModel):
 
 class BuildSummary(BaseModel):
     status: StatusCount
+    origins: dict[str, StatusCount]
     architectures: Dict[str, BuildArchitectures]
     configs: Dict[str, StatusCount]
     issues: List[Issue]
@@ -118,6 +123,7 @@ class GlobalFilters(BaseModel):
 
 class LocalFilters(BaseModel):
     issues: List[Tuple[str, Optional[int]]]
+    origins: list[str]
     has_unknown_issue: bool
 
 

--- a/backend/kernelCI_app/viewCommon.py
+++ b/backend/kernelCI_app/viewCommon.py
@@ -10,6 +10,7 @@ def create_details_build_summary(builds: BuildHistoryItem) -> dict:
     build_summ = create_default_build_status()
     config_summ = {}
     arch_summ = {}
+    origin_summ = {}
 
     for build in builds:
         status_key = build.status
@@ -29,8 +30,13 @@ def create_details_build_summary(builds: BuildHistoryItem) -> dict:
             if compiler and compiler not in status.setdefault("compilers", []):
                 status["compilers"].append(compiler)
 
+        if origin := build.origin:
+            status = origin_summ.setdefault(origin, create_default_build_status())
+            status[status_key] += 1
+
     return {
         "builds": build_summ,
         "configs": config_summ,
         "architectures": arch_summ,
+        "origins": origin_summ,
     }

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -124,6 +124,12 @@ class HardwareDetailsSummary(APIView):
         self.tree_status_summary = defaultdict(generate_tree_status_summary_dict)
         self.compatibles: List[str] = []
 
+        self.unfiltered_origins: dict[str, set[str]] = {
+            "build": set(),
+            "boot": set(),
+            "test": set(),
+        }
+
     def _process_test(self, record: Dict) -> None:
         is_record_boot = is_boot(record["path"])
         test_type_key: PossibleTestType = "boot" if is_record_boot else "test"
@@ -335,6 +341,7 @@ class HardwareDetailsSummary(APIView):
                         has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
                             "build"
                         ],
+                        origins=sorted(self.unfiltered_origins["build"]),
                     ),
                     boots=HardwareTestLocalFilters(
                         issues=list(self.unfiltered_boot_issues),
@@ -342,6 +349,7 @@ class HardwareDetailsSummary(APIView):
                         has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
                             "boot"
                         ],
+                        origins=sorted(self.unfiltered_origins["boot"]),
                     ),
                     tests=HardwareTestLocalFilters(
                         issues=list(self.unfiltered_test_issues),
@@ -349,6 +357,7 @@ class HardwareDetailsSummary(APIView):
                         has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
                             "test"
                         ],
+                        origins=sorted(self.unfiltered_origins["test"]),
                     ),
                 ),
                 common=HardwareCommon(

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -105,6 +105,12 @@ class HardwareDetails(APIView):
 
         self.tree_status_summary = defaultdict(generate_tree_status_summary_dict)
 
+        self.unfiltered_origins: dict[str, set[str]] = {
+            "build": set(),
+            "boot": set(),
+            "test": set(),
+        }
+
     def _process_test(self, record: Dict) -> None:
         is_record_boot = is_boot(record["path"])
         test_type_key: PossibleTestType = "boot" if is_record_boot else "test"
@@ -298,6 +304,7 @@ class HardwareDetails(APIView):
                 summary=Summary(
                     builds=BuildSummary(
                         status=self.builds["summary"]["builds"],
+                        origins=self.builds["summary"]["origins"],
                         architectures=self.builds["summary"]["architectures"],
                         configs=self.builds["summary"]["configs"],
                         issues=self.builds["issues"],
@@ -305,6 +312,7 @@ class HardwareDetails(APIView):
                     ),
                     boots=TestSummary(
                         status=self.boots["statusSummary"],
+                        origins=self.boots["origins"],
                         architectures=self.boots["archSummary"],
                         configs=self.boots["configs"],
                         issues=self.boots["issues"],
@@ -315,6 +323,7 @@ class HardwareDetails(APIView):
                     ),
                     tests=TestSummary(
                         status=self.tests["statusSummary"],
+                        origins=self.tests["origins"],
                         architectures=self.tests["archSummary"],
                         configs=self.tests["configs"],
                         issues=self.tests["issues"],
@@ -335,6 +344,7 @@ class HardwareDetails(APIView):
                         has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
                             "build"
                         ],
+                        origins=sorted(self.unfiltered_origins["build"]),
                     ),
                     boots=HardwareTestLocalFilters(
                         issues=list(self.unfiltered_boot_issues),
@@ -342,6 +352,7 @@ class HardwareDetails(APIView):
                         has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
                             "boot"
                         ],
+                        origins=sorted(self.unfiltered_origins["boot"]),
                     ),
                     tests=HardwareTestLocalFilters(
                         issues=list(self.unfiltered_test_issues),
@@ -349,6 +360,7 @@ class HardwareDetails(APIView):
                         has_unknown_issue=self.unfiltered_uncategorized_issue_flags[
                             "test"
                         ],
+                        origins=sorted(self.unfiltered_origins["test"]),
                     ),
                 ),
                 common=HardwareCommon(

--- a/backend/kernelCI_app/views/treeDetailsBootsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBootsView.py
@@ -12,7 +12,6 @@ from kernelCI_app.helpers.treeDetails import (
     decide_if_is_boot_filtered_out,
     decide_if_is_full_row_filtered_out,
     get_current_row_data,
-    is_test_boots_test,
 )
 from kernelCI_app.queries.tree import get_tree_details_data
 from kernelCI_app.typeModels.treeDetails import (
@@ -22,6 +21,7 @@ from kernelCI_app.typeModels.commonDetails import (
     CommonDetailsBootsResponse,
     TestHistoryItem,
 )
+from kernelCI_app.utils import is_boot
 
 
 class TreeDetailsBoots(APIView):
@@ -55,7 +55,7 @@ class TreeDetailsBoots(APIView):
             if row_data["test_id"] is None:
                 continue
 
-            if is_test_boots_test(row_data):
+            if is_boot(row_data["test_path"]):
                 self._process_boots_test(row_data)
 
     @extend_schema(

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -14,7 +14,6 @@ from kernelCI_app.helpers.treeDetails import (
     get_build,
     get_current_row_data,
     process_tree_url,
-    is_test_boots_test,
     process_boots_summary,
     process_builds_issue,
     process_test_summary,
@@ -36,7 +35,7 @@ from kernelCI_app.typeModels.treeDetails import (
     TreeCommon,
     TreeQueryParameters,
 )
-from kernelCI_app.utils import convert_issues_dict_to_list_typed
+from kernelCI_app.utils import convert_issues_dict_to_list_typed, is_boot
 
 from collections import defaultdict
 
@@ -166,7 +165,7 @@ class TreeDetailsSummary(APIView):
             if row_data["test_id"] is None:
                 continue
 
-            if is_test_boots_test(row_data):
+            if is_boot(row_data["test_path"]):
                 self._process_boots_test(row_data)
             else:
                 self._process_non_boots_test(row_data)

--- a/backend/kernelCI_app/views/treeDetailsTestsView.py
+++ b/backend/kernelCI_app/views/treeDetailsTestsView.py
@@ -11,7 +11,6 @@ from kernelCI_app.helpers.treeDetails import (
     decide_if_is_full_row_filtered_out,
     decide_if_is_test_filtered_out,
     get_current_row_data,
-    is_test_boots_test,
 )
 from kernelCI_app.queries.tree import get_tree_details_data
 from kernelCI_app.typeModels.treeDetails import (
@@ -21,6 +20,7 @@ from kernelCI_app.typeModels.commonDetails import (
     CommonDetailsTestsResponse,
     TestHistoryItem,
 )
+from kernelCI_app.utils import is_boot
 
 
 class TreeDetailsTests(APIView):
@@ -58,7 +58,7 @@ class TreeDetailsTests(APIView):
             if row_data["test_id"] is None:
                 continue
 
-            if is_test_boots_test(row_data):
+            if is_boot(row_data["test_path"]):
                 continue
             else:
                 self._process_non_boots_test(row_data)

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -18,7 +18,6 @@ from kernelCI_app.helpers.treeDetails import (
     get_build,
     get_current_row_data,
     process_tree_url,
-    is_test_boots_test,
     process_boots_summary,
     process_builds_issue,
     process_test_summary,
@@ -34,7 +33,7 @@ from kernelCI_app.typeModels.commonDetails import (
     Summary,
     TestSummary,
 )
-from kernelCI_app.utils import convert_issues_dict_to_list_typed
+from kernelCI_app.utils import convert_issues_dict_to_list_typed, is_boot
 
 from collections import defaultdict
 
@@ -171,7 +170,7 @@ class TreeDetails(APIView):
             if row_data["test_id"] is None:
                 continue
 
-            if is_test_boots_test(row_data):
+            if is_boot(row_data["test_path"]):
                 self._process_boots_test(row_data)
             else:
                 self._process_non_boots_test(row_data)

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1205,6 +1205,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/Build__Id'
+        origin:
+          $ref: '#/components/schemas/Origin'
         architecture:
           $ref: '#/components/schemas/Build__Architecture'
         config_name:
@@ -1241,8 +1243,6 @@ components:
           $ref: '#/components/schemas/Checkout__GitCommitName'
         git_commit_tags:
           $ref: '#/components/schemas/Checkout__GitCommitTags'
-        origin:
-          $ref: '#/components/schemas/Origin'
         log_excerpt:
           $ref: '#/components/schemas/Build__LogExcerpt'
         input_files:
@@ -1251,6 +1251,7 @@ components:
           $ref: '#/components/schemas/Build__OutputFiles'
       required:
       - id
+      - origin
       - architecture
       - config_name
       - misc
@@ -1269,7 +1270,6 @@ components:
       - git_commit_hash
       - git_commit_name
       - git_commit_tags
-      - origin
       - log_excerpt
       - input_files
       - output_files
@@ -1279,6 +1279,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/Build__Id'
+        origin:
+          $ref: '#/components/schemas/Origin'
         architecture:
           $ref: '#/components/schemas/Build__Architecture'
         config_name:
@@ -1303,6 +1305,7 @@ components:
           $ref: '#/components/schemas/Checkout__GitRepositoryBranch'
       required:
       - id
+      - origin
       - architecture
       - config_name
       - misc
@@ -1320,6 +1323,11 @@ components:
       properties:
         status:
           $ref: '#/components/schemas/StatusCount'
+        origins:
+          additionalProperties:
+            $ref: '#/components/schemas/StatusCount'
+          title: Origins
+          type: object
         architectures:
           additionalProperties:
             $ref: '#/components/schemas/BuildArchitectures'
@@ -1340,6 +1348,7 @@ components:
           type: integer
       required:
       - status
+      - origins
       - architectures
       - configs
       - issues
@@ -1802,6 +1811,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/Build__Id'
+        origin:
+          $ref: '#/components/schemas/Origin'
         architecture:
           $ref: '#/components/schemas/Build__Architecture'
         config_name:
@@ -1836,6 +1847,7 @@ components:
           - type: 'null'
       required:
       - id
+      - origin
       - architecture
       - config_name
       - misc
@@ -2084,6 +2096,8 @@ components:
         id:
           title: Id
           type: string
+        origin:
+          $ref: '#/components/schemas/Origin'
         status:
           anyOf:
           - type: string
@@ -2145,6 +2159,7 @@ components:
           $ref: '#/components/schemas/Checkout__GitRepositoryBranch'
       required:
       - id
+      - origin
       - status
       - duration
       - path
@@ -2173,6 +2188,11 @@ components:
             type: array
           title: Issues
           type: array
+        origins:
+          items:
+            type: string
+          title: Origins
+          type: array
         has_unknown_issue:
           title: Has Unknown Issue
           type: boolean
@@ -2183,6 +2203,7 @@ components:
           type: array
       required:
       - issues
+      - origins
       - has_unknown_issue
       - platforms
       title: HardwareTestLocalFilters
@@ -2522,11 +2543,17 @@ components:
             type: array
           title: Issues
           type: array
+        origins:
+          items:
+            type: string
+          title: Origins
+          type: array
         has_unknown_issue:
           title: Has Unknown Issue
           type: boolean
       required:
       - issues
+      - origins
       - has_unknown_issue
       title: LocalFilters
       type: object
@@ -2768,6 +2795,8 @@ components:
         id:
           title: Id
           type: string
+        origin:
+          $ref: '#/components/schemas/Origin'
         status:
           anyOf:
           - type: string
@@ -2825,6 +2854,7 @@ components:
           - type: 'null'
       required:
       - id
+      - origin
       - status
       - duration
       - path
@@ -2905,6 +2935,11 @@ components:
       properties:
         status:
           $ref: '#/components/schemas/StatusCount'
+        origins:
+          additionalProperties:
+            $ref: '#/components/schemas/StatusCount'
+          title: Origins
+          type: object
         architectures:
           items:
             $ref: '#/components/schemas/TestArchSummaryItem'
@@ -2955,6 +2990,7 @@ components:
           title: Platforms
       required:
       - status
+      - origins
       - architectures
       - configs
       - issues


### PR DESCRIPTION
In some cases a checkout with origin A will have builds with origin B, and a build with origin B might have tests with origin C.

## Changes
- Alters tree details query to allow tests and builds with origins different from the checkout origin;
- Returns build and tests origins from tree and hardware endpoints

## How to test
For most trees, check that the return in the items, `summary` and `filters` fields now include their origin
In more specific cases, check that this [localhost stable-rc tree](http://localhost:5173/tree/stable-rc/linux-6.6.y/18952a1fc4ac790deb4faa116f18310d7010a9fb) includes tests from riscv (check the summary response in the network tab), and this [localhost next master tree](http://localhost:5173/tree/next/master/2a628f951ed54c30a232230b5b58349d2a8dbb11) includes boots from ti.
Also check if other endpoints are still working correctly.
This [localhost test](http://localhost:5173/test/riscv%3A94baee65fddf236ba716ceadad6d6753b3119861ea4082366a0cf35a8b5c7a73) is an example of a test from a origin that doesn't have builds

Closes #1250 
Also Closes #1239 since the problem there was a build that had tests but all tests were from a different origin