### PR TITLE
Refactor: remove hardware used box

### DIFF
--- a/dashboard/src/components/Cards/HardwareTested.tsx
+++ b/dashboard/src/components/Cards/HardwareTested.tsx
@@ -11,7 +11,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 
 import type { TFilter } from '@/types/general';
 
-import FilterLink from '../Tabs/FilterLink';
+import FilterLink from '@/components/Tabs/FilterLink';
 
 interface IHardwareTested
   extends Pick<TTreeTestsData, 'environmentCompatible'> {
@@ -67,4 +67,4 @@ const HardwareTested = ({
   );
 };
 
-export default memo(HardwareTested);
+export const MemoizedHardwareTested = memo(HardwareTested);

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -7,7 +7,7 @@ import { useCallback, useMemo, type JSX } from 'react';
 
 import { BootsTable } from '@/components/BootsTable/BootsTable';
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
-import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
+import { MemoizedHardwareTested } from '@/components/Cards/HardwareTested';
 import {
   zTableFilterInfoDefault,
   type PossibleTableFilters,

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -269,32 +269,3 @@ const StatusChart = ({ statusCounts, title }: IStatusChart): JSX.Element => {
 };
 
 export const MemoizedStatusChart = memo(StatusChart);
-
-interface IHardwareUsed {
-  title: IBaseCard['title'];
-  hardwareUsed?: string[];
-}
-
-const HardwareUsed = ({ hardwareUsed, title }: IHardwareUsed): JSX.Element => {
-  const hardwareSorted = useMemo(() => {
-    return hardwareUsed?.sort().map(hardware => {
-      return (
-        <Badge key={hardware} variant="outline" className="text-sm font-normal">
-          {hardware}
-        </Badge>
-      );
-    });
-  }, [hardwareUsed]);
-
-  return (
-    <BaseCard
-      title={title}
-      content={
-        <div className="flex flex-row flex-wrap gap-4 p-4">
-          {hardwareSorted}
-        </div>
-      }
-    />
-  );
-};
-export const MemoizedHardwareUsed = memo(HardwareUsed);

--- a/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TestCards.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage } from 'react-intl';
-import { memo, useMemo, type JSX } from 'react';
+import { memo, type JSX } from 'react';
 
 import { DumbListingContent } from '@/components/ListingContent/ListingContent';
 import type { IBaseCard } from '@/components/Cards/BaseCard';
@@ -16,7 +16,6 @@ import { groupStatus } from '@/utils/status';
 import type { ArchCompilerStatus } from '@/types/general';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
-import { Badge } from '@/components/ui/badge';
 import FilterLink from '@/components/Tabs/FilterLink';
 import { DumbSummary, MemoizedSummaryItem } from '@/components/Tabs/Summary';
 

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/types/tree/TreeDetails';
 
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
-import MemoizedHardwareTested from '@/components/Cards/HardwareTested';
+import { MemoizedHardwareTested } from '@/components/Cards/HardwareTested';
 
 import { TestsTable } from '@/components/TestsTable/TestsTable';
 import {

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -34,8 +34,6 @@ import { GroupedTestStatus } from '@/components/Status/Status';
 
 import type { TFilter } from '@/types/general';
 
-import MemoizedHardwareUsed from '@/components/Cards/HardwareUsed';
-
 import { mapFilterToReq } from '@/components/Tabs/Filters';
 
 import DetailsFilterList from '@/components/Tabs/FilterList';
@@ -171,11 +169,7 @@ function TreeDetails(): JSX.Element {
     filter: reqFilter,
   });
 
-  const {
-    data,
-    isLoading,
-    status: summaryQueryStatus,
-  } = treeDetailsLazyLoaded.summary;
+  const { data, isLoading } = treeDetailsLazyLoaded.summary;
 
   const treeRouterStatus = useRouterState({
     select: s => s.location.state.treeStatusCount,
@@ -361,16 +355,6 @@ function TreeDetails(): JSX.Element {
             commitName={treeInfo?.commitName}
             commitTags={data?.common.git_commit_tags}
           />
-        </div>
-        <div className="mt-5">
-          {data && (
-            <MemoizedHardwareUsed
-              title={<FormattedMessage id="treeDetails.hardwareUsed" />}
-              hardwareUsed={data?.common.hardware}
-              diffFilter={diffFilter}
-              queryStatus={summaryQueryStatus}
-            />
-          )}
         </div>
         <div className="flex flex-col pb-2">
           <div className="sticky top-[4.5rem] z-10">


### PR DESCRIPTION
## Changes
- Removes the HardwareUsed card that was at the top of treeDetails page
- Removed duplicate HardwareTested component

## How to test
Go to treeDetails page and check that the hardwareUsed at the top is no longer there. All tabs and other pages should still behave normally.

Closes #1244 