### PR TITLE
Fix: copy tooltip values by selection

### DIFF
--- a/dashboard/src/components/Tooltip/CommitTagTooltip.tsx
+++ b/dashboard/src/components/Tooltip/CommitTagTooltip.tsx
@@ -47,12 +47,14 @@ export const CommitTagTooltip = ({
   });
 
   return (
-    <>
+    <div>
       <Tooltip>
-        <TooltipTrigger>{content}</TooltipTrigger>
+        <TooltipTrigger asChild>
+          <span>{content}</span>
+        </TooltipTrigger>
         <TooltipContent>{hover}</TooltipContent>
       </Tooltip>
       {copyButton && <CopyButton value={content} />}
-    </>
+    </div>
   );
 };

--- a/dashboard/src/components/TooltipDateTime/TooltipDateTime.tsx
+++ b/dashboard/src/components/TooltipDateTime/TooltipDateTime.tsx
@@ -45,7 +45,7 @@ const TooltipDateTime = ({
 
   return (
     <Tooltip>
-      <TooltipTrigger>
+      <TooltipTrigger asChild>
         {showRelative ? (
           <div className="text-start">
             {message && <span className="pl-2">{message}</span>}
@@ -55,7 +55,7 @@ const TooltipDateTime = ({
             />
           </div>
         ) : (
-          <span>
+          <span className="text-center">
             {date} {showLabelTime ? time : ''} {showLabelTZ ? tz : ''}
           </span>
         )}

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -134,13 +134,15 @@ const TreeHeader = ({
           <TableCell>{gitBranch ?? '-'}</TableCell>
           <TableCell>{commitTagTooltip}</TableCell>
           <TableCell>
-            <Tooltip>
-              <TooltipTrigger>
-                {truncateUrl(gitUrl, defaultUrlLength)}
-              </TooltipTrigger>
-              <TooltipContent>{gitUrl}</TooltipContent>
-            </Tooltip>
-            {gitUrl && <CopyButton value={gitUrl} />}
+            <div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>{truncateUrl(gitUrl, defaultUrlLength)}</span>
+                </TooltipTrigger>
+                <TooltipContent>{gitUrl}</TooltipContent>
+              </Tooltip>
+              {gitUrl && <CopyButton value={gitUrl} />}
+            </div>
           </TableCell>
         </TableRow>
       </TableBody>


### PR DESCRIPTION
Values under tooltipTrigger were treated as buttons, not allowing for selecting the text

## Changes
- Added `asChild` to the TooltipTrigger of the TreeDetailsHeader cell and to the datetime tooltip
- Adjusted the necessary components to keep the layout correct

## How to test
- Go to TreeDetails and check that now you can select the values for commit hash/tag and url
- Other tooltips should still work normally and the styling should not break

Closes #1252