### PR TITLE
Fix: wrong test sheet opening

### DIFF
--- a/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
+++ b/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
@@ -24,6 +24,7 @@ import WrapperTableWithLogSheet from '@/pages/TreeDetails/Tabs/WrapperTableWithL
 import { TableRowMemoized } from '@/components/Table/TableComponents';
 
 const ESTIMATED_ROW_HEIGHT = 60;
+const VIRTUALIZER_OVERSCAN = 5;
 
 interface IIndividualTestsTable {
   columns: ColumnDef<TIndividualTest>[];
@@ -46,6 +47,7 @@ export function IndividualTestsTable({
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     manualPagination: true,
+    getRowId: row => row.id,
     state: {
       sorting,
     },
@@ -76,7 +78,7 @@ export function IndividualTestsTable({
     count: modelRows.length,
     estimateSize: () => ESTIMATED_ROW_HEIGHT,
     getScrollElement: () => parentRef.current,
-    overscan: 5,
+    overscan: VIRTUALIZER_OVERSCAN,
   });
   const virtualItems = virtualizer.getVirtualItems();
 
@@ -91,12 +93,12 @@ export function IndividualTestsTable({
   const openLogSheet = useCallback((index: number) => setLog(index), [setLog]);
 
   const tableRows = useMemo((): JSX.Element[] => {
-    return virtualItems.map((virtualRow, idx) => {
+    return virtualItems.map(virtualRow => {
       const row = modelRows[virtualRow.index] as Row<TIndividualTest>;
       return (
         <TableRowMemoized<TIndividualTest>
           key={row.id}
-          index={idx}
+          index={virtualRow.index}
           row={row}
           openLogSheet={openLogSheet}
           currentLog={currentLog}


### PR DESCRIPTION
The individual tests table was opening the wrong log when scrolled down to virtualized items.
The idx of the virtual rows was being used instead of the index of all the rows, causing the sheet to show wrong logs once the visible rows were no longer the first ones.

Being more specific, the TableRowMemoized component receives the `openLogSheet` function and the `index` property, and after passing it down what it actually does is trigger the `setLog` setter to mark which `index` of the data the log belongs to. The problem was that it was using the index of the mapping from virtual rows, which are only the rows that are visible, so the index was always in a small range from 0 to around 15. The fix was to use the `virtualRows.index` instead, which holds the real index of each virtualized row (the index of the original row that that virtual row points to, not just of the ones visible).

## Changes
- Changes the index passed to the IndividualTestsTable rows
- Some other small changes in the file regarding code structure

## How to test
- Go to any test table, open the individualTestsTable, scroll down until the virtualization changes which rows are visible, open the log and check that that log really belongs to the test that you clicked on.
- Compare the behavior with staging/production instance.
Example: [build details page](https://dashboard.kernelci.org/build/maestro%3A682807b0fef071f536bfb26f), check the hardware of the test you click vs what appears in the log sheet

Closes #1231