### PR TITLE
Refactor: change checkout not found messages

### DIFF
--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -1,0 +1,15 @@
+# This file implements a rough start for localization,
+# but it doesn't implement the entire localization system.
+
+from enum import StrEnum, _simple_enum
+
+
+# TODO: replace this enum with a proper localization system
+@_simple_enum(StrEnum)
+class ClientStrings:
+    """Simple class for storing basis for internationalization strings"""
+
+    TREE_BUILDS_NOT_FOUND = "No builds available for this tree/branch/commit"
+    TREE_BOOTS_NOT_FOUND = "No boots available for this tree/branch/commit"
+    TREE_NOT_FOUND = "No results available for this tree/branch/commit"
+    TREE_TESTS_NOT_FOUND = "No tests available for this tree/branch/commit"

--- a/backend/kernelCI_app/views/treeDetailsBootsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBootsView.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
@@ -76,7 +77,7 @@ class TreeDetailsBoots(APIView):
 
         if len(rows) == 0:
             return create_api_error_response(
-                error_message="Tree checkout not found",
+                error_message=ClientStrings.TREE_NOT_FOUND,
                 status_code=HTTPStatus.OK,
             )
 
@@ -84,7 +85,7 @@ class TreeDetailsBoots(APIView):
             row_data = get_current_row_data(current_row=rows[0])
             if row_data["test_id"] is None:
                 return create_api_error_response(
-                    error_message="No boots found for this tree checkout",
+                    error_message=ClientStrings.TREE_BOOTS_NOT_FOUND,
                     status_code=HTTPStatus.OK,
                 )
 

--- a/backend/kernelCI_app/views/treeDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBuildsView.py
@@ -4,6 +4,7 @@ from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
@@ -79,7 +80,7 @@ class TreeDetailsBuilds(APIView):
 
         if len(rows) == 0:
             return create_api_error_response(
-                error_message="Tree checkout not found",
+                error_message=ClientStrings.TREE_NOT_FOUND,
                 status_code=HTTPStatus.OK,
             )
 
@@ -92,7 +93,7 @@ class TreeDetailsBuilds(APIView):
                 )
                 send_discord_notification(content=notification)
                 return create_api_error_response(
-                    error_message="No builds found for this tree checkout",
+                    error_message=ClientStrings.TREE_BUILDS_NOT_FOUND,
                     status_code=HTTPStatus.OK,
                 )
 

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 from pydantic import ValidationError
 from rest_framework.response import Response
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
 from kernelCI_app.helpers.filters import FilterParams
@@ -210,7 +211,7 @@ class TreeDetailsSummary(APIView):
 
         if len(rows) == 0:
             return create_api_error_response(
-                error_message="Tree checkout not found",
+                error_message=ClientStrings.TREE_NOT_FOUND,
                 status_code=HTTPStatus.OK,
             )
 
@@ -223,7 +224,7 @@ class TreeDetailsSummary(APIView):
                 )
                 send_discord_notification(content=notification)
                 return create_api_error_response(
-                    error_message="No builds found for this tree checkout",
+                    error_message=ClientStrings.TREE_BUILDS_NOT_FOUND,
                     status_code=HTTPStatus.OK,
                 )
 

--- a/backend/kernelCI_app/views/treeDetailsTestsView.py
+++ b/backend/kernelCI_app/views/treeDetailsTestsView.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from http import HTTPStatus
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
@@ -80,7 +81,7 @@ class TreeDetailsTests(APIView):
 
         if len(rows) == 0:
             return create_api_error_response(
-                error_message="Tree checkout not found",
+                error_message=ClientStrings.TREE_NOT_FOUND,
                 status_code=HTTPStatus.OK,
             )
 
@@ -88,7 +89,7 @@ class TreeDetailsTests(APIView):
             row_data = get_current_row_data(current_row=rows[0])
             if row_data["test_id"] is None:
                 return create_api_error_response(
-                    error_message="No tests found for this tree checkout",
+                    error_message=ClientStrings.TREE_TESTS_NOT_FOUND,
                     status_code=HTTPStatus.OK,
                 )
 

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List
 from http import HTTPStatus
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
 from kernelCI_app.helpers.filters import FilterParams
@@ -217,7 +218,7 @@ class TreeDetails(APIView):
 
         if len(rows) == 0:
             return create_api_error_response(
-                error_message="Tree checkout not found",
+                error_message=ClientStrings.TREE_NOT_FOUND,
                 status_code=HTTPStatus.OK,
             )
 
@@ -230,7 +231,7 @@ class TreeDetails(APIView):
                 )
                 send_discord_notification(content=notification)
                 return create_api_error_response(
-                    error_message="No builds found for this tree checkout",
+                    error_message=ClientStrings.TREE_BUILDS_NOT_FOUND,
                     status_code=HTTPStatus.OK,
                 )
 

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -190,7 +190,7 @@ export const messages = {
     'issue.alsoPresentTooltip': 'Issue also present in {tree}',
     'issue.firstSeen': 'First seen',
     'issue.newIssue': 'New issue: This is the first time this issue was seen',
-    'issue.noIssueFound': 'No issues found for this tree checkout',
+    'issue.noIssueFound': 'No issues found for this tree/branch/commit',
     'issue.path': 'Issues',
     'issue.searchPlaceholder': 'Search by issue comment with a regex',
     'issue.tooltip':
@@ -311,7 +311,7 @@ export const messages = {
     'treeDetails.inconclusiveBuilds': 'Inconclusive Builds',
     'treeDetails.inconclusiveTests': 'Inconclusive Tests',
     'treeDetails.invalidBuilds': 'Failed builds',
-    'treeDetails.notFound': 'Tree checkout not found',
+    'treeDetails.notFound': 'No results available for this tree/branch/commit',
     'treeDetails.successBoots': 'Success boots',
     'treeDetails.testsFailed': 'Failed tests',
     'treeDetails.testsHistory': 'Tests History',


### PR DESCRIPTION
Although the 'not found' is the usual message, it may confuse some users specially when seeing the 'checkout' word, which doesn't concern users that only send build or tests

## Changes
- Changes both endpoint messages and frontend "tree checkout not found" messages
- Also changes a issue not found message, moving it to "tree/branch/commit" format

## How to test
Go to any treeDetails endpoint with a checkout that has no data or a checkout that doesn't exist. Check the backend response for all endpoints (summary, full, builds, boots, tests) and check the frontend message as well.

Closes #1257