### PR TITLE
Fix: allow other test origins in hd

### DIFF
--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -396,7 +396,6 @@ def get_hardware_trees_data(
             Tests.objects.filter(
                 models.Q(environment_compatible__contains=[hardware_id])
                 | models.Q(environment_misc__platform=hardware_id),
-                origin=origin,
                 build__checkout__start_time__lte=end_datetime,
                 build__checkout__start_time__gte=start_datetime,
                 build__checkout__git_commit_hash__in=Subquery(trees_subquery),

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -366,6 +366,8 @@ function HardwareDetails(): JSX.Element {
             isLoading={summaryResponse.isLoading}
             errorMessage={summaryResponse.error?.message}
             emptyLabel="hardwareDetails.notFound"
+            forceErrorMessageUse
+            variant="warning"
           />
         }
       >


### PR DESCRIPTION
The test origin filter in the query was tied to the checkout origin, but now the origin filter only applies to the checkout, not the test.

The hardware listing and hardware commit history already had no filter for test origins.

## Changes
- Removes origin filter in the hardware details query
- Adds flag to hardware details error component in the frontend, allowing to show the error message more clearly

## How to test
- Browse hardwares from other origins, currently there are many from `ti` and check that they don't break when entering them, such as this [localhost ti,j7200-evm](http://localhost:5173/hardware/ti%2Cj7200-evm?et=1748971800&st=1748539800) vs [production ti,j7200-evm](https://dashboard.kernelci.org/hardware/ti%2Cj7200-evm?et=1748975400&st=1748543400)


Closes #1207