### PR TITLE
Refactor: change origin endpoint structure

### DIFF
--- a/backend/kernelCI_app/queries/checkout.py
+++ b/backend/kernelCI_app/queries/checkout.py
@@ -1,18 +1,32 @@
+from django.db import connection
 from kernelCI_app.cache import get_query_cache, set_query_cache
-from kernelCI_app.models import Checkouts
+from kernelCI_app.helpers.database import dict_fetchall
 
-ORIGINS_QUERY_KEY = "origins"
+ORIGINS_QUERY_KEY = "origins_query"
 ORIGINS_CACHE_TIMEOUT = 12 * 60 * 60  # 12 hours
 
 
-def get_origins() -> list[str]:
+def get_origins() -> list[dict[str, str]]:
     origins = get_query_cache(key=ORIGINS_QUERY_KEY)
+
     if origins is None:
-        origins = [
-            checkout["origin"]
-            for checkout in Checkouts.objects.values("origin").distinct()
-        ]
-        set_query_cache(
-            key=ORIGINS_QUERY_KEY, rows=origins, timeout=ORIGINS_CACHE_TIMEOUT
-        )
+        query = """
+            SELECT
+                DISTINCT C.ORIGIN AS origin,
+                'checkouts' AS table
+            FROM
+                CHECKOUTS C
+            """
+
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            records = dict_fetchall(cursor=cursor)
+            if records:
+                set_query_cache(
+                    key=ORIGINS_QUERY_KEY,
+                    rows=records,
+                    timeout=ORIGINS_CACHE_TIMEOUT,
+                )
+            return records
+
     return origins

--- a/backend/kernelCI_app/typeModels/origins.py
+++ b/backend/kernelCI_app/typeModels/origins.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+from kernelCI_app.typeModels.databases import Origin
+
+
+class OriginsResponse(BaseModel):
+    checkout_origins: list[Origin]

--- a/backend/kernelCI_app/views/originsView.py
+++ b/backend/kernelCI_app/views/originsView.py
@@ -1,25 +1,70 @@
 from http import HTTPStatus
+
+from pydantic import ValidationError
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.queries.checkout import get_origins
 from drf_spectacular.utils import extend_schema
+
+from kernelCI_app.typeModels.origins import OriginsResponse
 
 EXCLUDED_ORIGINS = ["kernelci"]
 
 
+def separate_origin_records(*, records: list[dict[str, str]]) -> set[str]:
+    """Iterates over the records for origins and returns a set for each table defined by those records
+
+    Params:
+      records: a list of records in the form of {"origin": "foo", "table": "bar"}
+
+    Returns:
+      The origin sets for each table"""
+
+    if not records:
+        return set()
+
+    checkout_origins: set[str] = set()
+    for record in records:
+        origin = record.get("origin")
+        if not origin or origin in EXCLUDED_ORIGINS:
+            continue
+
+        table = record.get("table")
+        match table:
+            case "checkouts":
+                checkout_origins.add(origin)
+            case _:
+                log_message(f"Unable to treat table {table} in origins view")
+
+    return checkout_origins
+
+
 class OriginsView(APIView):
+    def __init__(self):
+        self.checkout_origins: set[str] = set()
+
     @extend_schema(
-        responses={HTTPStatus.OK: list[str], HTTPStatus.BAD_REQUEST: dict[str, str]},
+        responses={
+            HTTPStatus.OK: OriginsResponse,
+            HTTPStatus.BAD_REQUEST: dict[str, str],
+        },
         methods=["GET"],
     )
     def get(self, _request) -> Response:
-        origins = get_origins()
-        if len(origins) == 0:
+        origin_records = get_origins()
+
+        if len(origin_records) == 0:
             return create_api_error_response(error_message="No origins found")
 
-        for excluded in EXCLUDED_ORIGINS:
-            if excluded in origins:
-                origins.remove(excluded)
+        self.checkout_origins = separate_origin_records(records=origin_records)
 
-        return Response(origins)
+        try:
+            valid_response = OriginsResponse(
+                checkout_origins=sorted(self.checkout_origins)
+            )
+        except ValidationError as e:
+            return Response(e.json(), HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        return Response(valid_response.model_dump())

--- a/backend/requests/origins-get.sh
+++ b/backend/requests/origins-get.sh
@@ -2,24 +2,25 @@ http 'http://localhost:8000/api/origins/'
 
 # HTTP/1.1 200 OK
 # Allow: GET, HEAD, OPTIONS
-# Content-Length: 88
+# Content-Length: 98
 # Content-Type: application/json
 # Cross-Origin-Opener-Policy: same-origin
-# Date: Wed, 02 Apr 2025 20:19:29 GMT
+# Date: Wed, 04 Jun 2025 14:22:51 GMT
 # Referrer-Policy: same-origin
 # Server: WSGIServer/0.2 CPython/3.12.7
 # Vary: Accept, Cookie, origin
 # X-Content-Type-Options: nosniff
 # X-Frame-Options: DENY
 
-# [
-#     "0dayci",
-#     "arm",
-#     "broonie",
-#     "kernelci",
-#     "maestro",
-#     "microsoft",
-#     "redhat",
-#     "syzbot",
-#     "tuxsuite"
-# ]
+# {
+#     "checkout_origins": [
+#         "0dayci",
+#         "arm",
+#         "broonie",
+#         "maestro",
+#         "microsoft",
+#         "redhat",
+#         "syzbot",
+#         "tuxsuite"
+#     ]
+# }

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -518,9 +518,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
+                $ref: '#/components/schemas/OriginsResponse'
           description: ''
         '400':
           content:
@@ -2599,6 +2597,17 @@ components:
       type: object
     Origin:
       type: string
+    OriginsResponse:
+      properties:
+        checkout_origins:
+          items:
+            $ref: '#/components/schemas/Origin'
+          title: Checkout Origins
+          type: array
+      required:
+      - checkout_origins
+      title: OriginsResponse
+      type: object
     PossibleIssueTags:
       enum:
       - mainline

--- a/dashboard/src/api/origin.ts
+++ b/dashboard/src/api/origin.ts
@@ -2,16 +2,18 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { MILLISECONDS_IN_ONE_HOUR } from '@/utils/date';
 
+import type { OriginsResponse } from '@/types/origins';
+
 import { RequestData } from './commonRequest';
 
-const fetchOrigins = async (): Promise<string[]> => {
-  const data = await RequestData.get<string[]>('/api/origins/');
+const fetchOrigins = async (): Promise<OriginsResponse> => {
+  const data = await RequestData.get<OriginsResponse>('/api/origins/');
   return data;
 };
 
 const ORIGIN_CACHE_DURATION = 2 * MILLISECONDS_IN_ONE_HOUR;
 
-export const useOrigins = (): UseQueryResult<string[]> => {
+export const useOrigins = (): UseQueryResult<OriginsResponse> => {
   return useQuery({
     queryKey: ['origins'],
     queryFn: () => fetchOrigins(),

--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -26,7 +26,7 @@ const getTargetPath = (basePath: string): PossibleMonitorPath => {
 
 const OriginSelect = ({ basePath }: { basePath: string }): JSX.Element => {
   const { origin } = useSearch({ strict: false });
-  const validOrigins = useOrigins();
+  const { data: originData, status: originStatus } = useOrigins();
 
   const targetPath = getTargetPath(basePath);
   const navigate = useNavigate({ from: targetPath });
@@ -41,15 +41,17 @@ const OriginSelect = ({ basePath }: { basePath: string }): JSX.Element => {
     [navigate, targetPath],
   );
 
-  const selectItems = useMemo(
-    () =>
-      validOrigins.data?.map(option => (
-        <SelectItem key={option} value={option}>
-          {option}
-        </SelectItem>
-      )),
-    [validOrigins.data],
-  );
+  const selectItems = useMemo(() => {
+    if (originData === undefined) {
+      return <></>;
+    }
+
+    return originData?.checkout_origins.map(option => (
+      <SelectItem key={option} value={option}>
+        {option}
+      </SelectItem>
+    ));
+  }, [originData]);
 
   useEffect(() => {
     if (origin === undefined) {
@@ -62,7 +64,7 @@ const OriginSelect = ({ basePath }: { basePath: string }): JSX.Element => {
     }
   });
 
-  if (validOrigins.status === 'pending') {
+  if (originStatus === 'pending') {
     return <FormattedMessage id="global.loading" />;
   }
 

--- a/dashboard/src/types/origins.ts
+++ b/dashboard/src/types/origins.ts
@@ -1,0 +1,3 @@
+export type OriginsResponse = {
+  checkout_origins: string[];
+};


### PR DESCRIPTION
This new structure allows adding other origins in the future and also better follows the structure we are using in other endpoints

## Changes
- Replaces origins query for a raw sql query
- Alters the response/request structure from a simple array to a dict of fields where each field shows the origins per table (currently only checkouts)

## How to test
This is only a refactor of the current behavior, no additions are made, and the endpoint should be working like before.

Part of #1242