### PR TITLE
Fix: build error on treeDetails

### DIFF
--- a/backend/kernelCI_app/helpers/build.py
+++ b/backend/kernelCI_app/helpers/build.py
@@ -5,7 +5,7 @@ from kernelCI_app.helpers.environment import get_schema_version
 from kernelCI_app.typeModels.databases import PASS_STATUS, FAIL_STATUS, NULL_STATUS
 
 
-def build_status_map(status: Optional[bool | str]) -> str:
+def build_status_map(status: Optional[bool | str | None]) -> str:
     if isinstance(status, str):
         return status
     status_map = {True: PASS_STATUS, False: FAIL_STATUS, None: NULL_STATUS}

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -100,11 +100,14 @@ class TestSummary(BaseModel):
     platforms: Optional[Dict[str, StatusCount]] = None
 
 
-class BuildSummary(BaseModel):
-    status: StatusCount
-    origins: dict[str, StatusCount]
-    architectures: Dict[str, BuildArchitectures]
-    configs: Dict[str, StatusCount]
+class BaseBuildSummary(BaseModel):
+    status: StatusCount = Field(default_factory=StatusCount)
+    origins: dict[str, StatusCount] = Field(default_factory=dict)
+    architectures: dict[str, BuildArchitectures] = Field(default_factory=dict)
+    configs: dict[str, StatusCount] = Field(default_factory=dict)
+
+
+class BuildSummary(BaseBuildSummary):
     issues: List[Issue]
     unknown_issues: int
 

--- a/backend/kernelCI_app/viewCommon.py
+++ b/backend/kernelCI_app/viewCommon.py
@@ -1,42 +1,44 @@
-from kernelCI_app.typeModels.commonDetails import BuildHistoryItem
+from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.commonDetails import (
+    BaseBuildSummary,
+    BuildArchitectures,
+    BuildHistoryItem,
+)
 
 
-# TODO: Change this for a pydantic model
-def create_default_build_status() -> dict:
-    return {"PASS": 0, "FAIL": 0, "NULL": 0}
+def _increment_status(var: StatusCount, status_key):
+    """Increments a specific status_key (PASS, FAIL...) of a StatusCount var"""
+    setattr(var, status_key, getattr(var, status_key) + 1)
 
 
-def create_details_build_summary(builds: BuildHistoryItem) -> dict:
-    build_summ = create_default_build_status()
-    config_summ = {}
-    arch_summ = {}
-    origin_summ = {}
+def create_details_build_summary(builds: list[BuildHistoryItem]) -> BaseBuildSummary:
+    status_summ = StatusCount()
+    config_summ: dict[str, StatusCount] = {}
+    arch_summ: dict[str, BuildArchitectures] = {}
+    origin_summ: dict[str, StatusCount] = {}
 
     for build in builds:
         status_key = build.status
-        build_summ[status_key] += 1
+        _increment_status(status_summ, status_key)
 
         if config := build.config_name:
-            status = config_summ.get(config)
-            if not status:
-                status = create_default_build_status()
-                config_summ[config] = status
-            status[status_key] += 1
+            status = config_summ.setdefault(config, StatusCount())
+            _increment_status(status, status_key)
 
         if arch := build.architecture:
-            status = arch_summ.setdefault(arch, create_default_build_status())
-            status[status_key] += 1
+            status = arch_summ.setdefault(arch, BuildArchitectures())
+            _increment_status(status, status_key)
             compiler = build.compiler
-            if compiler and compiler not in status.setdefault("compilers", []):
-                status["compilers"].append(compiler)
+            if compiler and compiler not in status.compilers:
+                status.compilers.append(compiler)
 
         if origin := build.origin:
-            status = origin_summ.setdefault(origin, create_default_build_status())
-            status[status_key] += 1
+            status = origin_summ.setdefault(origin, StatusCount())
+            _increment_status(status, status_key)
 
-    return {
-        "builds": build_summ,
-        "configs": config_summ,
-        "architectures": arch_summ,
-        "origins": origin_summ,
-    }
+    return BaseBuildSummary(
+        status=status_summ,
+        configs=config_summ,
+        architectures=arch_summ,
+        origins=origin_summ,
+    )

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -35,6 +35,7 @@ from kernelCI_app.queries.hardware import (
     get_hardware_trees_data,
 )
 from kernelCI_app.typeModels.commonDetails import (
+    BaseBuildSummary,
     BuildSummary,
     GlobalFilters,
     LocalFilters,
@@ -110,6 +111,9 @@ class HardwareDetails(APIView):
             "boot": set(),
             "test": set(),
         }
+
+        # TODO: move to a BuildSummary model and combine with self.builds above
+        self.base_build_summary = BaseBuildSummary()
 
     def _process_test(self, record: Dict) -> None:
         is_record_boot = is_boot(record["path"])
@@ -276,7 +280,7 @@ class HardwareDetails(APIView):
 
         self._sanitize_records(records, trees_with_selected_commits, is_all_selected)
 
-        self.builds["summary"] = create_details_build_summary(self.builds["items"])
+        self.base_build_summary = create_details_build_summary(self.builds["items"])
         self._format_processing_for_response()
 
         self.unfiltered_uncategorized_issue_flags: Dict[PossibleTabs, bool] = {
@@ -303,10 +307,10 @@ class HardwareDetails(APIView):
                 tests=self.tests["history"],
                 summary=Summary(
                     builds=BuildSummary(
-                        status=self.builds["summary"]["builds"],
-                        origins=self.builds["summary"]["origins"],
-                        architectures=self.builds["summary"]["architectures"],
-                        configs=self.builds["summary"]["configs"],
+                        status=self.base_build_summary.status,
+                        origins=self.base_build_summary.origins,
+                        architectures=self.base_build_summary.architectures,
+                        configs=self.base_build_summary.configs,
                         issues=self.builds["issues"],
                         unknown_issues=self.builds["failedWithUnknownIssues"],
                     ),

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -23,6 +23,7 @@ from kernelCI_app.helpers.treeDetails import (
 )
 from kernelCI_app.queries.tree import get_tree_details_data
 from kernelCI_app.typeModels.commonDetails import (
+    BaseBuildSummary,
     BuildSummary,
     DetailsFilters,
     GlobalFilters,
@@ -104,7 +105,7 @@ class TreeDetailsSummary(APIView):
         }
 
         # TODO: move to a BuildSummary model and combine with the other fields above
-        self.build_summary: dict[str, Any] = {"origins": {}}
+        self.base_build_summary = BaseBuildSummary()
 
         # TODO: move to a TestSummary model and combine with the other fields above
         self.test_summary: dict[str, Any] = {"origins": {}}
@@ -184,7 +185,7 @@ class TreeDetailsSummary(APIView):
             else:
                 self._process_non_boots_test(row_data)
 
-        self.build_summary = create_details_build_summary(self.builds)
+        self.base_build_summary = create_details_build_summary(self.builds)
         self.build_issues = convert_issues_dict_to_list_typed(
             issues_dict=self.build_issues_dict
         )
@@ -241,10 +242,10 @@ class TreeDetailsSummary(APIView):
                 ),
                 summary=Summary(
                     builds=BuildSummary(
-                        status=self.build_summary["builds"],
-                        origins=self.build_summary["origins"],
-                        architectures=self.build_summary["architectures"],
-                        configs=self.build_summary["configs"],
+                        status=self.base_build_summary.status,
+                        origins=self.base_build_summary.origins,
+                        architectures=self.base_build_summary.architectures,
+                        configs=self.base_build_summary.configs,
                         issues=self.build_issues,
                         unknown_issues=self.failed_builds_with_unknown_issues,
                     ),

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -27,6 +27,7 @@ from kernelCI_app.helpers.treeDetails import (
 )
 from kernelCI_app.queries.tree import get_tree_details_data
 from kernelCI_app.typeModels.commonDetails import (
+    BaseBuildSummary,
     BuildSummary,
     DetailsFilters,
     GlobalFilters,
@@ -105,7 +106,7 @@ class TreeDetails(APIView):
         }
 
         # TODO: move to a BuildSummary model and combine with the other fields above
-        self.build_summary: dict[str, Any] = {"origins": {}}
+        self.base_build_summary = BaseBuildSummary()
 
         # TODO: move to a TestSummary model and combine with the other fields above
         self.test_summary: dict[str, Any] = {"origins": {}}
@@ -189,7 +190,7 @@ class TreeDetails(APIView):
             else:
                 self._process_non_boots_test(row_data)
 
-        self.build_summary = create_details_build_summary(self.builds)
+        self.base_build_summary = create_details_build_summary(self.builds)
         self.build_issues = convert_issues_dict_to_list_typed(
             issues_dict=self.build_issues_dict
         )
@@ -244,10 +245,10 @@ class TreeDetails(APIView):
                 tests=self.testHistory,
                 summary=Summary(
                     builds=BuildSummary(
-                        status=self.build_summary["builds"],
-                        origins=self.build_summary["origins"],
-                        architectures=self.build_summary["architectures"],
-                        configs=self.build_summary["configs"],
+                        status=self.base_build_summary.status,
+                        origins=self.base_build_summary.origins,
+                        architectures=self.base_build_summary.architectures,
+                        configs=self.base_build_summary.configs,
                         issues=self.build_issues,
                         unknown_issues=self.failed_builds_with_unknown_issues,
                     ),

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1345,10 +1345,6 @@ components:
           title: Unknown Issues
           type: integer
       required:
-      - status
-      - origins
-      - architectures
-      - configs
       - issues
       - unknown_issues
       title: BuildSummary


### PR DESCRIPTION
Fixes a bug where a function that creates the build summary wasn't accounting for builds with status other than pass/fail/null (the equivalents of the old schema). Having an error there was breaking the endpoint, and therefore, the tree summary and tree details page in the dashboard.

## Changes
- Removes hardcoded status dictionary and replaces with the `StatusCount` type
- Also type-checks all other fields in that function and returns a `BaseBuildSummary` model
- Consequent uses of that function are then used as models instead of dictionaries

## How to test
Check that the tree endpoints are working correctly, also check the hardware endpoints which used the problematic function too.
Example: [localhost mainline tree](http://localhost:5173/tree/e271ed52b344ac02d4581286961d0c40acc54c03?ti%7Cc=v6.15-12426-ge271ed52b344&ti%7Cch=e271ed52b344ac02d4581286961d0c40acc54c03&ti%7Cgb=master&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Ftorvalds%2Flinux.git&ti%7Ct=mainline) vs [staging mainline tree](https://staging.dashboard.kernelci.org:9000/tree/e271ed52b344ac02d4581286961d0c40acc54c03?ti%7Cc=v6.15-12426-ge271ed52b344&ti%7Cch=e271ed52b344ac02d4581286961d0c40acc54c03&ti%7Cgb=master&ti%7Cgu=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Ftorvalds%2Flinux.git&ti%7Ct=mainline)


Closes #1274