### PR TITLE
Feat: add test origins manually

### DIFF
--- a/backend/kernelCI_app/tests/integrationTests/origins_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/origins_test.py
@@ -1,0 +1,25 @@
+from http import HTTPStatus
+from kernelCI_app.tests.utils.client.originClient import OriginClient
+from kernelCI_app.tests.utils.asserts import (
+    assert_status_code_and_error_response,
+    assert_has_fields_in_response_content,
+)
+from kernelCI_app.utils import string_to_json
+from kernelCI_app.tests.utils.fields.origins import origins_expected_fields
+
+client = OriginClient()
+
+
+def test_get_origins():
+    response = client.get_origins()
+    content = string_to_json(response.content.decode())
+    assert_status_code_and_error_response(
+        response=response,
+        content=content,
+        status_code=HTTPStatus.OK,
+        should_error=False,
+    )
+
+    assert_has_fields_in_response_content(
+        fields=origins_expected_fields, response_content=content
+    )

--- a/backend/kernelCI_app/tests/utils/client/originClient.py
+++ b/backend/kernelCI_app/tests/utils/client/originClient.py
@@ -1,0 +1,11 @@
+import requests
+from django.urls import reverse
+
+from kernelCI_app.tests.utils.client.baseClient import BaseClient
+
+
+class OriginClient(BaseClient):
+    def get_origins(self) -> requests.Response:
+        path = reverse("originsView")
+        url = self.get_endpoint(path=path)
+        return requests.get(url)

--- a/backend/kernelCI_app/tests/utils/fields/origins.py
+++ b/backend/kernelCI_app/tests/utils/fields/origins.py
@@ -1,0 +1,1 @@
+origins_expected_fields = ["checkout_origins", "test_origins"]

--- a/backend/kernelCI_app/typeModels/origins.py
+++ b/backend/kernelCI_app/typeModels/origins.py
@@ -5,3 +5,4 @@ from kernelCI_app.typeModels.databases import Origin
 
 class OriginsResponse(BaseModel):
     checkout_origins: list[Origin]
+    test_origins: list[Origin]

--- a/backend/kernelCI_app/views/originsView.py
+++ b/backend/kernelCI_app/views/originsView.py
@@ -12,6 +12,25 @@ from kernelCI_app.typeModels.origins import OriginsResponse
 
 EXCLUDED_ORIGINS = ["kernelci"]
 
+# For now we are hardcoding test origins since fetching them dynamically in a query is taking
+# around 8 minutes to finish. That time will result in a timeout every request, so this is a
+# temporary solution. Another option would be to create a cron job that feeds a TestOriginsCache
+# sqlite table, from which this endpoint would fetch.
+#
+# TODO: replace with a dynamic approach
+TEST_ORIGINS = [
+    "0dayci",
+    "arm",
+    "broonie",
+    "maestro",
+    "microsoft",
+    "redhat",
+    "riscv",
+    "syzbot",
+    "ti",
+    "tuxsuite",
+]
+
 
 def separate_origin_records(*, records: list[dict[str, str]]) -> set[str]:
     """Iterates over the records for origins and returns a set for each table defined by those records
@@ -62,7 +81,8 @@ class OriginsView(APIView):
 
         try:
             valid_response = OriginsResponse(
-                checkout_origins=sorted(self.checkout_origins)
+                checkout_origins=sorted(self.checkout_origins),
+                test_origins=TEST_ORIGINS,
             )
         except ValidationError as e:
             return Response(e.json(), HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/backend/requests/origins-get.sh
+++ b/backend/requests/origins-get.sh
@@ -2,10 +2,10 @@ http 'http://localhost:8000/api/origins/'
 
 # HTTP/1.1 200 OK
 # Allow: GET, HEAD, OPTIONS
-# Content-Length: 98
+# Content-Length: 204
 # Content-Type: application/json
 # Cross-Origin-Opener-Policy: same-origin
-# Date: Wed, 04 Jun 2025 14:22:51 GMT
+# Date: Thu, 12 Jun 2025 16:25:19 GMT
 # Referrer-Policy: same-origin
 # Server: WSGIServer/0.2 CPython/3.12.7
 # Vary: Accept, Cookie, origin
@@ -21,6 +21,18 @@ http 'http://localhost:8000/api/origins/'
 #         "microsoft",
 #         "redhat",
 #         "syzbot",
+#         "tuxsuite"
+#     ],
+#     "test_origins": [
+#         "0dayci",
+#         "arm",
+#         "broonie",
+#         "maestro",
+#         "microsoft",
+#         "redhat",
+#         "riscv",
+#         "syzbot",
+#         "ti",
 #         "tuxsuite"
 #     ]
 # }

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -2600,8 +2600,14 @@ components:
             $ref: '#/components/schemas/Origin'
           title: Checkout Origins
           type: array
+        test_origins:
+          items:
+            $ref: '#/components/schemas/Origin'
+          title: Test Origins
+          type: array
       required:
       - checkout_origins
+      - test_origins
       title: OriginsResponse
       type: object
     PossibleIssueTags:

--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -46,12 +46,19 @@ const OriginSelect = ({ basePath }: { basePath: string }): JSX.Element => {
       return <></>;
     }
 
-    return originData?.checkout_origins.map(option => (
+    let pageOrigins: string[];
+    if (targetPath === '/hardware') {
+      pageOrigins = originData.test_origins;
+    } else {
+      pageOrigins = originData.checkout_origins;
+    }
+
+    return pageOrigins.map(option => (
       <SelectItem key={option} value={option}>
         {option}
       </SelectItem>
     ));
-  }, [originData]);
+  }, [originData, targetPath]);
 
   useEffect(() => {
     if (origin === undefined) {

--- a/dashboard/src/types/origins.ts
+++ b/dashboard/src/types/origins.ts
@@ -1,3 +1,4 @@
 export type OriginsResponse = {
   checkout_origins: string[];
+  test_origins: string[];
 };


### PR DESCRIPTION
## Changes
- Adds a `TEST_ORIGINS` const variable to be returned in the origins endpoint. This is hardcoded because the query for them (selecting distinct origins from tests) was taking too long to finish, requiring a whole cache system in order to be usable. Not only that, but the origins aren't changed frequently, so for now it was discussed that the test origins could be added manually.
- Uses the test origins only in the hardware listing and hardware details origin selector, in the tree details the origins shown will still be the dynamic checkout origins.
- Added integration tests for the origins endpoint.

## How to test
- Go to hardware listing or hardware details and check the origin selector, the difference to the checkout origins should be the "riscv" and "ti" origins.
- The use of the origin selector should be normal in other cases

Closes #1242 