### PR TITLE
Refactor: hide issues without trees

### DIFF
--- a/backend/kernelCI_app/helpers/issueExtras.py
+++ b/backend/kernelCI_app/helpers/issueExtras.py
@@ -40,6 +40,9 @@ def assign_issue_first_seen(
     issue_key_list: List[Tuple[str, int]],
     processed_issues_table: ProcessedExtraDetailedIssues,
 ) -> None:
+    """
+    Assigns the first seen data to the processed_issues_table by querying with the issue_key_list.
+    """
     issue_id_list: List[str] = []
     versions_per_issue: Dict[str, Set[int]] = defaultdict(set)
     for issue_key in issue_key_list:
@@ -50,13 +53,13 @@ def assign_issue_first_seen(
     incident_records = get_issue_first_seen_data(issue_id_list=issue_id_list)
 
     for record in incident_records:
-        record_issue_id = record.issue_id
-        first_seen = record.first_seen
-        first_git_commit_hash = record.git_commit_hash
-        first_git_repository_url = record.git_repository_url
-        first_git_repository_branch = record.git_repository_branch
-        first_git_commit_name = record.git_commit_name
-        first_tree_name = record.tree_name
+        record_issue_id = record["issue_id"]
+        first_seen = record["first_seen"]
+        first_git_commit_hash = record["git_commit_hash"]
+        first_git_repository_url = record["git_repository_url"]
+        first_git_repository_branch = record["git_repository_branch"]
+        first_git_commit_name = record["git_commit_name"]
+        first_tree_name = record["tree_name"]
 
         processed_issue_from_id = processed_issues_table.get(record_issue_id)
         if processed_issue_from_id is None:

--- a/backend/kernelCI_app/views/issueView.py
+++ b/backend/kernelCI_app/views/issueView.py
@@ -10,7 +10,7 @@ from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
 from kernelCI_app.helpers.filters import FilterParams
-from kernelCI_app.helpers.issueExtras import assign_issue_first_seen
+from kernelCI_app.helpers.issueExtras import process_issues_extra_details
 from kernelCI_app.helpers.issueListing import should_discard_issue_record
 from kernelCI_app.queries.issues import get_issue_listing_data
 from kernelCI_app.typeModels.issueListing import (
@@ -71,6 +71,30 @@ class IssueView(APIView):
 
         return result
 
+    def _filter_records_by_extras(self, *, records: list[dict]):
+        """Filters out the extra details and the records with it.
+
+        Receives the list of records to be filtered based on the extra details
+
+        Returns the filtered extra_issue_details and filtered records"""
+        # Checks if there are issues with no checkouts and filters them out
+        issues_without_trees = []
+        processed_extras_with_trees = {}
+        for issue_id, issue_extras_data in self.processed_extra_issue_details.items():
+            for info in issue_extras_data["versions"].values():
+                if not info.trees:
+                    issues_without_trees.append(issue_id)
+                else:
+                    processed_extras_with_trees[issue_id] = issue_extras_data
+
+        refiltered_records = []
+        for issue in records:
+            if issue["id"] in issues_without_trees:
+                continue
+            refiltered_records.append(issue)
+
+        return (processed_extras_with_trees, refiltered_records)
+
     def _format_processing_for_response(self) -> None:
         for (
             issue_extras_id,
@@ -106,15 +130,22 @@ class IssueView(APIView):
         filtered_records = self._filter_records(issue_records=issue_records)
 
         issue_key_list = [(issue["id"], issue["version"]) for issue in filtered_records]
-        assign_issue_first_seen(
+        # The endpoint only returns the first_seen data, but getting the trees data is useful
+        # to filter out issues with incidents that are related to unexistent builds/checkouts
+        process_issues_extra_details(
             issue_key_list=issue_key_list,
             processed_issues_table=self.processed_extra_issue_details,
         )
 
+        (self.processed_extra_issue_details, refiltered_records) = (
+            self._filter_records_by_extras(records=filtered_records)
+        )
+
+        self._format_processing_for_response()
+
         try:
-            self._format_processing_for_response()
             valid_data = IssueListingResponse(
-                issues=filtered_records,
+                issues=refiltered_records,
                 extras=self.first_incidents,
                 filters=IssueListingFilters(
                     origins=sorted(self.unprocessed_origins),


### PR DESCRIPTION
In the issue listing page, there were a lot of issues where the first incident pointed to an unexisting checkout; those issues should be filtered out.
However, it is possible that the first incident was pointing to an unexisting checkout but later in the issue lifetime it had correct incidents, so the current approach in this PR filters out the issues where _no incidents_ have tree data.

## Changes
- Uses assign_issue_trees to check in which trees all the issues appeared, and then filters out the issues related to 0 trees
- Changes the assign_issue_first_seen query to use raw SQL (instead of returning a fake Incidents object) and adds query cache to it

## How to test
Go to the issue listing page, check that there are less issues listed, and that the ones with -/- first tree still have some tree in their issue details page
Also check the backend response to see if the extra info and the issue list are matching (no extra/lacking data)

Closes #1279 