### PR TITLE
Feat: short tree details url

### DIFF
--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -65,6 +65,11 @@ urlpatterns = [
         views.TreeDetails.as_view(),
         name="treeDetailsDirectView",
     ),
+    path(
+        "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>/summary",
+        views.TreeDetailsSummary.as_view(),
+        name="treeDetailsDirectSummaryView",
+    ),
     path("build/<str:build_id>", view_cache(views.BuildDetails), name="buildDetails"),
     path("build/<str:build_id>/tests", view_cache(views.BuildTests), name="buildTests"),
     path(

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -56,6 +56,11 @@ urlpatterns = [
         name="treeCommits",
     ),
     path(
+        "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>/commits",
+        view_cache(views.TreeCommitsHistory),
+        name="treeCommitsDirectView",
+    ),
+    path(
         "tree/<str:tree_name>/<str:branch>",
         view_cache(views.TreeLatest),
         name="treeLatest",

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -61,9 +61,9 @@ urlpatterns = [
         name="treeLatest",
     ),
     path(
-        "tree/<str:tree_name>/<str:branch>/<str:hash>",
-        view_cache(views.TreeLatest),
-        name="treeLatestHash",
+        "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>/full",
+        views.TreeDetails.as_view(),
+        name="treeDetailsDirectView",
     ),
     path("build/<str:build_id>", view_cache(views.BuildDetails), name="buildDetails"),
     path("build/<str:build_id>/tests", view_cache(views.BuildTests), name="buildTests"),

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 from http import HTTPStatus
+
+from django.http import HttpRequest
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
@@ -374,7 +376,13 @@ class TreeCommitsHistory(APIView):
         parameters=[TreeCommitsQueryParameters],
         methods=["GET"],
     )
-    def get(self, request, commit_hash: Optional[str]) -> Response:
+    def get(
+        self,
+        request: HttpRequest,
+        commit_hash: str,
+        tree_name: Optional[str] = None,
+        git_branch: Optional[str] = None,
+    ) -> Response:
         try:
             params = TreeCommitsQueryParameters(
                 origin=request.GET.get("origin"),
@@ -409,7 +417,8 @@ class TreeCommitsHistory(APIView):
             commit_hash=commit_hash,
             origin=params.origin,
             git_url=params.git_url,
-            git_branch=params.git_branch,
+            git_branch=params.git_branch or git_branch,
+            tree_name=tree_name,
         )
 
         if not rows:

--- a/backend/kernelCI_app/views/treeDetailsBootsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBootsView.py
@@ -70,7 +70,10 @@ class TreeDetailsBoots(APIView):
         git_branch_param = request.GET.get("git_branch")
 
         rows = get_tree_details_data(
-            origin_param, git_url_param, git_branch_param, commit_hash
+            origin_param=origin_param,
+            git_url_param=git_url_param,
+            git_branch_param=git_branch_param,
+            commit_hash=commit_hash,
         )
 
         self.filters = FilterParams(request)

--- a/backend/kernelCI_app/views/treeDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBuildsView.py
@@ -73,7 +73,10 @@ class TreeDetailsBuilds(APIView):
         git_branch_param = request.GET.get("git_branch")
 
         rows = get_tree_details_data(
-            origin_param, git_url_param, git_branch_param, commit_hash
+            origin_param=origin_param,
+            git_url_param=git_url_param,
+            git_branch_param=git_branch_param,
+            commit_hash=commit_hash,
         )
 
         self.filters = FilterParams(request)

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+from django.http import HttpRequest
 from pydantic import ValidationError
 from rest_framework.response import Response
 from kernelCI_app.constants.localization import ClientStrings
@@ -46,7 +47,7 @@ from rest_framework.views import APIView
 from kernelCI_app.viewCommon import create_details_build_summary
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from http import HTTPStatus
-from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
+from kernelCI_app.constants.general import DEFAULT_ORIGIN, MAESTRO_DUMMY_BUILD_PREFIX
 
 
 class TreeDetailsSummary(APIView):
@@ -201,13 +202,23 @@ class TreeDetailsSummary(APIView):
         parameters=[TreeQueryParameters],
         methods=["GET"],
     )
-    def get(self, request, commit_hash: str | None) -> Response:
-        origin_param = request.GET.get("origin")
+    def get(
+        self,
+        request: HttpRequest,
+        commit_hash: Optional[str],
+        tree_name: Optional[str] = None,
+        git_branch: Optional[str] = None,
+    ) -> Response:
+        origin_param = request.GET.get("origin", DEFAULT_ORIGIN)
         git_url_param = request.GET.get("git_url")
-        git_branch_param = request.GET.get("git_branch")
+        git_branch_param = request.GET.get("git_branch", git_branch)
 
         rows = get_tree_details_data(
-            origin_param, git_url_param, git_branch_param, commit_hash
+            origin_param=origin_param,
+            git_url_param=git_url_param,
+            tree_name=tree_name,
+            git_branch_param=git_branch_param,
+            commit_hash=commit_hash,
         )
 
         if len(rows) == 0:

--- a/backend/kernelCI_app/views/treeDetailsTestsView.py
+++ b/backend/kernelCI_app/views/treeDetailsTestsView.py
@@ -74,7 +74,10 @@ class TreeDetailsTests(APIView):
         git_branch_param = request.GET.get("git_branch")
 
         rows = get_tree_details_data(
-            origin_param, git_url_param, git_branch_param, commit_hash
+            origin_param=origin_param,
+            git_url_param=git_url_param,
+            git_branch_param=git_branch_param,
+            commit_hash=commit_hash,
         )
 
         self.filters = FilterParams(request)

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1105,6 +1105,76 @@ paths:
               schema:
                 $ref: '#/components/schemas/TreeLatestResponse'
           description: ''
+  /api/tree/{tree_name}/{git_branch}/{commit_hash}/commits:
+    get:
+      operationId: tree_commits_retrieve_2
+      parameters:
+      - in: path
+        name: commit_hash
+        schema:
+          type: string
+        required: true
+      - in: query
+        name: end_time_stamp_in_seconds
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: End Time Stamp In Seconds
+      - in: path
+        name: git_branch
+        schema:
+          type: string
+        required: true
+      - in: query
+        name: git_branch
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Git Branch
+      - in: query
+        name: git_url
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Git Url
+      - in: query
+        name: origin
+        schema:
+          title: Origin
+          type: string
+        required: true
+      - in: query
+        name: start_time_stamp_in_seconds
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Start Time Stamp In Seconds
+      - in: path
+        name: tree_name
+        schema:
+          type: string
+        required: true
+      tags:
+      - tree
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TreeCommitsResponse'
+          description: ''
   /api/tree/{tree_name}/{git_branch}/{commit_hash}/full:
     get:
       operationId: tree_full_retrieve_2

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1105,26 +1105,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/TreeLatestResponse'
           description: ''
-  /api/tree/{tree_name}/{branch}/{hash}:
+  /api/tree/{tree_name}/{git_branch}/{commit_hash}/full:
     get:
-      operationId: tree_retrieve_3
+      operationId: tree_full_retrieve_2
       parameters:
       - in: path
-        name: branch
+        name: commit_hash
         schema:
           type: string
         required: true
       - in: path
-        name: hash
+        name: git_branch
         schema:
+          type: string
+        required: true
+      - in: query
+        name: git_branch
+        schema:
+          title: Git Branch
+          type: string
+        required: true
+      - in: query
+        name: git_url
+        schema:
+          title: Git Url
           type: string
         required: true
       - in: query
         name: origin
         schema:
-          default: maestro
           title: Origin
           type: string
+        required: true
       - in: path
         name: tree_name
         schema:
@@ -1141,7 +1153,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TreeLatestResponse'
+                $ref: '#/components/schemas/TreeDetailsFullResponse'
           description: ''
 components:
   schemas:
@@ -3081,6 +3093,8 @@ components:
         index:
           title: Index
           type: string
+        origin:
+          $ref: '#/components/schemas/Origin'
         tree_name:
           anyOf:
           - type: string
@@ -3125,6 +3139,7 @@ components:
           title: Is Selected
       required:
       - index
+      - origin
       - tree_name
       - git_repository_branch
       - git_repository_url

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1155,6 +1155,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/TreeDetailsFullResponse'
           description: ''
+  /api/tree/{tree_name}/{git_branch}/{commit_hash}/summary:
+    get:
+      operationId: tree_summary_retrieve_2
+      parameters:
+      - in: path
+        name: commit_hash
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: git_branch
+        schema:
+          type: string
+        required: true
+      - in: query
+        name: git_branch
+        schema:
+          title: Git Branch
+          type: string
+        required: true
+      - in: query
+        name: git_url
+        schema:
+          title: Git Url
+          type: string
+        required: true
+      - in: query
+        name: origin
+        schema:
+          title: Origin
+          type: string
+        required: true
+      - in: path
+        name: tree_name
+        schema:
+          type: string
+        required: true
+      tags:
+      - tree
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SummaryResponse'
+          description: ''
 components:
   schemas:
     BuildArchitectures:

--- a/dashboard/src/api/commitHistory.ts
+++ b/dashboard/src/api/commitHistory.ts
@@ -1,7 +1,9 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
+import { treeDetailsDirectRouteName } from '@/types/tree/TreeDetails';
 import type {
+  TreeDetailsRouteFrom,
   TTreeCommitHistoryResponse,
   TTreeDetailsFilter,
 } from '@/types/tree/TreeDetails';
@@ -21,6 +23,8 @@ const fetchCommitHistory = async (
   filters: TTreeDetailsFilter,
   startTimestampInSeconds: number | undefined,
   endTimestampInSeconds: number | undefined,
+  treeName?: string,
+  treeUrlFrom?: TreeDetailsRouteFrom,
 ): Promise<TTreeCommitHistoryResponse> => {
   const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
 
@@ -33,8 +37,13 @@ const fetchCommitHistory = async (
     ...filtersFormatted,
   };
 
+  const baseUrl =
+    treeUrlFrom === treeDetailsDirectRouteName
+      ? `/api/tree/${treeName}/${gitBranch}/${commitHash}`
+      : `/api/tree/${commitHash}`;
+
   const data = await RequestData.get<TTreeCommitHistoryResponse>(
-    `/api/tree/${commitHash}/commits`,
+    `${baseUrl}/commits`,
     {
       params,
     },
@@ -51,6 +60,8 @@ export const useCommitHistory = ({
   filter,
   endTimestampInSeconds,
   startTimestampInSeconds,
+  treeName,
+  treeUrlFrom,
 }: {
   commitHash: string;
   origin: string;
@@ -59,6 +70,8 @@ export const useCommitHistory = ({
   filter: TTreeDetailsFilter | TFilter;
   startTimestampInSeconds?: number;
   endTimestampInSeconds?: number;
+  treeName?: string;
+  treeUrlFrom?: TreeDetailsRouteFrom;
 }): UseQueryResult<TTreeCommitHistoryResponse> => {
   const testFilter = getTargetFilter(filter, 'test');
   const treeDetailsFilter = getTargetFilter(filter, 'treeDetails');
@@ -78,6 +91,8 @@ export const useCommitHistory = ({
       filters,
       startTimestampInSeconds,
       endTimestampInSeconds,
+      treeName,
+      treeUrlFrom,
     ],
     queryFn: () =>
       fetchCommitHistory(
@@ -88,6 +103,8 @@ export const useCommitHistory = ({
         filters,
         startTimestampInSeconds,
         endTimestampInSeconds,
+        treeName,
+        treeUrlFrom,
       ),
   });
 };

--- a/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
+++ b/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
@@ -18,6 +18,7 @@ import type { TFilter } from '@/types/general';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import type { gitValues } from '@/components/Tooltip/CommitTagTooltip';
+import type { TreeDetailsRouteFrom } from '@/types/tree/TreeDetails';
 
 const graphDisplaySize = 8;
 
@@ -51,7 +52,10 @@ interface ICommitNavigationGraph {
   startTimestampInSeconds?: number;
   endTimestampInSeconds?: number;
   onMarkClick: (commitHash: string, commitName?: string) => void;
+  treeName?: string;
+  treeUrlFrom?: TreeDetailsRouteFrom;
 }
+
 const CommitNavigationGraph = ({
   origin,
   currentPageTab,
@@ -63,6 +67,8 @@ const CommitNavigationGraph = ({
   onMarkClick,
   endTimestampInSeconds,
   startTimestampInSeconds,
+  treeName,
+  treeUrlFrom,
 }: ICommitNavigationGraph): JSX.Element => {
   const { formatMessage } = useIntl();
 
@@ -76,6 +82,8 @@ const CommitNavigationGraph = ({
     filter: reqFilter,
     endTimestampInSeconds,
     startTimestampInSeconds,
+    treeName,
+    treeUrlFrom,
   });
 
   const displayableData = data ? data : null;

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -9,8 +9,10 @@ import { BootsTable } from '@/components/BootsTable/BootsTable';
 import MemoizedIssuesList from '@/components/Cards/IssuesList';
 import { MemoizedHardwareTested } from '@/components/Cards/HardwareTested';
 import {
-  zTableFilterInfoDefault,
+  type TreeDetailsRouteFrom,
   type PossibleTableFilters,
+  treeDetailsFromMap,
+  zTableFilterInfoDefault,
 } from '@/types/tree/TreeDetails';
 import {
   DesktopGrid,
@@ -32,25 +34,32 @@ import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 import { MemoizedOriginsCard } from '@/components/Cards/OriginsCard';
+import { getStringParam } from '@/utils/utils';
 
 interface BootsTabProps {
   treeDetailsLazyLoaded: TreeDetailsLazyLoaded;
+  urlFrom: TreeDetailsRouteFrom;
 }
 
-const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
-  const { treeId } = useParams({
-    from: '/_main/tree/$treeId',
+const BootsTab = ({
+  treeDetailsLazyLoaded,
+  urlFrom,
+}: BootsTabProps): JSX.Element => {
+  const params = useParams({
+    from: urlFrom,
   });
+  const treeId =
+    getStringParam(params, 'treeId') || getStringParam(params, 'hash');
 
   const { tableFilter, diffFilter } = useSearch({
-    from: '/_main/tree/$treeId',
+    from: urlFrom,
   });
 
   const currentPathFilter = diffFilter.bootPath
     ? Object.keys(diffFilter.bootPath)[0]
     : undefined;
 
-  const navigate = useNavigate({ from: '/tree/$treeId' });
+  const navigate = useNavigate({ from: treeDetailsFromMap[urlFrom] });
 
   const updatePathFilter = useCallback(
     (pathFilter: string) => {
@@ -204,7 +213,7 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
               />
             </div>
             <div>
-              <TreeCommitNavigationGraph />
+              <TreeCommitNavigationGraph urlFrom={urlFrom} />
               <MemoizedHardwareTested
                 title={<FormattedMessage id="bootsTab.hardwareTested" />}
                 environmentCompatible={hardwareData}
@@ -237,7 +246,7 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
               toggleFilterBySection={toggleFilterBySection}
               filterStatusKey="bootStatus"
             />
-            <TreeCommitNavigationGraph />
+            <TreeCommitNavigationGraph urlFrom={urlFrom} />
             <InnerMobileGrid>
               <div>
                 <MemoizedConfigList
@@ -305,7 +314,7 @@ const BootsTab = ({ treeDetailsLazyLoaded }: BootsTabProps): JSX.Element => {
               />
             </div>
           )}
-          <TreeCommitNavigationGraph />
+          <TreeCommitNavigationGraph urlFrom={urlFrom} />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -50,6 +50,7 @@ const BootsTab = ({
   });
   const treeId =
     getStringParam(params, 'treeId') || getStringParam(params, 'hash');
+  const treeName = getStringParam(params, 'treeName');
 
   const { tableFilter, diffFilter } = useSearch({
     from: urlFrom,
@@ -213,7 +214,10 @@ const BootsTab = ({
               />
             </div>
             <div>
-              <TreeCommitNavigationGraph urlFrom={urlFrom} />
+              <TreeCommitNavigationGraph
+                urlFrom={urlFrom}
+                treeName={treeName}
+              />
               <MemoizedHardwareTested
                 title={<FormattedMessage id="bootsTab.hardwareTested" />}
                 environmentCompatible={hardwareData}
@@ -246,7 +250,7 @@ const BootsTab = ({
               toggleFilterBySection={toggleFilterBySection}
               filterStatusKey="bootStatus"
             />
-            <TreeCommitNavigationGraph urlFrom={urlFrom} />
+            <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
             <InnerMobileGrid>
               <div>
                 <MemoizedConfigList
@@ -314,7 +318,7 @@ const BootsTab = ({
               />
             </div>
           )}
-          <TreeCommitNavigationGraph urlFrom={urlFrom} />
+          <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -27,6 +27,7 @@ import {
   sanitizeConfigs,
   sanitizeBuildsSummary,
   sanitizeBuilds,
+  getStringParam,
 } from '@/utils/utils';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
@@ -37,7 +38,11 @@ import type { IListingItem } from '@/components/ListingItem/ListingItem';
 import { RedirectFrom } from '@/types/general';
 import type { RequiredStatusCount, TFilterObjectsKeys } from '@/types/general';
 
-import type { AccordionItemBuilds } from '@/types/tree/TreeDetails';
+import {
+  treeDetailsFromMap,
+  type AccordionItemBuilds,
+  type TreeDetailsRouteFrom,
+} from '@/types/tree/TreeDetails';
 
 import type { TIssue } from '@/types/issues';
 
@@ -51,6 +56,7 @@ import { TreeDetailsBuildsTable } from './TreeDetailsBuildsTable';
 
 interface BuildTab {
   treeDetailsLazyLoaded: TreeDetailsLazyLoaded;
+  urlFrom: TreeDetailsRouteFrom;
 }
 
 interface IBuildsTab {
@@ -63,16 +69,21 @@ interface IBuildsTab {
   origins: Record<string, RequiredStatusCount>;
 }
 
-const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
+const BuildTab = ({
+  treeDetailsLazyLoaded,
+  urlFrom,
+}: BuildTab): JSX.Element => {
   const navigate = useNavigate({
-    from: '/tree/$treeId',
+    from: treeDetailsFromMap[urlFrom],
   });
 
   const { diffFilter } = useSearch({
-    from: '/_main/tree/$treeId',
+    from: urlFrom,
   });
 
-  const { treeId } = useParams({ from: '/_main/tree/$treeId' });
+  const params = useParams({ from: urlFrom });
+  const treeId =
+    getStringParam(params, 'treeId') || getStringParam(params, 'hash');
 
   const {
     data: summaryData,
@@ -186,7 +197,7 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
               />
             </div>
             <div>
-              <TreeCommitNavigationGraph />
+              <TreeCommitNavigationGraph urlFrom={urlFrom} />
               <MemoizedConfigsCard
                 configs={treeDetailsData.configs}
                 toggleFilterBySection={toggleFilterBySection}
@@ -210,7 +221,7 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
             />
           </DesktopGrid>
           <MobileGrid>
-            <TreeCommitNavigationGraph />
+            <TreeCommitNavigationGraph urlFrom={urlFrom} />
             <MemoizedStatusCard
               title={<FormattedMessage id="buildTab.buildStatus" />}
               toggleFilterBySection={toggleFilterBySection}
@@ -268,7 +279,10 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
               <div className="text-lg">
                 <FormattedMessage id="global.builds" />
               </div>
-              <TreeDetailsBuildsTable buildItems={treeDetailsData.builds} />
+              <TreeDetailsBuildsTable
+                buildItems={treeDetailsData.builds}
+                urlFrom={urlFrom}
+              />
             </div>
           </QuerySwitcher>
         </div>
@@ -285,7 +299,7 @@ const BuildTab = ({ treeDetailsLazyLoaded }: BuildTab): JSX.Element => {
               />
             </div>
           )}
-          <TreeCommitNavigationGraph />
+          <TreeCommitNavigationGraph urlFrom={urlFrom} />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -84,6 +84,7 @@ const BuildTab = ({
   const params = useParams({ from: urlFrom });
   const treeId =
     getStringParam(params, 'treeId') || getStringParam(params, 'hash');
+  const treeName = getStringParam(params, 'treeName');
 
   const {
     data: summaryData,
@@ -197,7 +198,10 @@ const BuildTab = ({
               />
             </div>
             <div>
-              <TreeCommitNavigationGraph urlFrom={urlFrom} />
+              <TreeCommitNavigationGraph
+                urlFrom={urlFrom}
+                treeName={treeName}
+              />
               <MemoizedConfigsCard
                 configs={treeDetailsData.configs}
                 toggleFilterBySection={toggleFilterBySection}
@@ -221,7 +225,7 @@ const BuildTab = ({
             />
           </DesktopGrid>
           <MobileGrid>
-            <TreeCommitNavigationGraph urlFrom={urlFrom} />
+            <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
             <MemoizedStatusCard
               title={<FormattedMessage id="buildTab.buildStatus" />}
               toggleFilterBySection={toggleFilterBySection}
@@ -299,7 +303,7 @@ const BuildTab = ({
               />
             </div>
           )}
-          <TreeCommitNavigationGraph urlFrom={urlFrom} />
+          <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -8,18 +8,26 @@ import {
   zTableFilterInfoDefault,
   type AccordionItemBuilds,
   type PossibleTableFilters,
+  type TreeDetailsRouteFrom,
+  treeDetailsFromMap,
 } from '@/types/tree/TreeDetails';
+import { getStringParam } from '@/utils/utils';
 
 export interface TTreeDetailsBuildsTable {
   buildItems: AccordionItemBuilds[];
+  urlFrom: TreeDetailsRouteFrom;
 }
 
 export function TreeDetailsBuildsTable({
   buildItems,
+  urlFrom,
 }: TTreeDetailsBuildsTable): JSX.Element {
-  const { treeId } = useParams({ from: '/_main/tree/$treeId' });
-  const { tableFilter } = useSearch({ from: '/_main/tree/$treeId' });
-  const navigate = useNavigate({ from: '/tree/$treeId' });
+  const params = useParams({ from: urlFrom });
+  const { tableFilter } = useSearch({ from: urlFrom });
+  const navigate = useNavigate({ from: treeDetailsFromMap[urlFrom] });
+
+  const treeId =
+    getStringParam(params, 'treeId') || getStringParam(params, 'hash');
 
   const getRowLink = useCallback(
     (buildId: string): LinkProps => ({

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -48,6 +48,7 @@ const TestsTab = ({
   const params = useParams({ from: urlFrom });
   const treeId =
     getStringParam(params, 'treeId') || getStringParam(params, 'hash');
+  const treeName = getStringParam(params, 'treeName');
 
   const {
     data: summaryData,
@@ -215,7 +216,10 @@ const TestsTab = ({
               />
             </div>
             <div>
-              <TreeCommitNavigationGraph urlFrom={urlFrom} />
+              <TreeCommitNavigationGraph
+                urlFrom={urlFrom}
+                treeName={treeName}
+              />
               <MemoizedHardwareTested
                 title={<FormattedMessage id="testsTab.hardwareTested" />}
                 environmentCompatible={hardwareData}
@@ -248,7 +252,7 @@ const TestsTab = ({
               toggleFilterBySection={toggleFilterBySection}
               filterStatusKey="testStatus"
             />
-            <TreeCommitNavigationGraph urlFrom={urlFrom} />
+            <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
             <InnerMobileGrid>
               <div>
                 <MemoizedConfigList
@@ -317,7 +321,7 @@ const TestsTab = ({
               />
             </div>
           )}
-          <TreeCommitNavigationGraph urlFrom={urlFrom} />
+          <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -6,6 +6,8 @@ import { useParams, useNavigate, useSearch } from '@tanstack/react-router';
 import { useCallback, useMemo, type JSX } from 'react';
 
 import {
+  treeDetailsFromMap,
+  type TreeDetailsRouteFrom,
   zTableFilterInfoDefault,
   type PossibleTableFilters,
 } from '@/types/tree/TreeDetails';
@@ -32,13 +34,20 @@ import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 import { MemoizedOriginsCard } from '@/components/Cards/OriginsCard';
+import { getStringParam } from '@/utils/utils';
 
 interface TestsTabProps {
   treeDetailsLazyLoaded: TreeDetailsLazyLoaded;
+  urlFrom: TreeDetailsRouteFrom;
 }
 
-const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
-  const { treeId } = useParams({ from: '/_main/tree/$treeId' });
+const TestsTab = ({
+  treeDetailsLazyLoaded,
+  urlFrom,
+}: TestsTabProps): JSX.Element => {
+  const params = useParams({ from: urlFrom });
+  const treeId =
+    getStringParam(params, 'treeId') || getStringParam(params, 'hash');
 
   const {
     data: summaryData,
@@ -63,14 +72,14 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
   const fullTestsData = useMemo(() => fullData?.tests, [fullData?.tests]);
 
   const { tableFilter, diffFilter } = useSearch({
-    from: '/_main/tree/$treeId',
+    from: urlFrom,
   });
 
   const currentPathFilter = diffFilter.testPath
     ? Object.keys(diffFilter.testPath)[0]
     : undefined;
 
-  const navigate = useNavigate({ from: '/tree/$treeId' });
+  const navigate = useNavigate({ from: treeDetailsFromMap[urlFrom] });
 
   const updatePathFilter = useCallback(
     (pathFilter: string) => {
@@ -206,7 +215,7 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
               />
             </div>
             <div>
-              <TreeCommitNavigationGraph />
+              <TreeCommitNavigationGraph urlFrom={urlFrom} />
               <MemoizedHardwareTested
                 title={<FormattedMessage id="testsTab.hardwareTested" />}
                 environmentCompatible={hardwareData}
@@ -239,7 +248,7 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
               toggleFilterBySection={toggleFilterBySection}
               filterStatusKey="testStatus"
             />
-            <TreeCommitNavigationGraph />
+            <TreeCommitNavigationGraph urlFrom={urlFrom} />
             <InnerMobileGrid>
               <div>
                 <MemoizedConfigList
@@ -308,7 +317,7 @@ const TestsTab = ({ treeDetailsLazyLoaded }: TestsTabProps): JSX.Element => {
               />
             </div>
           )}
-          <TreeCommitNavigationGraph />
+          <TreeCommitNavigationGraph urlFrom={urlFrom} />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
@@ -1,23 +1,37 @@
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import CommitNavigationGraph from '@/components/CommitNavigationGraph/CommitNavigationGraph';
+import type {
+  TTreeInformation,
+  TreeDetailsRouteFrom,
+} from '@/types/tree/TreeDetails';
 
-const TreeCommitNavigationGraph = (): React.ReactNode => {
-  const {
-    origin,
-    currentPageTab,
-    diffFilter,
-    treeInfo: { gitUrl, gitBranch, headCommitHash },
-  } = useSearch({ from: '/_main/tree/$treeId' });
+import { treeDetailsFromMap } from '@/types/tree/TreeDetails';
+import { sanitizeTreeinfo } from '@/utils/treeDetails';
 
-  const { treeId } = useParams({
-    from: '/_main/tree/$treeId',
+const TreeCommitNavigationGraph = ({
+  urlFrom,
+}: {
+  urlFrom: TreeDetailsRouteFrom;
+}): React.ReactNode => {
+  const { origin, currentPageTab, diffFilter, treeInfo } = useSearch({
+    from: urlFrom,
   });
 
+  const params = useParams({
+    from: urlFrom,
+  });
+
+  const sanitizedTreeInfo = useMemo((): TTreeInformation & {
+    hash: string;
+  } => {
+    return sanitizeTreeinfo({ treeInfo, params, urlFrom });
+  }, [params, treeInfo, urlFrom]);
+
   const navigate = useNavigate({
-    from: '/tree/$treeId',
+    from: treeDetailsFromMap[urlFrom],
   });
 
   const markClickHandle = useCallback(
@@ -47,10 +61,10 @@ const TreeCommitNavigationGraph = (): React.ReactNode => {
   return (
     <CommitNavigationGraph
       origin={origin}
-      gitBranch={gitBranch}
-      gitUrl={gitUrl}
-      treeId={treeId}
-      headCommitHash={headCommitHash}
+      gitBranch={sanitizedTreeInfo.gitBranch}
+      gitUrl={sanitizedTreeInfo.gitUrl}
+      treeId={sanitizedTreeInfo.hash}
+      headCommitHash={sanitizedTreeInfo.headCommitHash}
       onMarkClick={markClickHandle}
       diffFilter={diffFilter}
       currentPageTab={currentPageTab}

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
@@ -8,13 +8,18 @@ import type {
   TreeDetailsRouteFrom,
 } from '@/types/tree/TreeDetails';
 
-import { treeDetailsFromMap } from '@/types/tree/TreeDetails';
+import {
+  treeDetailsDirectRouteName,
+  treeDetailsFromMap,
+} from '@/types/tree/TreeDetails';
 import { sanitizeTreeinfo } from '@/utils/treeDetails';
 
 const TreeCommitNavigationGraph = ({
   urlFrom,
+  treeName,
 }: {
   urlFrom: TreeDetailsRouteFrom;
+  treeName: string;
 }): React.ReactNode => {
   const { origin, currentPageTab, diffFilter, treeInfo } = useSearch({
     from: urlFrom,
@@ -36,26 +41,54 @@ const TreeCommitNavigationGraph = ({
 
   const markClickHandle = useCallback(
     (commitHash: string, commitName?: string) => {
-      navigate({
-        to: '/tree/$treeId',
-        params: {
-          treeId: commitHash,
-        },
-        state: s => ({
-          ...s,
-          id: commitHash,
-        }),
-        search: previousParams => ({
-          ...previousParams,
-          treeInfo: {
-            ...previousParams.treeInfo,
-            commitName: commitName,
-            commitHash: commitHash,
+      if (urlFrom === treeDetailsDirectRouteName) {
+        navigate({
+          to: treeDetailsFromMap[urlFrom],
+          params: {
+            treeName: sanitizedTreeInfo.treeName!,
+            branch: sanitizedTreeInfo.gitBranch!,
+            hash: commitHash,
           },
-        }),
-      });
+          state: s => ({
+            ...s,
+            id: commitHash,
+          }),
+          search: previousParams => ({
+            ...previousParams,
+            treeInfo: {
+              ...previousParams.treeInfo,
+              headCommitHash: sanitizedTreeInfo.headCommitHash,
+            },
+          }),
+        });
+      } else {
+        navigate({
+          to: treeDetailsFromMap[urlFrom],
+          params: {
+            treeId: commitHash,
+          },
+          state: s => ({
+            ...s,
+            id: commitHash,
+          }),
+          search: previousParams => ({
+            ...previousParams,
+            treeInfo: {
+              ...previousParams.treeInfo,
+              commitName: commitName,
+              commitHash: commitHash,
+            },
+          }),
+        });
+      }
     },
-    [navigate],
+    [
+      navigate,
+      sanitizedTreeInfo.gitBranch,
+      sanitizedTreeInfo.headCommitHash,
+      sanitizedTreeInfo.treeName,
+      urlFrom,
+    ],
   );
 
   return (
@@ -68,6 +101,8 @@ const TreeCommitNavigationGraph = ({
       onMarkClick={markClickHandle}
       diffFilter={diffFilter}
       currentPageTab={currentPageTab}
+      treeName={treeName}
+      treeUrlFrom={urlFrom}
     />
   );
 };

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -6,7 +6,11 @@ import { useCallback, useMemo } from 'react';
 import type { ITabItem, TabRightElementRecord } from '@/components/Tabs/Tabs';
 import Tabs from '@/components/Tabs/Tabs';
 
-import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
+import type { TreeDetailsRouteFrom } from '@/types/tree/TreeDetails';
+import {
+  treeDetailsFromMap,
+  zPossibleTabValidator,
+} from '@/types/tree/TreeDetails';
 
 import type { TreeDetailsLazyLoaded } from '@/hooks/useTreeDetailsLazyLoadQuery';
 
@@ -18,39 +22,57 @@ export interface ITreeDetailsTab {
   treeDetailsLazyLoaded: TreeDetailsLazyLoaded;
   filterListElement?: JSX.Element;
   countElements: TabRightElementRecord;
+  urlFrom: TreeDetailsRouteFrom;
 }
 
 const TreeDetailsTab = ({
   filterListElement,
   countElements,
   treeDetailsLazyLoaded,
+  urlFrom,
 }: ITreeDetailsTab): JSX.Element => {
   const { currentPageTab } = useSearch({
-    from: '/_main/tree/$treeId',
+    from: urlFrom,
   });
-  const navigate = useNavigate({ from: '/tree/$treeId' });
+  const navigate = useNavigate({ from: treeDetailsFromMap[urlFrom] });
+
   const treeDetailsTab: ITabItem[] = useMemo(
     () => [
       {
         name: 'global.builds',
-        content: <BuildTab treeDetailsLazyLoaded={treeDetailsLazyLoaded} />,
+        content: (
+          <BuildTab
+            treeDetailsLazyLoaded={treeDetailsLazyLoaded}
+            urlFrom={urlFrom}
+          />
+        ),
         disabled: false,
         rightElement: countElements['buildTab'],
       },
       {
         name: 'global.boots',
-        content: <BootsTab treeDetailsLazyLoaded={treeDetailsLazyLoaded} />,
+        content: (
+          <BootsTab
+            treeDetailsLazyLoaded={treeDetailsLazyLoaded}
+            urlFrom={urlFrom}
+          />
+        ),
         disabled: false,
         rightElement: countElements['bootTab'],
       },
       {
         name: 'global.tests',
-        content: <TestsTab treeDetailsLazyLoaded={treeDetailsLazyLoaded} />,
+        content: (
+          <TestsTab
+            treeDetailsLazyLoaded={treeDetailsLazyLoaded}
+            urlFrom={urlFrom}
+          />
+        ),
         disabled: false,
         rightElement: countElements['testTab'],
       },
     ],
-    [countElements, treeDetailsLazyLoaded],
+    [countElements, treeDetailsLazyLoaded, urlFrom],
   );
 
   const onValueChange: (value: string) => void = useCallback(

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as MainCheckoutTreeNameBranchIndexImport } from './routes/_main/c
 import { Route as MainalternativesTTestIdIndexImport } from './routes/_main/(alternatives)/t/$testId/index'
 import { Route as MainalternativesIIssueIdIndexImport } from './routes/_main/(alternatives)/i/$issueId/index'
 import { Route as MainalternativesBBuildIdIndexImport } from './routes/_main/(alternatives)/b/$buildId/index'
+import { Route as MainTreeTreeNameBranchHashRouteImport } from './routes/_main/tree/$treeName/$branch/$hash/route'
 import { Route as MainTreeTreeNameBranchHashIndexImport } from './routes/_main/tree/$treeName/$branch/$hash/index'
 import { Route as MainTreeTreeIdTestTestIdIndexImport } from './routes/_main/tree/$treeId/test/$testId/index'
 import { Route as MainTreeTreeIdBuildBuildIdIndexImport } from './routes/_main/tree/$treeId/build/$buildId/index'
@@ -252,11 +253,18 @@ const MainalternativesBBuildIdIndexRoute =
     getParentRoute: () => MainalternativesBBuildIdRouteRoute,
   } as any)
 
+const MainTreeTreeNameBranchHashRouteRoute =
+  MainTreeTreeNameBranchHashRouteImport.update({
+    id: '/$treeName/$branch/$hash',
+    path: '/$treeName/$branch/$hash',
+    getParentRoute: () => MainTreeRouteRoute,
+  } as any)
+
 const MainTreeTreeNameBranchHashIndexRoute =
   MainTreeTreeNameBranchHashIndexImport.update({
-    id: '/$treeName/$branch/$hash/',
-    path: '/$treeName/$branch/$hash/',
-    getParentRoute: () => MainTreeRouteRoute,
+    id: '/',
+    path: '/',
+    getParentRoute: () => MainTreeTreeNameBranchHashRouteRoute,
   } as any)
 
 const MainTreeTreeIdTestTestIdIndexRoute =
@@ -480,6 +488,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MainTreeTreeIdIndexImport
       parentRoute: typeof MainTreeTreeIdRouteImport
     }
+    '/_main/tree/$treeName/$branch/$hash': {
+      id: '/_main/tree/$treeName/$branch/$hash'
+      path: '/$treeName/$branch/$hash'
+      fullPath: '/tree/$treeName/$branch/$hash'
+      preLoaderRoute: typeof MainTreeTreeNameBranchHashRouteImport
+      parentRoute: typeof MainTreeRouteImport
+    }
     '/_main/(alternatives)/b/$buildId/': {
       id: '/_main/(alternatives)/b/$buildId/'
       path: '/'
@@ -587,10 +602,10 @@ declare module '@tanstack/react-router' {
     }
     '/_main/tree/$treeName/$branch/$hash/': {
       id: '/_main/tree/$treeName/$branch/$hash/'
-      path: '/$treeName/$branch/$hash'
-      fullPath: '/tree/$treeName/$branch/$hash'
+      path: '/'
+      fullPath: '/tree/$treeName/$branch/$hash/'
       preLoaderRoute: typeof MainTreeTreeNameBranchHashIndexImport
-      parentRoute: typeof MainTreeRouteImport
+      parentRoute: typeof MainTreeTreeNameBranchHashRouteImport
     }
     '/_main/(alternatives)/c/$treeName/$branch/$hash/': {
       id: '/_main/(alternatives)/c/$treeName/$branch/$hash/'
@@ -675,18 +690,33 @@ const MainTreeTreeIdRouteRouteChildren: MainTreeTreeIdRouteRouteChildren = {
 const MainTreeTreeIdRouteRouteWithChildren =
   MainTreeTreeIdRouteRoute._addFileChildren(MainTreeTreeIdRouteRouteChildren)
 
+interface MainTreeTreeNameBranchHashRouteRouteChildren {
+  MainTreeTreeNameBranchHashIndexRoute: typeof MainTreeTreeNameBranchHashIndexRoute
+}
+
+const MainTreeTreeNameBranchHashRouteRouteChildren: MainTreeTreeNameBranchHashRouteRouteChildren =
+  {
+    MainTreeTreeNameBranchHashIndexRoute: MainTreeTreeNameBranchHashIndexRoute,
+  }
+
+const MainTreeTreeNameBranchHashRouteRouteWithChildren =
+  MainTreeTreeNameBranchHashRouteRoute._addFileChildren(
+    MainTreeTreeNameBranchHashRouteRouteChildren,
+  )
+
 interface MainTreeRouteRouteChildren {
   MainTreeTreeIdRouteRoute: typeof MainTreeTreeIdRouteRouteWithChildren
   MainTreeIndexRoute: typeof MainTreeIndexRoute
+  MainTreeTreeNameBranchHashRouteRoute: typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   MainTreeTreeNameBranchIndexRoute: typeof MainTreeTreeNameBranchIndexRoute
-  MainTreeTreeNameBranchHashIndexRoute: typeof MainTreeTreeNameBranchHashIndexRoute
 }
 
 const MainTreeRouteRouteChildren: MainTreeRouteRouteChildren = {
   MainTreeTreeIdRouteRoute: MainTreeTreeIdRouteRouteWithChildren,
   MainTreeIndexRoute: MainTreeIndexRoute,
+  MainTreeTreeNameBranchHashRouteRoute:
+    MainTreeTreeNameBranchHashRouteRouteWithChildren,
   MainTreeTreeNameBranchIndexRoute: MainTreeTreeNameBranchIndexRoute,
-  MainTreeTreeNameBranchHashIndexRoute: MainTreeTreeNameBranchHashIndexRoute,
 }
 
 const MainTreeRouteRouteWithChildren = MainTreeRouteRoute._addFileChildren(
@@ -842,6 +872,7 @@ export interface FileRoutesByFullPath {
   '/issue/$issueId/': typeof MainIssueIssueIdIndexRoute
   '/test/$testId/': typeof MainTestTestIdIndexRoute
   '/tree/$treeId/': typeof MainTreeTreeIdIndexRoute
+  '/tree/$treeName/$branch/$hash': typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   '/b/$buildId/': typeof MainalternativesBBuildIdIndexRoute
   '/i/$issueId/': typeof MainalternativesIIssueIdIndexRoute
   '/t/$testId/': typeof MainalternativesTTestIdIndexRoute
@@ -857,7 +888,7 @@ export interface FileRoutesByFullPath {
   '/hardware/$hardwareId/test/$testId': typeof MainHardwareHardwareIdTestTestIdIndexRoute
   '/tree/$treeId/build/$buildId': typeof MainTreeTreeIdBuildBuildIdIndexRoute
   '/tree/$treeId/test/$testId': typeof MainTreeTreeIdTestTestIdIndexRoute
-  '/tree/$treeName/$branch/$hash': typeof MainTreeTreeNameBranchHashIndexRoute
+  '/tree/$treeName/$branch/$hash/': typeof MainTreeTreeNameBranchHashIndexRoute
   '/c/$treeName/$branch/$hash': typeof MainalternativesCTreeNameBranchHashIndexRoute
 }
 
@@ -917,6 +948,7 @@ export interface FileRoutesById {
   '/_main/issue/$issueId/': typeof MainIssueIssueIdIndexRoute
   '/_main/test/$testId/': typeof MainTestTestIdIndexRoute
   '/_main/tree/$treeId/': typeof MainTreeTreeIdIndexRoute
+  '/_main/tree/$treeName/$branch/$hash': typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   '/_main/(alternatives)/b/$buildId/': typeof MainalternativesBBuildIdIndexRoute
   '/_main/(alternatives)/i/$issueId/': typeof MainalternativesIIssueIdIndexRoute
   '/_main/(alternatives)/t/$testId/': typeof MainalternativesTTestIdIndexRoute
@@ -962,6 +994,7 @@ export interface FileRouteTypes {
     | '/issue/$issueId/'
     | '/test/$testId/'
     | '/tree/$treeId/'
+    | '/tree/$treeName/$branch/$hash'
     | '/b/$buildId/'
     | '/i/$issueId/'
     | '/t/$testId/'
@@ -977,7 +1010,7 @@ export interface FileRouteTypes {
     | '/hardware/$hardwareId/test/$testId'
     | '/tree/$treeId/build/$buildId'
     | '/tree/$treeId/test/$testId'
-    | '/tree/$treeName/$branch/$hash'
+    | '/tree/$treeName/$branch/$hash/'
     | '/c/$treeName/$branch/$hash'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -1034,6 +1067,7 @@ export interface FileRouteTypes {
     | '/_main/issue/$issueId/'
     | '/_main/test/$testId/'
     | '/_main/tree/$treeId/'
+    | '/_main/tree/$treeName/$branch/$hash'
     | '/_main/(alternatives)/b/$buildId/'
     | '/_main/(alternatives)/i/$issueId/'
     | '/_main/(alternatives)/t/$testId/'
@@ -1122,8 +1156,8 @@ export const routeTree = rootRoute
       "children": [
         "/_main/tree/$treeId",
         "/_main/tree/",
-        "/_main/tree/$treeName/$branch/",
-        "/_main/tree/$treeName/$branch/$hash/"
+        "/_main/tree/$treeName/$branch/$hash",
+        "/_main/tree/$treeName/$branch/"
       ]
     },
     "/_main/": {
@@ -1230,6 +1264,13 @@ export const routeTree = rootRoute
       "filePath": "_main/tree/$treeId/index.tsx",
       "parent": "/_main/tree/$treeId"
     },
+    "/_main/tree/$treeName/$branch/$hash": {
+      "filePath": "_main/tree/$treeName/$branch/$hash/route.tsx",
+      "parent": "/_main/tree",
+      "children": [
+        "/_main/tree/$treeName/$branch/$hash/"
+      ]
+    },
     "/_main/(alternatives)/b/$buildId/": {
       "filePath": "_main/(alternatives)/b/$buildId/index.tsx",
       "parent": "/_main/(alternatives)/b/$buildId"
@@ -1292,7 +1333,7 @@ export const routeTree = rootRoute
     },
     "/_main/tree/$treeName/$branch/$hash/": {
       "filePath": "_main/tree/$treeName/$branch/$hash/index.tsx",
-      "parent": "/_main/tree"
+      "parent": "/_main/tree/$treeName/$branch/$hash"
     },
     "/_main/(alternatives)/c/$treeName/$branch/$hash/": {
       "filePath": "_main/(alternatives)/c/$treeName/$branch/$hash/index.tsx",

--- a/dashboard/src/routes/_main/tree/$treeId/index.tsx
+++ b/dashboard/src/routes/_main/tree/$treeId/index.tsx
@@ -3,5 +3,5 @@ import { createFileRoute } from '@tanstack/react-router';
 import TreeDetails from '@/pages/TreeDetails/TreeDetails';
 
 export const Route = createFileRoute('/_main/tree/$treeId/')({
-  component: TreeDetails,
+  component: () => <TreeDetails urlFrom="/_main/tree/$treeId" />,
 });

--- a/dashboard/src/routes/_main/tree/$treeId/route.tsx
+++ b/dashboard/src/routes/_main/tree/$treeId/route.tsx
@@ -19,7 +19,7 @@ import {
   zTreeInformation,
 } from '@/types/tree/TreeDetails';
 
-const defaultValues = {
+export const treeDetailsDefaultValues = {
   diffFilter: DEFAULT_DIFF_FILTER,
   origin: DEFAULT_ORIGIN,
   treeInfo: DEFAULT_TREE_INFO,
@@ -27,7 +27,7 @@ const defaultValues = {
   tableFilter: zTableFilterInfoDefault,
 };
 
-const treeDetailsSearchSchema = z.object({
+export const treeDetailsSearchSchema = z.object({
   diffFilter: zDiffFilter,
   origin: zOrigin,
   treeInfo: zTreeInformation,
@@ -37,5 +37,5 @@ const treeDetailsSearchSchema = z.object({
 
 export const Route = createFileRoute('/_main/tree/$treeId')({
   validateSearch: treeDetailsSearchSchema,
-  search: { middlewares: [stripSearchParams(defaultValues)] },
+  search: { middlewares: [stripSearchParams(treeDetailsDefaultValues)] },
 });

--- a/dashboard/src/routes/_main/tree/$treeName/$branch/$hash/index.tsx
+++ b/dashboard/src/routes/_main/tree/$treeName/$branch/$hash/index.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-import { TreeLatest } from '@/pages/TreeLatest';
+import TreeDetails from '@/pages/TreeDetails/TreeDetails';
 
 export const Route = createFileRoute('/_main/tree/$treeName/$branch/$hash/')({
-  component: () => {
-    return <TreeLatest urlFrom="/_main/tree/$treeName/$branch/$hash/" />;
-  },
+  component: () => (
+    <TreeDetails urlFrom="/_main/tree/$treeName/$branch/$hash" />
+  ),
 });

--- a/dashboard/src/routes/_main/tree/$treeName/$branch/$hash/route.tsx
+++ b/dashboard/src/routes/_main/tree/$treeName/$branch/$hash/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
+
+import {
+  treeDetailsDefaultValues,
+  treeDetailsSearchSchema,
+} from '@/routes/_main/tree/$treeId/route';
+
+export const Route = createFileRoute('/_main/tree/$treeName/$branch/$hash')({
+  validateSearch: treeDetailsSearchSchema,
+  search: { middlewares: [stripSearchParams(treeDetailsDefaultValues)] },
+});

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -213,3 +213,20 @@ export type LogFilesResponse = {
 };
 
 export type TTreeCommitHistoryResponse = PaginatedCommitHistoryByTree[];
+
+// TODO: These variables could be defined in the route files but it would cause
+// a circular dependency, requiring rewiring of the imports.
+export const treeDetailsDirectRouteName = '/_main/tree/$treeName/$branch/$hash';
+export const treeDetailsRouteName = '/_main/tree/$treeId';
+
+// This map is necessary since the "from" parameter in `useSearch` and `useParameters`
+// requires the "/_main" prefix, while the "from" in `navigate` doesn't
+export const treeDetailsFromMap = {
+  [treeDetailsDirectRouteName]: '/tree/$treeName/$branch/$hash',
+  [treeDetailsRouteName]: '/tree/$treeId',
+} as const;
+
+export type TreeDetailsRouteFrom = keyof typeof treeDetailsFromMap;
+
+export type TreeDetailsNavigateFrom =
+  (typeof treeDetailsFromMap)[TreeDetailsRouteFrom];

--- a/dashboard/src/utils/treeDetails.ts
+++ b/dashboard/src/utils/treeDetails.ts
@@ -1,0 +1,42 @@
+import {
+  treeDetailsDirectRouteName,
+  type TreeDetailsRouteFrom,
+  type TTreeInformation,
+} from '@/types/tree/TreeDetails';
+
+import { getStringParam } from './utils';
+
+type SanitizedTreeInfo = TTreeInformation & {
+  hash: string;
+};
+
+export const sanitizeTreeinfo = ({
+  treeInfo,
+  params,
+  urlFrom,
+}: {
+  treeInfo: TTreeInformation;
+  params: Record<string, string>; // as params from treeDetailsUrls
+  urlFrom: TreeDetailsRouteFrom;
+}): SanitizedTreeInfo => {
+  if (urlFrom === treeDetailsDirectRouteName) {
+    return {
+      treeName: getStringParam(params, 'treeName'),
+      gitBranch: getStringParam(params, 'branch'),
+      hash: getStringParam(params, 'hash'),
+      commitName: treeInfo.commitName,
+      gitUrl: treeInfo.gitUrl,
+      // Copying the hash into headCommitHash is meant for the first entering of the page, when there is no hash selected.
+      headCommitHash: treeInfo.headCommitHash || getStringParam(params, 'hash'),
+    };
+  }
+
+  return {
+    treeName: treeInfo.treeName,
+    gitBranch: treeInfo.gitBranch,
+    hash: getStringParam(params, 'treeId'),
+    commitName: treeInfo.commitName,
+    gitUrl: treeInfo.gitUrl,
+    headCommitHash: treeInfo.headCommitHash,
+  };
+};

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -232,3 +232,11 @@ export const getTitle = (title?: string, loading?: boolean): string => {
 
   return valueOrEmpty(title);
 };
+
+export const getStringParam = (
+  params: Record<string, string>,
+  key: string,
+  defaultValue?: string,
+): string => {
+  return key in params ? params[key] : defaultValue ?? '';
+};


### PR DESCRIPTION
## Description
This PR changes the way that the data is used in order to get the treeDetails page. Instead of relying on the `git_url` of a tree, we now only need the `tree_name`, `git_repository_branch`, and `git_commit_hash`. When all of them are available, the url for the treeDetails page should be `/tree/<tree_name>/<branch>/<hash>`.

This has implications of changing how the backend uses those variables to query the database, and implications on the frontend subcomponents that get information from the url and navigate between pages. The frontend page can now be accessed through both urls (no redirecting, just using the same component), and the tree listing page will send the user to the new url for treeDetails. The backend views can also be accessed through both endpoints.

One issue with accessing the endpoint through two endpoints: there are some trees that don't have the url information (even though they should have), and in those cases it was useful to query by `git_repository_url IS NULL` but since the endpoints can be accessed without passing the git_url param (using only tree_name, branch, and hash to get the data), it's unclear if an empty git_url means that a tree has `NULL` git_url or if the endpoint was just accessed without that information. This means that the where clause for `git_url IS NULL` is only used if `tree_name` is also None, meaning that the user did access the endpoint from a place where they should pass `git_url`, but didn't.

The url `/tree/<tree_name>/<branch>` still leads to the shortcut of latest commit hash, and transfers the user to the old, longer, url for now.
Other endpoints such as treeDetailsBuilds/Boots/Tests were not changed.

## Changes
- [x] The backend treeDetails full and summary endpoints accepts both kinds of access (using the information in the `treeInfo` request parameters or using the `tree_name`, `branch` and `hash` from the url itself) to return the data.
- [x] Alters the frontend route of /tree/name/branch/hash to copy treeDetails search schema
- [x] Refactors treeDetails subcomponents to accept both urls in the `useSearch` and `navigate` `from` parameters.
- [x] Alters the treeListing table to direct to the direct page when possible;
- [x] Changes treeCommitHistory to be able to return data without passing a git_url for the query
  - [x] Uses `tree_name` instead of `git_url`
  - [x] Alter frontend api to call the endpoint based on which treeDetails url is being used

## How to test
Check the treeDetails page through the frontend, including cases of empty tree name or branch or url.
Check the treeDetails components, navigation and data, comparing with the production instance, all should be the same.
Check the commitHistory and treeDetailsSummary endpoints


Closes #1281 