### PR TITLE
fix:issue details log excerpt has no height limit

### DIFF
--- a/dashboard/src/components/Filter/CodeBlock.tsx
+++ b/dashboard/src/components/Filter/CodeBlock.tsx
@@ -232,6 +232,7 @@ const CodeBlock = ({
   code,
   highlightsClassnames,
   variant = 'default',
+  className,
 }: TCodeBlockProps): JSX.Element => {
   const disableHighlight = code.length >= MAX_HIGHLIGHT_CODE_LENGTH;
 
@@ -303,6 +304,7 @@ const CodeBlock = ({
               : parsedCode.highlightedCode
           }
           statsElement={statsElement}
+          className={className}
         />
       </div>
     </>

--- a/dashboard/src/utils/misc.tsx
+++ b/dashboard/src/utils/misc.tsx
@@ -47,7 +47,9 @@ export const miscContentHandler = ({
   const showContent = match({ [fieldKey]: fieldValue })
     .with({ log_excerpt: '' }, _ => false)
     .with({ log_excerpt: P.string }, field => {
-      children = <CodeBlock code={field.log_excerpt} />;
+      children = (
+        <CodeBlock code={field.log_excerpt} className="max-h-[80vh]" />
+      );
       return true;
     })
     .otherwise(_ => {


### PR DESCRIPTION
## Description
This PR updates the component's maximum height constraint from max-h-[80%] to max-h-[80vh] to ensure correct rendering and scrolling behavior.
Using a percentage-based max height (80%) caused issues when the component was rendered inside containers with dynamic height, preventing overflow-auto from working correctly. By switching to a viewport-based height (80vh), the component now correctly limits its height relative to the viewport, allowing scrollbars to appear as expected when content overflows.

## Changes
- [x] Replaced max-h-[80%] with max-h-[80vh] in the component's class

## How to test
Access a issue detail page as in the following URL: /issue/redhat%3A5489bb749eafbe4f9233f4a1e660c6d234b16408?iv=1
Verify that the element previously overflowing now respects a height limit.
Confirm that it is scrollable when the content exceeds the visible area.
Ensure the scrollbar appears and functions correctly across different screen sizes.

## Visual Reference

![image](https://github.com/user-attachments/assets/41066f10-3a12-4160-93bf-d32a24c6e365)

Closes #1147 