### PR TITLE
Feat: Add kci-dev information

### DIFF
--- a/backend/kernelCI_app/tests/integrationTests/treeListing_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeListing_test.py
@@ -58,7 +58,7 @@ def pytest_generate_tests(metafunc):
                 False,
             ),
             (
-                {"origin": "tuxsuite", "interval_in_days": "7"},
+                {"origin": "linaro", "interval_in_days": "7"},
                 HTTPStatus.OK,
                 False,
             ),

--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -51,6 +51,8 @@ import MemoizedLinkItem from '@/components/DetailsLink';
 import { LinkIcon } from '@/components/Icons/Link';
 import { processLogData } from '@/hooks/useLogData';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
 import BuildDetailsTestSection from './BuildDetailsTestSection';
 
 interface BuildDetailsProps {
@@ -271,6 +273,21 @@ const BuildDetails = ({
     );
   }, [data?.git_commit_name, data?.tree_name, formatMessage, isLoading]);
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter
+        commandGroup="details"
+        args={{
+          cmdName: 'build',
+          id: buildId,
+          'download-logs': true,
+          json: true,
+        }}
+      />
+    ),
+    [buildId],
+  );
+
   return (
     <PageWithTitle title={buildDetailsTabTitle}>
       <MemoizedBuildDetailsOGTags
@@ -309,6 +326,7 @@ const BuildDetails = ({
                 />
               )}
               {filesSection && <SectionGroup sections={[filesSection]} />}
+              {kcidevComponent}
             </div>
             <LogOrJsonSheetContent
               type={sheetType}

--- a/dashboard/src/components/Footer/KcidevFooter.tsx
+++ b/dashboard/src/components/Footer/KcidevFooter.tsx
@@ -1,0 +1,174 @@
+import { memo, useMemo, type JSX } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { TbTerminal2 } from 'react-icons/tb';
+
+import { TooltipIcon } from '@/components/Icons/TooltipIcon';
+
+// These types define the possible args of the command,
+// including their variation (command after `kci-dev results`)
+type TreeDetailsCmdFlags = {
+  cmdName: 'summary' | 'builds' | 'boots' | 'tests';
+  'git-url'?: string;
+  branch?: string;
+  commit: string;
+};
+
+type DetailsCmdFlags = {
+  cmdName: 'build' | 'boot' | 'test';
+  id: string;
+  'download-logs': boolean;
+  json: boolean;
+};
+
+type HardwareDetailsCmdFlags = {
+  cmdName:
+    | 'hardware summary'
+    | 'hardware builds'
+    | 'hardware boots'
+    | 'hardware tests';
+  name: string;
+  origin: string;
+  json?: boolean;
+};
+
+type HardwareListingCmdFlags = {
+  cmdName: 'hardware list';
+  origin: string;
+  json: boolean;
+};
+
+type TreeListingCmdFlags = {
+  cmdName: 'trees';
+};
+
+// This map dictates which flags each commandGroup will accept
+type CommandArgsMap = {
+  treeDetails: TreeDetailsCmdFlags;
+  details: DetailsCmdFlags;
+  hardwareDetails: HardwareDetailsCmdFlags;
+  hardwareListing: HardwareListingCmdFlags;
+  trees: TreeListingCmdFlags;
+  issue: never;
+};
+
+// This type and map will tell which arguments will be added as `command value` or `command --key value`
+type PositionalArgs = {
+  required: string[];
+  flags: string[];
+};
+
+const commandArgs: {
+  [K in keyof CommandArgsMap]: PositionalArgs;
+} = {
+  treeDetails: {
+    required: ['cmdName'],
+    flags: ['git-url', 'branch', 'commit'],
+  },
+  details: {
+    required: ['cmdName'],
+    flags: ['id', 'download-logs', 'json'],
+  },
+  hardwareDetails: {
+    required: ['cmdName'],
+    flags: ['name', 'origin', 'json'],
+  },
+  hardwareListing: {
+    required: ['cmdName'],
+    flags: ['origin', 'json'],
+  },
+  trees: {
+    required: ['cmdName'],
+    flags: [],
+  },
+  issue: {
+    required: [],
+    flags: [],
+  },
+};
+
+const BASECOMMAND = 'kci-dev results';
+
+const buildCommand = <K extends keyof CommandArgsMap>(
+  commandGroup: K,
+  args: CommandArgsMap[K],
+): string | undefined => {
+  const parts = [BASECOMMAND];
+
+  for (const key in args) {
+    if (Object.prototype.hasOwnProperty.call(args, key)) {
+      const value = args[key];
+      if (value) {
+        if (commandArgs[commandGroup]['required'].includes(key)) {
+          parts.push(String(value));
+        } else {
+          if (typeof value === 'boolean' && value) {
+            parts.push(`--${key}`);
+          } else {
+            parts.push(`--${key} '${value}'`);
+          }
+        }
+      } else {
+        // for the purpose of the examples, if some of the values
+        // are missing then we don't return the command
+        return undefined;
+      }
+    }
+  }
+
+  return parts.join(' ');
+};
+
+// TODO: there are better ways of passing the args,
+// one of them could be changing the parameters of the component itself
+// instead of passing the args inside an object, which would also help with memoization
+const KcidevFooter = <K extends keyof CommandArgsMap>({
+  commandGroup,
+  args,
+}: {
+  commandGroup: K;
+  args?: CommandArgsMap[K];
+}): JSX.Element => {
+  const { formatMessage } = useIntl();
+
+  const kcidevLink = useMemo(() => {
+    return (
+      <a
+        href="https://kci.dev"
+        target="_blank"
+        rel="noreferrer"
+        className="text-dark-blue underline"
+      >
+        {formatMessage({ id: 'global.kcidev' })}
+      </a>
+    );
+  }, [formatMessage]);
+
+  const command = useMemo(() => {
+    if (!args) {
+      return;
+    }
+
+    return buildCommand(commandGroup, args);
+  }, [commandGroup, args]);
+
+  return (
+    <div className="flex justify-center text-center align-middle text-[14px]">
+      <span className="inline">
+        <span className="mr-1 font-bold">
+          <FormattedMessage id="footer.question" />
+        </span>
+        <FormattedMessage id="footer.kcidev" values={{ link: kcidevLink }} />
+      </span>
+      {command && (
+        <TooltipIcon
+          tooltipId="footer.command"
+          tooltipValues={{ command: command }}
+          icon={<TbTerminal2 className="ml-2 size-5" />}
+        />
+      )}
+    </div>
+  );
+};
+
+export const MemoizedKcidevFooter = memo(KcidevFooter);

--- a/dashboard/src/components/Icons/TooltipIcon.tsx
+++ b/dashboard/src/components/Icons/TooltipIcon.tsx
@@ -6,6 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import { formattedBreakLineValue, type MessagesKey } from '@/locales/messages';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
+import { cn } from '@/lib/utils';
 
 export const TooltipIcon = ({
   triggerClassName,
@@ -13,19 +14,21 @@ export const TooltipIcon = ({
   contentClassName,
   tooltipId,
   tooltipValues,
+  icon,
 }: {
   triggerClassName?: string;
   iconClassName?: string;
   contentClassName?: string;
   tooltipId: MessagesKey;
   tooltipValues?: Record<string, unknown>;
+  icon?: JSX.Element;
 }): JSX.Element => {
   return (
     <Tooltip>
       <TooltipTrigger className={triggerClassName}>
-        <LiaQuestionCircle className={iconClassName} />
+        {icon ?? <LiaQuestionCircle className={iconClassName} />}
       </TooltipTrigger>
-      <TooltipContent className={contentClassName}>
+      <TooltipContent className={cn('whitespace-pre-line', contentClassName)}>
         <FormattedMessage
           id={tooltipId}
           values={{ ...formattedBreakLineValue, ...tooltipValues }}

--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -48,6 +48,8 @@ import { TooltipIcon } from '@/components/Icons/TooltipIcon';
 
 import { Badge } from '@/components/ui/badge';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
 import { IssueDetailsTestSection } from './IssueDetailsTestSection';
 
 import { IssueDetailsBuildSection } from './IssueDetailsBuildSection';
@@ -252,25 +254,26 @@ export const IssueDetails = ({
       >
         <ErrorBoundary FallbackComponent={UnexpectedError}>
           <Sheet>
-            {breadcrumb}
-            <SectionGroup sections={sectionsData} />
-
-            <IssueDetailsTestSection
-              issueId={issueId}
-              versionNumber={versionNumber}
-              testTableFilter={tableFilter.testsTable}
-              getTableRowLink={getTestTableRowLink}
-              onClickFilter={onClickTestFilter}
-            />
-
-            <IssueDetailsBuildSection
-              issueId={issueId}
-              versionNumber={versionNumber}
-              buildTableFilter={tableFilter.buildsTable}
-              getTableRowLink={getBuildTableRowLink}
-              onClickFilter={onClickBuildFilter}
-            />
-            <LogOrJsonSheetContent type="json" jsonContent={jsonContent} />
+            <div className="pb-10">
+              {breadcrumb}
+              <SectionGroup sections={sectionsData} />
+              <IssueDetailsTestSection
+                issueId={issueId}
+                versionNumber={versionNumber}
+                testTableFilter={tableFilter.testsTable}
+                getTableRowLink={getTestTableRowLink}
+                onClickFilter={onClickTestFilter}
+              />
+              <IssueDetailsBuildSection
+                issueId={issueId}
+                versionNumber={versionNumber}
+                buildTableFilter={tableFilter.buildsTable}
+                getTableRowLink={getBuildTableRowLink}
+                onClickFilter={onClickBuildFilter}
+              />
+              <LogOrJsonSheetContent type="json" jsonContent={jsonContent} />
+              <MemoizedKcidevFooter commandGroup="issue" />
+            </div>
           </Sheet>
         </ErrorBoundary>
       </QuerySwitcher>

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -69,6 +69,10 @@ import { processLogData } from '@/hooks/useLogData';
 import { dateObjectToTimestampInSeconds, daysToSeconds } from '@/utils/date';
 import { REDUCED_TIME_SEARCH } from '@/utils/constants/general';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
+import { isBoot } from '@/utils/test';
+
 import { StatusHistoryItem } from './StatusHistoryItem';
 
 const TestDetailsSections = ({
@@ -572,6 +576,22 @@ const TestDetails = ({ breadcrumb }: TestsDetailsProps): JSX.Element => {
     );
   }, [data?.path, formatMessage, isLoading]);
 
+  const kcidevComponent = useMemo(() => {
+    const command = isBoot(data?.path) ? 'boot' : 'test';
+
+    return (
+      <MemoizedKcidevFooter
+        commandGroup={'details'}
+        args={{
+          cmdName: command,
+          id: testId,
+          'download-logs': true,
+          json: true,
+        }}
+      />
+    );
+  }, [data?.path, testId]);
+
   return (
     <PageWithTitle title={testDetailsTabTitle}>
       <MemoizedTestDetailsOGTags title={testDetailsTabTitle} data={data} />
@@ -605,6 +625,7 @@ const TestDetails = ({ breadcrumb }: TestsDetailsProps): JSX.Element => {
               status={issueStatus}
               error={issueError?.message}
             />
+            {kcidevComponent}
           </div>
           <LogOrJsonSheetContent
             type={sheetType}

--- a/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
@@ -16,6 +16,8 @@ import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import { matchesRegexOrIncludes } from '@/lib/string';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
 import { TreeTable } from './TreeTable';
 
 interface ITreeListingPage {
@@ -99,6 +101,13 @@ const TreeListingPage = ({ inputFilter }: ITreeListingPage): JSX.Element => {
       });
   }, [data, fastData, inputFilter, isLoading, fastStatus]);
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter commandGroup="trees" args={{ cmdName: 'trees' }} />
+    ),
+    [],
+  );
+
   if (error) {
     return <div>Error: {error.message}</div>;
   }
@@ -119,6 +128,7 @@ const TreeListingPage = ({ inputFilter }: ITreeListingPage): JSX.Element => {
       <div className="flex flex-col gap-6">
         <TreeTable treeTableRows={listItems} />
       </div>
+      {kcidevComponent}
     </QuerySwitcher>
   );
 };

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -92,6 +92,10 @@ export const messages = {
     'filter.testStatus': 'Test Status',
     'filter.treeSubtitle': 'Please select one or more Trees:',
     'filter.treeURL': 'Tree URL',
+    'footer.command': 'Command for this page:\n{command}',
+    'footer.kcidev':
+      'You can use {link} to retrieve KernelCI data from the command line',
+    'footer.question': 'Did you know?',
     'global.allCount': 'All: {count}',
     'global.arch': 'Arch',
     'global.architecture': 'Architecture',
@@ -133,6 +137,7 @@ export const messages = {
     'global.inconclusiveCount': 'Inconclusive: {count}',
     'global.info': 'Info',
     'global.issues': 'Issues',
+    'global.kcidev': 'kci-dev',
     'global.last': 'Last',
     'global.legend': 'Legend',
     'global.loading': 'Loading...',

--- a/dashboard/src/pages/Hardware/HardwareListingPage.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPage.tsx
@@ -22,6 +22,8 @@ import {
   includesInAnStringOrStringArray,
 } from '@/lib/string';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
 import { HardwareTable } from './HardwareTable';
 
 interface HardwareListingPageProps {
@@ -68,6 +70,7 @@ const HardwareListingPage = ({
 }: HardwareListingPageProps): JSX.Element => {
   const { startTimestampInSeconds, endTimestampInSeconds } =
     useHardwareListingTime();
+  const { origin } = useSearch({ from: '/_main/hardware' });
 
   const { data, error, status, isLoading } = useHardwareListing(
     startTimestampInSeconds,
@@ -130,6 +133,16 @@ const HardwareListingPage = ({
       .sort((a, b) => a.platform.localeCompare(b.platform));
   }, [data, error, inputFilter]);
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter
+        commandGroup="hardwareListing"
+        args={{ cmdName: 'hardware list', origin: origin, json: true }}
+      />
+    ),
+    [origin],
+  );
+
   return (
     <QuerySwitcher
       status={status}
@@ -150,6 +163,7 @@ const HardwareListingPage = ({
           startTimestampInSeconds={startTimestampInSeconds}
         />
       </div>
+      {kcidevComponent}
     </QuerySwitcher>
   );
 };

--- a/dashboard/src/pages/IssueListing/IssueListingPage.tsx
+++ b/dashboard/src/pages/IssueListing/IssueListingPage.tsx
@@ -22,6 +22,8 @@ import { REDUCED_TIME_SEARCH } from '@/utils/constants/general';
 
 import { mapFilterToReq } from '@/components/Tabs/Filters';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
 import IssueListingFilter from './IssueListingFilter';
 
 interface IIssueListingPage {
@@ -96,6 +98,7 @@ export const IssueListingPage = ({
           </div>
         </div>
         <IssueTable issueListing={filteredData} />
+        <MemoizedKcidevFooter commandGroup="issue" />
       </div>
     </QuerySwitcher>
   );

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -35,6 +35,7 @@ import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 import { MemoizedOriginsCard } from '@/components/Cards/OriginsCard';
 import { sanitizeTreeinfo } from '@/utils/treeDetails';
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
 
 interface BootsTabProps {
   treeDetailsLazyLoaded: TreeDetailsLazyLoaded;
@@ -187,8 +188,27 @@ const BootsTab = ({
 
   const { formatMessage } = useIntl();
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter
+        commandGroup="treeDetails"
+        args={{
+          cmdName: 'boots',
+          'git-url': sanitizedTreeInfo.gitUrl,
+          branch: sanitizedTreeInfo.gitBranch,
+          commit: sanitizedTreeInfo.hash,
+        }}
+      />
+    ),
+    [
+      sanitizedTreeInfo.gitBranch,
+      sanitizedTreeInfo.gitUrl,
+      sanitizedTreeInfo.hash,
+    ],
+  );
+
   return (
-    <div>
+    <div className="pb-10">
       <QuerySwitcher
         data={nonEmptyData}
         status={summaryStatus}
@@ -316,6 +336,7 @@ const BootsTab = ({
               currentPathFilter={currentPathFilter}
             />
           </QuerySwitcher>
+          {kcidevComponent}
         </div>
       </QuerySwitcher>
       {isEmptySummary && (

--- a/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Boots/BootsTab.tsx
@@ -34,7 +34,7 @@ import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 import { MemoizedOriginsCard } from '@/components/Cards/OriginsCard';
-import { getStringParam } from '@/utils/utils';
+import { sanitizeTreeinfo } from '@/utils/treeDetails';
 
 interface BootsTabProps {
   treeDetailsLazyLoaded: TreeDetailsLazyLoaded;
@@ -45,22 +45,31 @@ const BootsTab = ({
   treeDetailsLazyLoaded,
   urlFrom,
 }: BootsTabProps): JSX.Element => {
+  const navigate = useNavigate({ from: treeDetailsFromMap[urlFrom] });
   const params = useParams({
     from: urlFrom,
   });
-  const treeId =
-    getStringParam(params, 'treeId') || getStringParam(params, 'hash');
-  const treeName = getStringParam(params, 'treeName');
-
-  const { tableFilter, diffFilter } = useSearch({
+  const { tableFilter, diffFilter, treeInfo } = useSearch({
     from: urlFrom,
   });
+
+  const sanitizedTreeInfo = useMemo(() => {
+    return sanitizeTreeinfo({
+      params,
+      treeInfo,
+      urlFrom,
+      summaryUrl: treeDetailsLazyLoaded.summary.data?.common.tree_url,
+    });
+  }, [
+    params,
+    treeDetailsLazyLoaded.summary.data?.common.tree_url,
+    treeInfo,
+    urlFrom,
+  ]);
 
   const currentPathFilter = diffFilter.bootPath
     ? Object.keys(diffFilter.bootPath)[0]
     : undefined;
-
-  const navigate = useNavigate({ from: treeDetailsFromMap[urlFrom] });
 
   const updatePathFilter = useCallback(
     (pathFilter: string) => {
@@ -145,13 +154,13 @@ const BootsTab = ({
       to: '/tree/$treeId/test/$testId',
       params: {
         testId: bootId,
-        treeId: treeId,
+        treeId: sanitizedTreeInfo.hash,
       },
       search: s => ({
         origin: s.origin,
       }),
     }),
-    [treeId],
+    [sanitizedTreeInfo.hash],
   );
 
   const hardwareData = useMemo((): PropertyStatusCounts => {
@@ -216,7 +225,7 @@ const BootsTab = ({
             <div>
               <TreeCommitNavigationGraph
                 urlFrom={urlFrom}
-                treeName={treeName}
+                treeName={sanitizedTreeInfo.treeName}
               />
               <MemoizedHardwareTested
                 title={<FormattedMessage id="bootsTab.hardwareTested" />}
@@ -235,7 +244,7 @@ const BootsTab = ({
               failedWithUnknownIssues={summaryBootsData?.unknown_issues}
               diffFilter={diffFilter}
               issueFilterSection="bootIssue"
-              detailsId={treeId}
+              detailsId={sanitizedTreeInfo.hash}
               pageFrom={RedirectFrom.Tree}
               issueExtraDetails={
                 treeDetailsLazyLoaded.issuesExtras.data?.issues
@@ -250,7 +259,10 @@ const BootsTab = ({
               toggleFilterBySection={toggleFilterBySection}
               filterStatusKey="bootStatus"
             />
-            <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
+            <TreeCommitNavigationGraph
+              urlFrom={urlFrom}
+              treeName={sanitizedTreeInfo.treeName}
+            />
             <InnerMobileGrid>
               <div>
                 <MemoizedConfigList
@@ -282,7 +294,7 @@ const BootsTab = ({
                 failedWithUnknownIssues={summaryBootsData?.unknown_issues}
                 diffFilter={diffFilter}
                 issueFilterSection="bootIssue"
-                detailsId={treeId}
+                detailsId={sanitizedTreeInfo.hash}
                 pageFrom={RedirectFrom.Tree}
                 issueExtraDetails={
                   treeDetailsLazyLoaded.issuesExtras.data?.issues
@@ -318,7 +330,10 @@ const BootsTab = ({
               />
             </div>
           )}
-          <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
+          <TreeCommitNavigationGraph
+            urlFrom={urlFrom}
+            treeName={sanitizedTreeInfo.treeName}
+          />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -51,6 +51,7 @@ import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import { MemoizedOriginsCard } from '@/components/Cards/OriginsCard';
 import { sanitizeTreeinfo } from '@/utils/treeDetails';
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
 
 import { TreeDetailsBuildsTable } from './TreeDetailsBuildsTable';
 
@@ -169,8 +170,27 @@ const BuildTab = ({
 
   const { formatMessage } = useIntl();
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter
+        commandGroup="treeDetails"
+        args={{
+          cmdName: 'builds',
+          'git-url': sanitizedTreeInfo.gitUrl,
+          branch: sanitizedTreeInfo.gitBranch,
+          commit: sanitizedTreeInfo.hash,
+        }}
+      />
+    ),
+    [
+      sanitizedTreeInfo.gitBranch,
+      sanitizedTreeInfo.gitUrl,
+      sanitizedTreeInfo.hash,
+    ],
+  );
+
   return (
-    <div>
+    <div className="pb-10">
       <QuerySwitcher
         data={summaryData}
         status={summaryStatus}
@@ -299,6 +319,7 @@ const BuildTab = ({
               />
             </div>
           </QuerySwitcher>
+          {kcidevComponent}
         </div>
       </QuerySwitcher>
       {isEmptySummary && (

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/BuildTab.tsx
@@ -27,7 +27,6 @@ import {
   sanitizeConfigs,
   sanitizeBuildsSummary,
   sanitizeBuilds,
-  getStringParam,
 } from '@/utils/utils';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
@@ -51,6 +50,7 @@ import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import { MemoizedOriginsCard } from '@/components/Cards/OriginsCard';
+import { sanitizeTreeinfo } from '@/utils/treeDetails';
 
 import { TreeDetailsBuildsTable } from './TreeDetailsBuildsTable';
 
@@ -73,18 +73,25 @@ const BuildTab = ({
   treeDetailsLazyLoaded,
   urlFrom,
 }: BuildTab): JSX.Element => {
-  const navigate = useNavigate({
-    from: treeDetailsFromMap[urlFrom],
-  });
-
-  const { diffFilter } = useSearch({
+  const navigate = useNavigate({ from: treeDetailsFromMap[urlFrom] });
+  const params = useParams({ from: urlFrom });
+  const { diffFilter, treeInfo } = useSearch({
     from: urlFrom,
   });
 
-  const params = useParams({ from: urlFrom });
-  const treeId =
-    getStringParam(params, 'treeId') || getStringParam(params, 'hash');
-  const treeName = getStringParam(params, 'treeName');
+  const sanitizedTreeInfo = useMemo(() => {
+    return sanitizeTreeinfo({
+      params,
+      treeInfo,
+      urlFrom,
+      summaryUrl: treeDetailsLazyLoaded.summary.data?.common.tree_url,
+    });
+  }, [
+    params,
+    treeDetailsLazyLoaded.summary.data?.common.tree_url,
+    treeInfo,
+    urlFrom,
+  ]);
 
   const {
     data: summaryData,
@@ -200,7 +207,7 @@ const BuildTab = ({
             <div>
               <TreeCommitNavigationGraph
                 urlFrom={urlFrom}
-                treeName={treeName}
+                treeName={sanitizedTreeInfo.treeName}
               />
               <MemoizedConfigsCard
                 configs={treeDetailsData.configs}
@@ -216,7 +223,7 @@ const BuildTab = ({
               }
               diffFilter={diffFilter}
               issueFilterSection="buildIssue"
-              detailsId={treeId}
+              detailsId={sanitizedTreeInfo.hash}
               pageFrom={RedirectFrom.Tree}
               issueExtraDetails={
                 treeDetailsLazyLoaded.issuesExtras.data?.issues
@@ -225,7 +232,10 @@ const BuildTab = ({
             />
           </DesktopGrid>
           <MobileGrid>
-            <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
+            <TreeCommitNavigationGraph
+              urlFrom={urlFrom}
+              treeName={sanitizedTreeInfo.treeName}
+            />
             <MemoizedStatusCard
               title={<FormattedMessage id="buildTab.buildStatus" />}
               toggleFilterBySection={toggleFilterBySection}
@@ -259,7 +269,7 @@ const BuildTab = ({
               }
               diffFilter={diffFilter}
               issueFilterSection="buildIssue"
-              detailsId={treeId}
+              detailsId={sanitizedTreeInfo.hash}
               pageFrom={RedirectFrom.Tree}
               issueExtraDetails={
                 treeDetailsLazyLoaded.issuesExtras.data?.issues
@@ -303,7 +313,10 @@ const BuildTab = ({
               />
             </div>
           )}
-          <TreeCommitNavigationGraph urlFrom={urlFrom} treeName={treeName} />
+          <TreeCommitNavigationGraph
+            urlFrom={urlFrom}
+            treeName={sanitizedTreeInfo.treeName}
+          />
         </div>
       )}
     </div>

--- a/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Tests/TestsTab.tsx
@@ -35,6 +35,7 @@ import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 import { MemoizedOriginsCard } from '@/components/Cards/OriginsCard';
 import { sanitizeTreeinfo } from '@/utils/treeDetails';
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
 
 interface TestsTabProps {
   treeDetailsLazyLoaded: TreeDetailsLazyLoaded;
@@ -189,8 +190,27 @@ const TestsTab = ({
 
   const { formatMessage } = useIntl();
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter
+        commandGroup="treeDetails"
+        args={{
+          cmdName: 'tests',
+          'git-url': sanitizedTreeInfo.gitUrl,
+          branch: sanitizedTreeInfo.gitBranch,
+          commit: sanitizedTreeInfo.hash,
+        }}
+      />
+    ),
+    [
+      sanitizedTreeInfo.gitBranch,
+      sanitizedTreeInfo.gitUrl,
+      sanitizedTreeInfo.hash,
+    ],
+  );
+
   return (
-    <div>
+    <div className="pb-10">
       <QuerySwitcher
         data={nonEmptyData}
         status={summaryStatus}
@@ -319,6 +339,7 @@ const TestsTab = ({
               currentPathFilter={currentPathFilter}
             />
           </QuerySwitcher>
+          {kcidevComponent}
         </div>
       </QuerySwitcher>
       {isEmptySummary && (

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeCommitNavigationGraph.tsx
@@ -19,7 +19,7 @@ const TreeCommitNavigationGraph = ({
   treeName,
 }: {
   urlFrom: TreeDetailsRouteFrom;
-  treeName: string;
+  treeName?: string;
 }): React.ReactNode => {
   const { origin, currentPageTab, diffFilter, treeInfo } = useSearch({
     from: urlFrom,

--- a/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Boots/BootsTab.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useCallback, type JSX } from 'react';
+import { useCallback, useMemo, type JSX } from 'react';
 
 import type { LinkProps } from '@tanstack/react-router';
 
@@ -35,6 +35,8 @@ import { RedirectFrom, type TFilterObjectsKeys } from '@/types/general';
 import { HardwareDetailsTabsQuerySwitcher } from '@/pages/hardwareDetails/Tabs/HardwareDetailsTabsQuerySwitcher';
 import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
 import { HardwareDetailsBootsTable } from './HardwareDetailsBootsTable';
 
 interface IBootsTab {
@@ -50,7 +52,7 @@ const BootsTab = ({
   bootsSummary,
   fullDataResult,
 }: IBootsTab): JSX.Element => {
-  const { tableFilter, diffFilter } = useSearch({
+  const { tableFilter, diffFilter, origin } = useSearch({
     from: '/_main/hardware/$hardwareId',
   });
 
@@ -130,8 +132,23 @@ const BootsTab = ({
     [navigate],
   );
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter
+        commandGroup="hardwareDetails"
+        args={{
+          cmdName: 'hardware boots',
+          name: hardwareId,
+          origin: origin,
+          json: true,
+        }}
+      />
+    ),
+    [hardwareId, origin],
+  );
+
   return (
-    <div className="flex flex-col gap-8 pt-4">
+    <div className="flex flex-col gap-8 pt-4 pb-10">
       <DesktopGrid>
         <div>
           <MemoizedStatusCard
@@ -213,6 +230,7 @@ const BootsTab = ({
           currentPathFilter={currentPathFilter}
         />
       </HardwareDetailsTabsQuerySwitcher>
+      {kcidevComponent}
     </div>
   );
 };

--- a/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Build/BuildTab.tsx
@@ -32,6 +32,8 @@ import { HardwareDetailsTabsQuerySwitcher } from '@/pages/hardwareDetails/Tabs/H
 
 import { generateDiffFilter } from '@/components/Tabs/tabsUtils';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
 import { HardwareDetailsBuildsTable } from './HardwareDetailsBuildsTable';
 
 interface IBuildTab {
@@ -51,7 +53,7 @@ const BuildTab = ({
     from: '/hardware/$hardwareId',
   });
 
-  const { diffFilter } = useSearch({
+  const { diffFilter, origin } = useSearch({
     from: '/_main/hardware/$hardwareId',
   });
 
@@ -87,8 +89,23 @@ const BuildTab = ({
     [buildsSummary.configs],
   );
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter
+        commandGroup="hardwareDetails"
+        args={{
+          cmdName: 'hardware builds',
+          name: hardwareId,
+          origin: origin,
+          json: true,
+        }}
+      />
+    ),
+    [hardwareId, origin],
+  );
+
   return (
-    <div className="flex flex-col gap-8 pt-4">
+    <div className="flex flex-col gap-8 pt-4 pb-10">
       <DesktopGrid>
         <div>
           <MemoizedStatusCard
@@ -168,6 +185,7 @@ const BuildTab = ({
             hardwareId={hardwareId}
           />
         </HardwareDetailsTabsQuerySwitcher>
+        {kcidevComponent}
       </div>
     </div>
   );

--- a/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/Tests/TestsTab.tsx
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import { useCallback, type JSX } from 'react';
+import { useCallback, useMemo, type JSX } from 'react';
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
@@ -34,6 +34,8 @@ import { RedirectFrom, type TFilterObjectsKeys } from '@/types/general';
 
 import { HardwareDetailsTabsQuerySwitcher } from '@/pages/hardwareDetails/Tabs/HardwareDetailsTabsQuerySwitcher';
 
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
 import HardwareDetailsTestTable from './HardwareDetailsTestsTable';
 
 interface ITestsTab {
@@ -49,7 +51,7 @@ const TestsTab = ({
   testsSummary,
   fullDataResult,
 }: ITestsTab): JSX.Element => {
-  const { tableFilter, diffFilter } = useSearch({
+  const { tableFilter, diffFilter, origin } = useSearch({
     from: '/_main/hardware/$hardwareId',
   });
 
@@ -115,8 +117,23 @@ const TestsTab = ({
     [navigate],
   );
 
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter
+        commandGroup="hardwareDetails"
+        args={{
+          cmdName: 'hardware tests',
+          name: hardwareId,
+          origin: origin,
+          json: true,
+        }}
+      />
+    ),
+    [hardwareId, origin],
+  );
+
   return (
-    <div className="flex flex-col gap-8 pt-4">
+    <div className="flex flex-col gap-8 pt-4 pb-10">
       <DesktopGrid>
         <div>
           <MemoizedStatusCard
@@ -198,6 +215,7 @@ const TestsTab = ({
           currentPathFilter={currentPathFilter}
         />
       </HardwareDetailsTabsQuerySwitcher>
+      {kcidevComponent}
     </div>
   );
 };

--- a/dashboard/src/utils/test.ts
+++ b/dashboard/src/utils/test.ts
@@ -1,0 +1,3 @@
+export const isBoot = (path?: string): boolean => {
+  return path !== undefined && (path === 'boot' || path.startsWith('boot.'));
+};

--- a/dashboard/src/utils/treeDetails.ts
+++ b/dashboard/src/utils/treeDetails.ts
@@ -14,10 +14,12 @@ export const sanitizeTreeinfo = ({
   treeInfo,
   params,
   urlFrom,
+  summaryUrl,
 }: {
   treeInfo: TTreeInformation;
   params: Record<string, string>; // as params from treeDetailsUrls
   urlFrom: TreeDetailsRouteFrom;
+  summaryUrl?: string;
 }): SanitizedTreeInfo => {
   if (urlFrom === treeDetailsDirectRouteName) {
     return {
@@ -25,7 +27,7 @@ export const sanitizeTreeinfo = ({
       gitBranch: getStringParam(params, 'branch'),
       hash: getStringParam(params, 'hash'),
       commitName: treeInfo.commitName,
-      gitUrl: treeInfo.gitUrl,
+      gitUrl: treeInfo.gitUrl ?? summaryUrl,
       // Copying the hash into headCommitHash is meant for the first entering of the page, when there is no hash selected.
       headCommitHash: treeInfo.headCommitHash || getStringParam(params, 'hash'),
     };
@@ -36,7 +38,7 @@ export const sanitizeTreeinfo = ({
     gitBranch: treeInfo.gitBranch,
     hash: getStringParam(params, 'treeId'),
     commitName: treeInfo.commitName,
-    gitUrl: treeInfo.gitUrl,
+    gitUrl: treeInfo.gitUrl ?? summaryUrl,
     headCommitHash: treeInfo.headCommitHash,
   };
 };


### PR DESCRIPTION
## Changes
- Adds a component that can be used as a footer to show a CTA for kci-dev, as well as a tooltip with the equivalent tooltip for that specific page
- Uses that component in all pages, showing the command for the pages that have an equivalent command for them
  - This includes the specific "builds/boots/tests" for treeDetails and hardwareDetails
  - It does not show any command for treeDetails without git_url
  - It does not show any command for issueListing and issueDetails pages since there are no commands for it there
  - All commands are subcommands of `kci-dev results`
- In order to use that component, the `sanitizeTreeInfo` was also used in the treeDetails tabs to get the required data and unify the processing.

## How to test
Go to any page and check the footer at the bottom of the page
Check the different commands, including the difference for each tab under treeDetails and hardwareDetails

## Visual reference
Isolated component while hovering in the icon:
![image](https://github.com/user-attachments/assets/a48a20c7-2d5e-48b5-a216-981710b947a1)

Component with dynamic command:
In treeDetails:
![image](https://github.com/user-attachments/assets/755f7403-c95a-4297-b236-c1de8e25a343)
In buildDetails:
![image](https://github.com/user-attachments/assets/8808b7da-417e-4e5c-9cd6-72789d8430f3)


In the treeListing page:
![image](https://github.com/user-attachments/assets/6041662e-ada2-42e0-be6d-860be4c685b4)


Closes #1247 
