### PR TITLE
Fix: c shortcut to direct url

### DIFF
--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -701,6 +701,7 @@ def get_latest_tree(
         "git_commit_hash",
         "git_commit_name",
         "git_repository_url",
+        "git_repository_branch",
         "tree_name",
         "origin",
     ]

--- a/backend/kernelCI_app/tests/integrationTests/treeLatest_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeLatest_test.py
@@ -50,3 +50,40 @@ def test_tree_latest(tree_name, git_branch, query, has_error_body):
         status_code=HTTPStatus.OK,
         should_error=has_error_body,
     )
+
+
+@pytest.mark.parametrize(
+    "tree_name, git_branch, commit_hash, query, has_error_body",
+    [
+        (
+            "android",
+            "android-mainline",
+            "8dec85f986c74f6c94895d3b56f518de02f9e820",
+            {},
+            False,
+        ),
+        (
+            "mainline",
+            "master",
+            "c4dce0c094a89b1bc8fde1163342bd6fe29c0370",
+            {"origin": "microsoft"},
+            False,
+        ),
+        ("android", "android-mainline", "wrong_hash", {}, True),
+        ("invalid_tree_name", "invalid_branch", "any_hash", {}, True),
+    ],
+)
+def test_tree_latest_hash(tree_name, git_branch, commit_hash, query, has_error_body):
+    response = client.get_tree_latest_hash(
+        tree_name=tree_name,
+        git_branch=git_branch,
+        commit_hash=commit_hash,
+        query=query,
+    )
+    content = string_to_json(response.content.decode())
+    assert_status_code_and_error_response(
+        response=response,
+        content=content,
+        status_code=HTTPStatus.OK,
+        should_error=has_error_body,
+    )

--- a/backend/kernelCI_app/tests/utils/client/treeClient.py
+++ b/backend/kernelCI_app/tests/utils/client/treeClient.py
@@ -30,6 +30,20 @@ class TreeClient(BaseClient):
         url = self.get_endpoint(path=path, query=query)
         return requests.get(url)
 
+    def get_tree_latest_hash(
+        self, *, tree_name: str, git_branch: str, commit_hash: str, query: dict
+    ) -> requests.Response:
+        path = reverse(
+            "treeLatestHash",
+            kwargs={
+                "tree_name": tree_name,
+                "git_branch": git_branch,
+                "commit_hash": commit_hash,
+            },
+        )
+        url = self.get_endpoint(path=path, query=query)
+        return requests.get(url)
+
     def get_tree_details_summary(
         self,
         *,

--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -24,7 +24,9 @@ class TreeLatestQueryParameters(BaseModel):
 
 class TreeLatestResponse(BaseCheckouts):
     api_url: str
+    old_api_url: str
     tree_name: str
+    git_repository_branch: str
 
 
 class TreeCommon(BaseModel):

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -66,6 +66,11 @@ urlpatterns = [
         name="treeLatest",
     ),
     path(
+        "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>",
+        view_cache(views.TreeLatest),
+        name="treeLatestHash",
+    ),
+    path(
         "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>/full",
         views.TreeDetails.as_view(),
         name="treeDetailsDirectView",

--- a/backend/requests/tree-latest-get.sh
+++ b/backend/requests/tree-latest-get.sh
@@ -4,21 +4,25 @@ http 'http://localhost:8000/api/tree/android/android-mainline'
 http 'http://localhost:8000/api/tree/mainline/master/a33b5a08cbbdd7aadff95f40cbb45ab86841679e' origin==microsoft
 
 # HTTP/1.1 200 OK
+# Allow: GET, HEAD, OPTIONS
 # Cache-Control: max-age=0
-# Content-Length: 377
+# Content-Length: 489
 # Content-Type: application/json
 # Cross-Origin-Opener-Policy: same-origin
-# Date: Tue, 07 Jan 2025 16:42:56 GMT
-# Expires: Tue, 07 Jan 2025 16:42:56 GMT
+# Date: Thu, 26 Jun 2025 11:51:01 GMT
+# Expires: Thu, 26 Jun 2025 11:51:01 GMT
 # Referrer-Policy: same-origin
 # Server: WSGIServer/0.2 CPython/3.12.7
-# Vary: origin
+# Vary: Accept, Cookie, origin
 # X-Content-Type-Options: nosniff
 # X-Frame-Options: DENY
 
 # {
-#     "api_url": "/api/tree/544ae1decdc3aede3d021ef1310d586f6383c30b/full?origin=maestro&git_url=https%3A%2F%2Fandroid.googlesource.com%2Fkernel%2Fcommon&git_branch=android-mainline",
-#     "git_commit_hash": "544ae1decdc3aede3d021ef1310d586f6383c30b",
-#     "git_commit_name": "ASB-2024-12-05_mainline-227-g544ae1decdc3",
-#     "git_repository_url": "https://android.googlesource.com/kernel/common"
+#     "api_url": "/api/tree/mainline/master/a33b5a08cbbdd7aadff95f40cbb45ab86841679e/full?origin=microsoft&git_url=https%3A%2F%2Fgit.kernel.org%2Fpub%2Fscm%2Flinux%2Fkernel%2Fgit%2Ftorvalds%2Flinux.git&git_branch=master",
+#     "git_commit_hash": "a33b5a08cbbdd7aadff95f40cbb45ab86841679e",
+#     "git_commit_name": "v6.15-rc3-8-ga33b5a08cbbd",
+#     "git_repository_branch": "master",
+#     "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+#     "origin": "microsoft",
+#     "tree_name": "mainline"
 # }

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1105,6 +1105,44 @@ paths:
               schema:
                 $ref: '#/components/schemas/TreeLatestResponse'
           description: ''
+  /api/tree/{tree_name}/{git_branch}/{commit_hash}:
+    get:
+      operationId: tree_retrieve_3
+      parameters:
+      - in: path
+        name: commit_hash
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: git_branch
+        schema:
+          type: string
+        required: true
+      - in: query
+        name: origin
+        schema:
+          default: maestro
+          title: Origin
+          type: string
+      - in: path
+        name: tree_name
+        schema:
+          type: string
+        required: true
+      tags:
+      - tree
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TreeLatestResponse'
+          description: ''
   /api/tree/{tree_name}/{git_branch}/{commit_hash}/commits:
     get:
       operationId: tree_commits_retrieve_2
@@ -3386,8 +3424,14 @@ components:
         api_url:
           title: Api Url
           type: string
+        old_api_url:
+          title: Old Api Url
+          type: string
         tree_name:
           title: Tree Name
+          type: string
+        git_repository_branch:
+          title: Git Repository Branch
           type: string
       required:
       - git_repository_url
@@ -3395,7 +3439,9 @@ components:
       - git_commit_name
       - origin
       - api_url
+      - old_api_url
       - tree_name
+      - git_repository_branch
       title: TreeLatestResponse
       type: object
     TreeListingFastResponse:

--- a/dashboard/src/pages/TreeLatest.tsx
+++ b/dashboard/src/pages/TreeLatest.tsx
@@ -6,13 +6,6 @@ import type { JSX } from 'react';
 
 import { useTreeLatest } from '@/api/tree';
 
-import {
-  defaultValidadorValues,
-  zTableFilterInfoDefault,
-} from '@/types/tree/TreeDetails';
-
-import { DEFAULT_DIFF_FILTER } from '@/types/general';
-
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
@@ -31,7 +24,7 @@ export const TreeLatest = ({
 }: {
   urlFrom: TreeLatestFrom | TreeLatestWithHashFrom;
 }): JSX.Element => {
-  const searchParams = useSearch({ from: urlFrom });
+  const { origin } = useSearch({ from: urlFrom });
   const navigate = useNavigate();
   const params = useParams({
     from: urlFrom,
@@ -43,27 +36,21 @@ export const TreeLatest = ({
   const { isLoading, data, status, error } = useTreeLatest(
     treeName,
     branch,
-    searchParams.origin,
+    origin,
     hash,
   );
 
   if (data) {
     navigate({
-      to: '/tree/$treeId',
-      params: { treeId: data.git_commit_hash },
+      to: '/tree/$treeName/$branch/$hash',
+      params: {
+        treeName: data.tree_name,
+        branch: data.git_repository_branch,
+        hash: data.git_commit_hash,
+      },
       search: s => ({
         ...s,
-        origin: searchParams.origin,
-        currentPageTab: defaultValidadorValues.tab,
-        diffFilter: DEFAULT_DIFF_FILTER,
-        tableFilter: zTableFilterInfoDefault,
-        treeInfo: {
-          gitBranch: branch,
-          gitUrl: data.git_repository_url || undefined,
-          treeName: data.tree_name,
-          commitName: data.git_commit_name || undefined,
-          headCommitHash: data.git_commit_hash,
-        },
+        origin: origin,
       }),
     });
   }

--- a/dashboard/src/routes/_main/(alternatives)/c/$treeName/$branch/$hash/index.tsx
+++ b/dashboard/src/routes/_main/(alternatives)/c/$treeName/$branch/$hash/index.tsx
@@ -1,11 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router';
-
-import { TreeLatest } from '@/pages/TreeLatest';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute(
   '/_main/(alternatives)/c/$treeName/$branch/$hash/',
 )({
-  component: () => (
-    <TreeLatest urlFrom="/_main/(alternatives)/c/$treeName/$branch/$hash/" />
-  ),
+  loaderDeps: ({ search }) => ({ search }),
+  loader: ({ deps, params }) => {
+    throw redirect({
+      to: '/tree/$treeName/$branch/$hash',
+      search: deps.search,
+      params,
+    });
+  },
 });

--- a/dashboard/src/types/tree/Tree.tsx
+++ b/dashboard/src/types/tree/Tree.tsx
@@ -45,6 +45,7 @@ export type Tree = BaseTree & Required<AllTabCounts>;
 
 export type TreeLatestResponse = {
   tree_name: string;
+  git_repository_branch: string;
   api_url: string;
   git_commit_hash: string;
   git_repository_url: string | null;


### PR DESCRIPTION
## Changes
Fixes the /c/treeName/branch/hash route by redirecting it to the direct route

Changes the /c/treeName/branch shortcut to go to the direct url instead of the long url since we know that that tree will always have the treeName and branch

## How to test
Test the /c/treeName/branch and the /c/treeName/branch/hash routes and see that both are working and are directing the user to the direct treeDetails url (/tree/treeName/branch/url) instead of the long one.
Check that the other treeDetails endpoint are still working normally

Closes #1311