### PR TITLE
feat(logviewer): remove hardware info from build log viewer drawer

### DIFF
--- a/dashboard/src/components/Log/LogViewerCard.tsx
+++ b/dashboard/src/components/Log/LogViewerCard.tsx
@@ -47,6 +47,10 @@ export const LogViewerCard = ({
     logData?.hardware,
     formatMessage({ id: 'global.unknown' }),
   );
+  const architecture = valueOrEmpty(
+    logData?.architecture,
+    formatMessage({ id: 'global.unknownArchitecture' }),
+  );
 
   const fileName = useMemo(() => {
     try {
@@ -60,7 +64,7 @@ export const LogViewerCard = ({
   const linkComponent = useMemo(() => {
     if (logUrl) {
       return (
-        <>
+        <div className="mt-3">
           <Link
             to="/log-viewer"
             className="text-blue flex items-center gap-1 underline transition hover:brightness-125"
@@ -80,12 +84,20 @@ export const LogViewerCard = ({
               <SearchIcon className="text-blue w-full" />
             </div>
           </Link>
-        </>
+        </div>
       );
     } else {
-      return <FormattedMessage id="logSheet.noLogFound" />;
+      return (
+        <div className="mt-3">
+          <FormattedMessage id="logSheet.noLogFound" />
+        </div>
+      );
     }
   }, [logUrl, itemId, itemType, fileName]);
+
+  const hardwareLabel = useMemo(() => {
+    return `${hardware} (${architecture})`;
+  }, [hardware, architecture]);
 
   return (
     <div className="gap-0">
@@ -95,21 +107,23 @@ export const LogViewerCard = ({
         ) : (
           <>
             <div>
-              <span className="font-medium">
+              <div className="font-medium">
                 {getTreeBranchHash(
                   logData?.tree_name,
                   logData?.git_repository_branch,
                   logData?.git_commit_hash,
                 )}
-              </span>
-              <div className="mb-3 text-sm">
-                <FormattedMessage
-                  id="title.hardwareDetails"
-                  values={{
-                    hardwareName: `${hardware} (${logData?.architecture})`,
-                  }}
-                />
               </div>
+              {logData?.type !== 'build' && (
+                <div className="mb-3 text-sm">
+                  <FormattedMessage
+                    id="title.hardwareDetails"
+                    values={{
+                      hardwareName: hardwareLabel,
+                    }}
+                  />
+                </div>
+              )}
               {variant === 'modal' && linkComponent}
             </div>
             <Tooltip>

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -169,6 +169,7 @@ export const messages = {
     'global.trees': 'Trees',
     'global.underDevelopment': 'Under Development',
     'global.unknown': 'Unknown',
+    'global.unknownArchitecture': 'Unknown architecture',
     'global.url': 'URL',
     'global.viewJson': 'View Json',
     'global.viewLog': 'View Log Excerpt',


### PR DESCRIPTION
## Description
This PR removes the hardware information (e.g., hardware type, architecture) from the build drawer in the `LogViewerCard` component when viewing build logs.
Also fix cases which the hardware information could show null or undefined values for hardware or architecture.
The hardware information is still rendered for test logs, where this data is meaningful. For build logs, the section is omitted entirely to improve clarity.

## Changes
- [x] Updated LogViewerCard.tsx to conditionally render hardware info
- [x] Prevented display of null or undefined values in the drawer
- [x] Scoped hardware info to not display in build logs but still diplay in other scenarios

## How to test
1. Open the log viewer for a build.
1. Confirm that hardware-related information is no longer displayed.
1. Open the log viewer for a test instead of a build.
1. Confirm that the hardware information is still present and correctly displayed when available.

## Visual Reference
Build logs:
![image](https://github.com/user-attachments/assets/c082f828-aff9-4b39-9132-26fb3ea56690)

Test logs:
![image](https://github.com/user-attachments/assets/23043014-7ded-4aa2-a2dd-8493bda74301)


Closes #1283