### PR TITLE
feat(database): separate SQLite databases

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -183,7 +183,7 @@ GMAIL_API_TOKEN = get_json_env_var("GMAIL_API_TOKEN", "gmail_api_token.json")
 # the default value here is for when running locally
 BACKEND_VOLUME_DIR = get_json_env_var("BACKEND_VOLUME_DIR", "volume_data")
 
-DATABASE_ROUTERS = ["kernelCI_app.routers.disableMigrateRouter.DisableMigrateRouter"]
+DATABASE_ROUTERS = ["kernelCI_app.routers.databaseRouter.DatabaseRouter"]
 
 DATABASES = {
     "default": get_json_env_var(
@@ -202,6 +202,10 @@ DATABASES = {
     "cache": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(BACKEND_VOLUME_DIR, "cache.sqlite3"),
+    },
+    "notifications": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BACKEND_VOLUME_DIR, "notifications.sqlite3"),
     },
 }
 

--- a/backend/kernelCI_app/routers/databaseRouter.py
+++ b/backend/kernelCI_app/routers/databaseRouter.py
@@ -1,0 +1,19 @@
+class DatabaseRouter:
+    """
+    A router to control all database operations on models in the
+    kernelCI_app application.
+    """
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        if db == "default":
+            return False
+        if model_name in ["notificationscheckout", "notificationsissue"]:
+            return db == "notifications"
+        if model_name in ["checkoutscache"]:
+            return db == "cache"
+        if hints.get("run_always", False):
+            return True
+        # Default None return to prevent duplication of schema.
+        # If new model is added, it will not be migrated to any database.
+        # To create new model schema, add it to the logic as above.
+        return None

--- a/backend/kernelCI_app/routers/disableMigrateRouter.py
+++ b/backend/kernelCI_app/routers/disableMigrateRouter.py
@@ -1,9 +1,0 @@
-class DisableMigrateRouter:
-    """
-    Database router to disable migration for databases that are manually managed.
-    """
-
-    def allow_migrate(self, db, app_label, model_name=None, **hints):
-        if db == "default":
-            return False
-        return True

--- a/backend/kernelCI_cache/migrations/0011_copy_data_from_cache_if_exists.py
+++ b/backend/kernelCI_cache/migrations/0011_copy_data_from_cache_if_exists.py
@@ -1,0 +1,125 @@
+from kernelCI.settings import DATABASES
+from kernelCI_app.helpers.discordWebhook import send_discord_notification
+from django.db import migrations, connections
+
+cache_path = DATABASES["cache"]["NAME"]
+
+
+def _copy_if_data_not_exists(
+    cache_cursor, notif_cursor, table_name: str, columns: list[str]
+):
+    notif_cursor.execute(f"""SELECT id FROM {table_name} LIMIT 1;""")
+    existent_data = notif_cursor.fetchone()
+    if not existent_data:
+        print(f"Copying data from {table_name}")
+        query_placeholder = ", ".join(["?"] * len(columns))
+        columns_names = ", ".join(columns)
+        cache_cursor.execute(
+            f"""SELECT {columns_names}
+            FROM {table_name};"""
+        )
+        rows = cache_cursor.fetchall()
+        if rows:
+            notif_cursor.executemany(
+                f"""INSERT INTO {table_name}
+                ({columns_names})
+                VALUES ({query_placeholder})""",
+                rows,
+            )
+    else:
+        print(
+            f"Skipping {table_name} migration: "
+            f"Data already exists in the {table_name} table."
+        )
+
+
+def copy_from_cache_to_notification_tables(apps, schema_editor):
+    cache_conn = connections["cache"]
+    notification_conn = connections["notifications"]
+
+    with cache_conn.cursor() as cache_cursor, notification_conn.cursor() as notif_cursor:
+        try:
+            print("\nRUNNING DATA TRANSFER MIGRATION")
+            # Check if tables exist in databases
+            cache_cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='notifications_checkout';"
+            )
+            has_checkout_cache = cache_cursor.fetchone() is not None
+
+            cache_cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='notifications_issue';"
+            )
+            has_issue_cache = cache_cursor.fetchone() is not None
+
+            notif_cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='notifications_checkout';"
+            )
+            has_checkout_notif = notif_cursor.fetchone() is not None
+
+            notif_cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='notifications_issue';"
+            )
+            has_issue_notif = notif_cursor.fetchone() is not None
+
+            try:
+                # Copy data if both tables exist in both dbs and if the target tables are empty
+                if has_checkout_cache and has_checkout_notif:
+                    _copy_if_data_not_exists(
+                        cache_cursor=cache_cursor,
+                        notif_cursor=notif_cursor,
+                        table_name="notifications_checkout",
+                        columns=[
+                            "id",
+                            "notification_message_id",
+                            "notification_sent",
+                            "checkout_id",
+                        ],
+                    )
+                else:
+                    print(
+                        "Skipping notifications_checkout migration: "
+                        "Table does not exist in one of the databases."
+                    )
+
+                if has_issue_cache and has_issue_notif:
+                    _copy_if_data_not_exists(
+                        cache_cursor=cache_cursor,
+                        notif_cursor=notif_cursor,
+                        table_name="notifications_issue",
+                        columns=[
+                            "id",
+                            "notification_message_id",
+                            "notification_sent",
+                            "issue_id",
+                            "issue_version",
+                            "issue_type",
+                        ],
+                    )
+                else:
+                    print(
+                        "Skipping notifications_issue migration: "
+                        "Table does not exist in one of the databases."
+                    )
+            except Exception as e:
+                cache_cursor.rollback()
+                notif_cursor.rollback()
+                raise e
+        except Exception as e:
+            print(f"\nError during data transfer migration: {e}.")
+            send_discord_notification(
+                content=f"\nError during data transfer migration: {e}."
+            )
+            raise e
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("kernelCI_cache", "0010_notificationsissue"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            copy_from_cache_to_notification_tables, hints={"run_always": True}
+        ),
+    ]

--- a/backend/kernelCI_cache/queries/issues.py
+++ b/backend/kernelCI_cache/queries/issues.py
@@ -19,7 +19,7 @@ def get_unsent_issues() -> list[UnsentIssueKeys]:
             N.notification_sent IS NULL
         """
 
-    with connections["cache"].cursor() as cursor:
+    with connections["notifications"].cursor() as cursor:
         cursor.execute(query)
         results = dict_fetchall(cursor)
 
@@ -49,7 +49,7 @@ def get_all_issue_keys() -> list[IssueKeyTuple]:
             notifications_issue
     """
 
-    with connections["cache"].cursor() as cursor:
+    with connections["notifications"].cursor() as cursor:
         cursor.execute(query)
         results = cursor.fetchall()
 

--- a/backend/kernelCI_cache/queries/notifications.py
+++ b/backend/kernelCI_cache/queries/notifications.py
@@ -11,7 +11,7 @@ def mark_checkout_notification_as_sent(
 ) -> bool:
     try:
         timestamp = get_current_timestamp_kcidb_format()
-        NotificationsCheckout.objects.using("cache").create(
+        NotificationsCheckout.objects.using("notifications").create(
             checkout_id=checkout_id,
             notification_message_id=msg_id,
             notification_sent=timestamp,
@@ -32,7 +32,7 @@ def mark_issue_notification_sent(
     """Creates an entry for an issue notification"""
     try:
         timestamp = get_current_timestamp_kcidb_format()
-        NotificationsIssue.objects.using("cache").update_or_create(
+        NotificationsIssue.objects.using("notifications").update_or_create(
             issue_id=issue_id,
             issue_version=issue_version,
             issue_type=issue_type,
@@ -62,7 +62,7 @@ def mark_issue_notification_not_sent(
     """
     try:
         issue_exists = (
-            NotificationsIssue.objects.using("cache")
+            NotificationsIssue.objects.using("notifications")
             .filter(
                 issue_id=issue_id,
                 issue_version=issue_version,
@@ -71,7 +71,7 @@ def mark_issue_notification_not_sent(
         )
 
         if not issue_exists:
-            NotificationsIssue.objects.using("cache").create(
+            NotificationsIssue.objects.using("notifications").create(
                 issue_id=issue_id,
                 issue_version=issue_version,
                 issue_type=issue_type,

--- a/backend/migrate-cache-db.sh
+++ b/backend/migrate-cache-db.sh
@@ -1,2 +1,3 @@
 poetry run python3 manage.py makemigrations kernelCI_cache
+poetry run python3 manage.py migrate --database=notifications
 poetry run python3 manage.py migrate --database=cache


### PR DESCRIPTION
## Description
This PR separates the SQLite databases used by the backend to better reflect the purpose and lifecycle of different types of data.
It also implements the automatic migration of notifications data from the cache database to the new notification database, as part of the multi-database separation process.

## Changes
- [x] Created a new sqlite database called notification 
- [x] Redirected the older references to cache to the new notification database
- [x] Created a migration to transfer data from cache database to notication database if it is possible

## How to test
1. Run the migration `migrate-cache-db.sh` in different scenarios:
    1.1. Legacy schema: cache DB exists with notifications data, and the notification DB does not exist.
    1.2. Partial schema: cache DB exists but is empty, and the notification DB does not exist.
    1.3. Fresh setup: neither cache nor notification tables exist.
1. Verify that `volume_data/cache.sqlite3` and `volume_data/notifications.sqlite3` databases is created
1. Start the backend server and perform a quick sanity check:

Closes #1223