### PR TITLE
Feat: improve summary notification performance

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -25,7 +25,7 @@ The command supports four primary actions:
         * Report for a specific issue
         * Report for all pending issues
 1. `summary`
-    * Runs a checkout summary report for trees listed in [summary-signup.yaml](../backend/kernelCI_app/management/commands/data/summary-signup.yaml).
+    * Runs a checkout summary report for trees listed in the [subscriptions folder](../backend/data/notifications/subscriptions/).
 1.  `fake_report`
     * Generates a fake report (for  testing email send).
 
@@ -35,7 +35,7 @@ The command supports four primary actions:
 | Option | Description | Type | Default |
 |--------|-------------|------|---------|
 | `--add-mailing-lists` | Include community mailing lists in recipients | Flag | False |
-| `--ignore-recipients` | Bypass [recipients.yaml](../backend/kernelCI_app/management/commands/data/recipients.yaml) file | Flag | False |
+| `--ignore-recipients` | Bypass the recipients in the subscription file | Flag | False |
 | `--send` | Send email after generating report | Flag | False |
 | `--to` | Specify direct recipient email | String | None |
 | `--cc` | Specify CC recipient emails a "email1, email2" list  | String | None |
@@ -45,7 +45,7 @@ The command supports four primary actions:
 
 ## Adding yourself to recipients
 
-Edit the [recipients.yaml](../backend/kernelCI_app/management/commands/data/recipients.yaml) and send a PR to the dashboard.
+Edit the corresponding tree file in the [subscriptions folder](../backend/data/notifications/subscriptions) and send a PR to the dashboard.
 
 Use the git tree name reported by the
 Web Dashboard.
@@ -53,7 +53,7 @@ Web Dashboard.
 
 ## Signup tree for checkout summary
 
-Edit the [summary-signup.yaml](../backend/kernelCI_app/management/commands/data/summary-signup.yaml) and send a PR to the dashboard.
+Add a new file in the [subscriptions folder](../backend/data/notifications/subscriptions/) and send a PR to the dashboard.
 
 Use the git tree name reported by the
-Web Dashboard
+Web Dashboard.


### PR DESCRIPTION
The major bottleneck in the summary command is the tests_results query, which was improved to be simpler and more direct.

## Description of the problem

The summary command will get the data from the submission files, add the kcidb data on it, then query the history of tests for that tree.

The query for test history will gather all checkouts for that tree between the latest checkouts and 30 days ago, then partition the tests by path+platform+config, and assign them a row_number from latest to oldest, then only return the tests where the latest item is in the searched checkout hash, limited to 5 tests.

This query performs a row_number() operation over many rows, causing it to be very slow specially on the mainline/master tree, where there is no path filter as well. This PR addresses the performance by improving the query and simplifying it, but more changes to the logic is needed.

## How to test
The best way to test this is through a query tool like pgadmin or dbeaver, executing the query, checking its time and also the explain/analyze of it.

Closes #1310