### PR TITLE
Feat: add checkout summary endpoint

### DIFF
--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -27,6 +27,7 @@ class DocStrings:
 
     PROXY_URL_DESCRIPTION = "URL to the proxy"
 
+    CHECKOUT_START_TIME_DESCRIPTION = "Start time of the checkout"
     COMMIT_HASH_PATH_DESCRIPTION = "Commit hash of the tree"
     TREE_NAME_PATH_DESCRIPTION = "Name of the tree"
     BUILD_ID_PATH_DESCRIPTION = "ID of the build"
@@ -76,4 +77,26 @@ class DocStrings:
     STATUS_HISTORY_CONFIG_NAME_DESCRIPTION = "Config name filter to retrieve tests"
     STATUS_HISTORY_FIELD_TS_DESCRIPTION = (
         "Test timestamp filter to retrieve tests prior to it"
+    )
+
+    BUILD_STATUS_SUMMARY_DESCRIPTION = "Summary of build statuses"
+    BOOT_STATUS_SUMMARY_DESCRIPTION = "Summary of boot test statuses"
+    TEST_STATUS_SUMMARY_DESCRIPTION = "Summary of test statuses"
+
+    # KCI Summary related descriptions
+    REGRESSIONS_GROUP = "Regressions are grouped by hardware, config, and path."
+    KCI_SUMMARY_PATH_DESCRIPTION = (
+        "The test path to query for. SQL Wildcard can be used."
+    )
+    KCI_SUMMARY_DASHBOARD_URL_DESCRIPTION = (
+        "The dashboard url of this tree/branch/commit"
+    )
+    KCI_SUMMARY_POSSIBLE_REGRESSIONS_DESCRIPTION = (
+        "History of tests that are possible regressions." + REGRESSIONS_GROUP
+    )
+    KCI_SUMMARY_FIXED_REGRESSIONS_DESCRIPTION = (
+        "History of tests that are fixed regressions." + REGRESSIONS_GROUP
+    )
+    KCI_SUMMARY_UNSTABLE_TESTS_DESCRIPTION = (
+        "History of tests that are unstable. " + REGRESSIONS_GROUP
     )

--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -100,3 +100,6 @@ class DocStrings:
     KCI_SUMMARY_UNSTABLE_TESTS_DESCRIPTION = (
         "History of tests that are unstable. " + REGRESSIONS_GROUP
     )
+    KCI_SUMMARY_GROUP_SIZE_DESCRIPTION = (
+        "Maximum number of entries to be retrieved in a test history."
+    )

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -388,8 +388,18 @@ def evaluate_test_results(
     branch: str,
     commit_hash: str,
     path: str,
+    interval: str,
+    group_size: int,
 ):
-    tests = kcidb_tests_results(origin, giturl, branch, commit_hash, path)
+    tests = kcidb_tests_results(
+        origin,
+        giturl,
+        branch,
+        commit_hash,
+        path,
+        interval,
+        group_size,
+    )
 
     # Group by platform, then by config_name, then by path
     grouped = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
@@ -466,6 +476,8 @@ def run_checkout_summary(
                 branch=branch,
                 commit_hash=commit_hash,
                 path=path,
+                interval="7 days",
+                group_size=5,
             )
 
             always = (

--- a/backend/kernelCI_app/queries/notifications.py
+++ b/backend/kernelCI_app/queries/notifications.py
@@ -492,7 +492,7 @@ def kcidb_tests_results(origin, giturl, branch, hash, path, interval, group_size
                     AND c.git_repository_branch = %(branch)s
                     AND t.path LIKE %(path)s
                     AND t.environment_misc->>'platform' != 'kubernetes'
-                    AND C.start_time < (
+                    AND C.start_time <= (
                         SELECT
                             MAX(start_time)
                         FROM

--- a/backend/kernelCI_app/typeModels/kciSummary.py
+++ b/backend/kernelCI_app/typeModels/kciSummary.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from typing import TypedDict
+from pydantic import BaseModel, Field
+
+from kernelCI_app.constants.general import DEFAULT_ORIGIN
+from kernelCI_app.constants.localization import DocStrings
+from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.databases import Test__Id, Test__StartTime, Test__Status
+from kernelCI_app.typeModels.treeListing import TestStatusCount
+
+DEFAULT_PATH_SEARCH = "%"
+
+
+class KciSummaryQueryParameters(BaseModel):
+    origin: str = Field(
+        default=DEFAULT_ORIGIN, description=DocStrings.TREE_QUERY_ORIGIN_DESCRIPTION
+    )
+    git_branch: str = Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION)
+    git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
+    path: str = Field(
+        default=DEFAULT_PATH_SEARCH, description=DocStrings.KCI_SUMMARY_PATH_DESCRIPTION
+    )
+
+
+class RegressionHistoryItem(TypedDict):
+    id: Test__Id
+    start_time: Test__StartTime
+    status: Test__Status
+
+
+type RegressionData = dict[str, dict[str, dict[str, list[RegressionHistoryItem]]]]
+"""The history of tests is grouped by hardware, then config, then path."""
+
+
+class KciSummaryResponse(BaseModel):
+    dashboard_url: str = Field(
+        description=DocStrings.KCI_SUMMARY_DASHBOARD_URL_DESCRIPTION
+    )
+    git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
+    git_branch: str = Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION)
+    commit_hash: str = Field(description=DocStrings.COMMIT_HASH_PATH_DESCRIPTION)
+    origin: str = Field(description=DocStrings.TREE_QUERY_ORIGIN_DESCRIPTION)
+    checkout_start_time: datetime = Field(
+        description=DocStrings.CHECKOUT_START_TIME_DESCRIPTION
+    )
+    build_status_summary: StatusCount = Field(
+        description=DocStrings.BUILD_STATUS_SUMMARY_DESCRIPTION,
+    )
+    boot_status_summary: TestStatusCount = Field(
+        description=DocStrings.BOOT_STATUS_SUMMARY_DESCRIPTION
+    )
+    test_status_summary: TestStatusCount = Field(
+        description=DocStrings.TEST_STATUS_SUMMARY_DESCRIPTION
+    )
+    possible_regressions: RegressionData = Field(
+        description=DocStrings.KCI_SUMMARY_POSSIBLE_REGRESSIONS_DESCRIPTION,
+    )
+    fixed_regressions: RegressionData = Field(
+        description=DocStrings.KCI_SUMMARY_FIXED_REGRESSIONS_DESCRIPTION
+    )
+    unstable_tests: RegressionData = Field(
+        description=DocStrings.KCI_SUMMARY_UNSTABLE_TESTS_DESCRIPTION,
+    )

--- a/backend/kernelCI_app/typeModels/kciSummary.py
+++ b/backend/kernelCI_app/typeModels/kciSummary.py
@@ -9,6 +9,7 @@ from kernelCI_app.typeModels.databases import Test__Id, Test__StartTime, Test__S
 from kernelCI_app.typeModels.treeListing import TestStatusCount
 
 DEFAULT_PATH_SEARCH = "%"
+DEFAULT_GROUP_SIZE = 3
 
 
 class KciSummaryQueryParameters(BaseModel):
@@ -19,6 +20,11 @@ class KciSummaryQueryParameters(BaseModel):
     git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
     path: str = Field(
         default=DEFAULT_PATH_SEARCH, description=DocStrings.KCI_SUMMARY_PATH_DESCRIPTION
+    )
+    group_size: int = Field(
+        gt=0,
+        default=DEFAULT_GROUP_SIZE,
+        description=DocStrings.KCI_SUMMARY_GROUP_SIZE_DESCRIPTION,
     )
 
 

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -151,4 +151,5 @@ urlpatterns = [
     ),
     path("proxy/", views.ProxyView.as_view(), name="proxyView"),
     path("origins/", views.OriginsView.as_view(), name="originsView"),
+    path("kci-summary/", views.KciSummary.as_view(), name="kciSummary"),
 ]

--- a/backend/kernelCI_app/views/kciSummaryView.py
+++ b/backend/kernelCI_app/views/kciSummaryView.py
@@ -1,0 +1,96 @@
+from http import HTTPStatus
+from urllib.parse import quote_plus
+
+from django.http import HttpRequest
+from drf_spectacular.utils import extend_schema
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from pydantic import ValidationError
+
+from kernelCI_app.constants.general import DEFAULT_ORIGIN
+from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.helpers.trees import sanitize_tree
+from kernelCI_app.management.commands.helpers.summary import TreeKey
+from kernelCI_app.management.commands.notifications import evaluate_test_results
+from kernelCI_app.queries.notifications import get_checkout_summary_data
+from kernelCI_app.typeModels.kciSummary import (
+    DEFAULT_PATH_SEARCH,
+    KciSummaryQueryParameters,
+    KciSummaryResponse,
+)
+
+
+class KciSummary(APIView):
+    @extend_schema(
+        responses=KciSummaryResponse,
+        parameters=[KciSummaryQueryParameters],
+        methods=["GET"],
+    )
+    def get(self, request: HttpRequest):
+        try:
+            params = KciSummaryQueryParameters(
+                origin=request.GET.get("origin", DEFAULT_ORIGIN),
+                git_branch=request.GET.get("git_branch"),
+                git_url=request.GET.get("git_url"),
+                path=request.GET.get("path", DEFAULT_PATH_SEARCH),
+            )
+            origin = params.origin
+            git_url = params.git_url
+            git_branch = params.git_branch
+        except ValidationError as e:
+            return create_api_error_response(error_message=e.json())
+
+        # Even though this is using a single key and could be swapped for the treeListing query directly,
+        # it is better to keep the same query as the notification command
+        tree_key: TreeKey = (git_branch, git_url, origin)
+        records = get_checkout_summary_data([tree_key])
+        if not records:
+            return create_api_error_response(
+                error_message="Tree not found", status_code=HTTPStatus.OK
+            )
+        record = records[0]
+
+        checkout = sanitize_tree(record)
+        tree_name = checkout.tree_name
+        branch = checkout.git_repository_branch
+        commit_hash = checkout.git_commit_hash
+        git_url_safe = quote_plus(checkout.git_repository_url)
+
+        if tree_name and branch:
+            dashboard_url = f"https://d.kernelci.org/tree/{tree_name}/{branch}/{commit_hash}?o={origin}"
+        else:
+            dashboard_url = f"""https://d.kernelci.org/tree/{commit_hash}
+                ?ti%7Cc={checkout.git_commit_name}
+                &ti%7Cch={commit_hash}
+                &ti%7Cgb={branch}
+                &ti%7Cgu={git_url_safe}
+                &ti%7Ct={tree_name}
+                &o={origin}"""
+
+        new_issues, fixed_issues, unstable_tests = evaluate_test_results(
+            origin=origin,
+            giturl=git_url,
+            branch=git_branch,
+            commit_hash=commit_hash,
+            path=params.path,
+        )
+
+        try:
+            valid_response = KciSummaryResponse(
+                dashboard_url=dashboard_url,
+                git_url=git_url,
+                git_branch=branch,
+                commit_hash=commit_hash,
+                origin=origin,
+                checkout_start_time=checkout.start_time,
+                build_status_summary=checkout.build_status,
+                boot_status_summary=checkout.boot_status,
+                test_status_summary=checkout.test_status,
+                possible_regressions=new_issues,
+                fixed_regressions=fixed_issues,
+                unstable_tests=unstable_tests,
+            )
+        except ValidationError as e:
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        return Response(valid_response.model_dump())

--- a/backend/requests/kci-summary-get.sh
+++ b/backend/requests/kci-summary-get.sh
@@ -1,0 +1,80 @@
+http "http://localhost:8000/api/kci-summary/" git_branch==for-kernelci git_url==https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git origin==maestro
+
+# HTTP/1.1 200 OK
+# Allow: GET, HEAD, OPTIONS
+# Content-Length: 3677
+# Content-Type: application/json
+# Cross-Origin-Opener-Policy: same-origin
+# Date: Wed, 02 Jul 2025 17:57:35 GMT
+# Referrer-Policy: same-origin
+# Server: WSGIServer/0.2 CPython/3.12.7
+# Vary: Accept, Cookie, origin
+# X-Content-Type-Options: nosniff
+# X-Frame-Options: DENY
+
+# {
+#     "boot_status_summary": {
+#         "done_count": 0,
+#         "error_count": 0,
+#         "fail_count": 0,
+#         "miss_count": 13,
+#         "null_count": 0,
+#         "pass_count": 9,
+#         "skip_count": 0
+#     },
+#     "build_status_summary": {
+#         "DONE": 0,
+#         "ERROR": 0,
+#         "FAIL": 0,
+#         "MISS": 0,
+#         "NULL": 0,
+#         "PASS": 9,
+#         "SKIP": 0
+#     },
+#     "checkout_start_time": "2025-07-01T15:08:26.610000Z",
+#     "commit_hash": "3c795c3404e82c4db5c69317847dc5bbafbb368b",
+#     "dashboard_url": "https://d.kernelci.org/tree/arm64/for-kernelci/3c795c3404e82c4db5c69317847dc5bbafbb368b?o=maestro",
+#     "fixed_regressions": {},
+#     "git_branch": "for-kernelci",
+#     "git_url": "https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git",
+#     "origin": "maestro",
+#     "possible_regressions": {},
+#     "test_status_summary": {
+#         "done_count": 0,
+#         "error_count": 0,
+#         "fail_count": 0,
+#         "miss_count": 0,
+#         "null_count": 62,
+#         "pass_count": 592,
+#         "skip_count": 0
+#     },
+#     "unstable_tests": {
+#         "bcm2711-rpi-4-b": {
+#             "defconfig+lab-setup+kselftest": {
+#                 "boot": [
+#                     {
+#                         "id": "maestro:686413d35c2cf25042f65ec8",
+#                         "start_time": "2025-07-01T16:58:59.086000Z",
+#                         "status": "MISS"
+#                     },
+#                     {
+#                         "id": "maestro:686413cf5c2cf25042f65ead",
+#                         "start_time": "2025-07-01T16:58:55.436000Z",
+#                         "status": "PASS"
+#                     },
+#                     {
+#                         "id": "maestro:6862e6f15c2cf25042f38ba1",
+#                         "start_time": "2025-06-30T19:35:13.117000Z",
+#                         "status": "PASS"
+#                     },
+#                     {
+#                         "id": "maestro:6862e6ed5c2cf25042f38b85",
+#                         "start_time": "2025-06-30T19:35:09.018000Z",
+#                         "status": "PASS"
+#                     }
+#                 ]
+#             }
+#         },
+#         ...
+#     }
+# }

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -498,6 +498,14 @@ paths:
         description: Git repository URL of the tree
         required: true
       - in: query
+        name: group_size
+        schema:
+          default: 3
+          exclusiveMinimum: 0
+          title: Group Size
+          type: integer
+        description: Maximum number of entries to be retrieved in a test history.
+      - in: query
         name: origin
         schema:
           default: maestro

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -479,6 +479,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/IssueExtraDetailsResponse'
           description: ''
+  /api/kci-summary/:
+    get:
+      operationId: kci_summary_retrieve
+      parameters:
+      - in: query
+        name: git_branch
+        schema:
+          title: Git Branch
+          type: string
+        description: Git branch name of the tree
+        required: true
+      - in: query
+        name: git_url
+        schema:
+          title: Git Url
+          type: string
+        description: Git repository URL of the tree
+        required: true
+      - in: query
+        name: origin
+        schema:
+          default: maestro
+          title: Origin
+          type: string
+        description: Origin of the tree
+      - in: query
+        name: path
+        schema:
+          default: '%'
+          title: Path
+          type: string
+        description: The test path to query for. SQL Wildcard can be used.
+      tags:
+      - kci-summary
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KciSummaryResponse'
+          description: ''
   /api/log-downloader/:
     get:
       operationId: log_downloader_retrieve
@@ -2799,6 +2844,69 @@ components:
       - type: 'null'
     Issue__Version:
       type: integer
+    KciSummaryResponse:
+      properties:
+        dashboard_url:
+          description: The dashboard url of this tree/branch/commit
+          title: Dashboard Url
+          type: string
+        git_url:
+          description: Git repository URL of the tree
+          title: Git Url
+          type: string
+        git_branch:
+          description: Git branch name of the tree
+          title: Git Branch
+          type: string
+        commit_hash:
+          description: Commit hash of the tree
+          title: Commit Hash
+          type: string
+        origin:
+          description: Origin of the tree
+          title: Origin
+          type: string
+        checkout_start_time:
+          description: Start time of the checkout
+          format: date-time
+          title: Checkout Start Time
+          type: string
+        build_status_summary:
+          $ref: '#/components/schemas/StatusCount'
+          description: Summary of build statuses
+        boot_status_summary:
+          $ref: '#/components/schemas/TestStatusCount'
+          description: Summary of boot test statuses
+        test_status_summary:
+          $ref: '#/components/schemas/TestStatusCount'
+          description: Summary of test statuses
+        possible_regressions:
+          $ref: '#/components/schemas/RegressionData'
+          description: History of tests that are possible regressions.Regressions
+            are grouped by hardware, config, and path.
+        fixed_regressions:
+          $ref: '#/components/schemas/RegressionData'
+          description: History of tests that are fixed regressions.Regressions are
+            grouped by hardware, config, and path.
+        unstable_tests:
+          $ref: '#/components/schemas/RegressionData'
+          description: History of tests that are unstable. Regressions are grouped
+            by hardware, config, and path.
+      required:
+      - dashboard_url
+      - git_url
+      - git_branch
+      - commit_hash
+      - origin
+      - checkout_start_time
+      - build_status_summary
+      - boot_status_summary
+      - test_status_summary
+      - possible_regressions
+      - fixed_regressions
+      - unstable_tests
+      title: KciSummaryResponse
+      type: object
     LocalFilters:
       properties:
         issues:
@@ -2903,6 +3011,30 @@ components:
     ProcessedExtraDetailedIssues:
       additionalProperties:
         $ref: '#/components/schemas/ExtraIssuesData'
+      type: object
+    RegressionData:
+      additionalProperties:
+        additionalProperties:
+          additionalProperties:
+            items:
+              $ref: '#/components/schemas/RegressionHistoryItem'
+            type: array
+          type: object
+        type: object
+      type: object
+    RegressionHistoryItem:
+      properties:
+        id:
+          $ref: '#/components/schemas/Test__Id'
+        start_time:
+          $ref: '#/components/schemas/Test__StartTime'
+        status:
+          $ref: '#/components/schemas/Test__Status'
+      required:
+      - id
+      - start_time
+      - status
+      title: RegressionHistoryItem
       type: object
     StatusCount:
       properties:


### PR DESCRIPTION
The endpoint is meant to return the same data as the checkout summary notification command. However, this endpoint returns the data for a single tree.

## Changes
- Added new endpoint that queries the same data as the notification would query.

## How to test
This endpoint is backend-only, meaning that it is not called by the frontend of the dashboard. To test it, you can use the swagger UI or send requests directly to the url.
Test with some trees (branch + url), as well as different paths and origins.
A tree that currently returns inconclusive tests is branch `for-kernelci` url `https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git`. An example of the response can be seen in the requests folder.

Closes #1321 