### PR TITLE
Feat: multiple path report

### DIFF
--- a/backend/data/notifications/example-subscription.yaml
+++ b/backend/data/notifications/example-subscription.yaml
@@ -11,14 +11,14 @@ tree: # The filename and the name of the tree may follow the trees-name.yaml fil
       branch: master
       always: True
     
-    - microsoft:
+    - microsoft: # The name of the report does not matter, as long as they are unique
       origin: microsoft
       branch: master
       always: True
 
     - rt_tests:
       branch: master
-      path: rt-tests*
+      path: [rt-tests%] # An array of paths to be looked at in the query
       recipients:
         - linux-rt-devel@lists.linux.dev
       # The possible options for a report should be documented in the `PossibleReportOptions` type

--- a/backend/data/notifications/subscriptions/media-committers.yaml
+++ b/backend/data/notifications/subscriptions/media-committers.yaml
@@ -6,8 +6,8 @@ media-committers:
   reports:
     - fixes:
       branch: fixes
-      path: fluster%
+      path: [fluster%]
 
     - next:
       branch: next
-      path: fluster%
+      path: [fluster%]

--- a/backend/data/notifications/subscriptions/stable-rt.yaml
+++ b/backend/data/notifications/subscriptions/stable-rt.yaml
@@ -7,32 +7,32 @@ stable-rt:
   reports:
     - v5.4-rt:
       branch: v5.4-rt
-      path: rt-tests%
+      path: [rt-tests%]
   
     - v5.10-rt:
       branch: v5.10-rt
-      path: rt-tests%
+      path: [rt-tests%]
   
     - v5.10-rt-next:
       branch: v5.10-rt-next
-      path: rt-tests%
+      path: [rt-tests%]
   
     - v5.15-rt:
       branch: v5.15-rt
-      path: rt-tests%
+      path: [rt-tests%]
   
     - v5.15-rt-next:
       branch: v5.15-rt-next
-      path: rt-tests%
+      path: [rt-tests%]
   
     - v6.1-rt:
       branch: v6.1-rt
-      path: rt-tests%
+      path: [rt-tests%]
   
     - v6.6-rt:
       branch: v6.6-rt
-      path: rt-tests%
+      path: [rt-tests%]
   
     - v6.6-rt-next:
       branch: v6.6-rt-next
-      path: rt-tests%
+      path: [rt-tests%]

--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -86,7 +86,7 @@ class DocStrings:
     # KCI Summary related descriptions
     REGRESSIONS_GROUP = "Regressions are grouped by hardware, config, and path."
     KCI_SUMMARY_PATH_DESCRIPTION = (
-        "The test path to query for. SQL Wildcard can be used."
+        "A list of test paths to query for. SQL Wildcard can be used."
     )
     KCI_SUMMARY_DASHBOARD_URL_DESCRIPTION = (
         "The dashboard url of this tree/branch/commit"

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -387,18 +387,18 @@ def evaluate_test_results(
     giturl: str,
     branch: str,
     commit_hash: str,
-    path: str,
+    path: list[str],
     interval: str,
     group_size: int,
 ):
     tests = kcidb_tests_results(
-        origin,
-        giturl,
-        branch,
-        commit_hash,
-        path,
-        interval,
-        group_size,
+        origin=origin,
+        giturl=giturl,
+        branch=branch,
+        hash=commit_hash,
+        paths=path,
+        interval=interval,
+        group_size=group_size,
     )
 
     # Group by platform, then by config_name, then by path

--- a/backend/kernelCI_app/typeModels/kciSummary.py
+++ b/backend/kernelCI_app/typeModels/kciSummary.py
@@ -8,7 +8,7 @@ from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.databases import Test__Id, Test__StartTime, Test__Status
 from kernelCI_app.typeModels.treeListing import TestStatusCount
 
-DEFAULT_PATH_SEARCH = "%"
+DEFAULT_PATH_SEARCH = ["%"]
 DEFAULT_GROUP_SIZE = 3
 
 
@@ -18,7 +18,7 @@ class KciSummaryQueryParameters(BaseModel):
     )
     git_branch: str = Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION)
     git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
-    path: str = Field(
+    path: list[str] = Field(
         default=DEFAULT_PATH_SEARCH, description=DocStrings.KCI_SUMMARY_PATH_DESCRIPTION
     )
     group_size: int = Field(

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -515,10 +515,13 @@ paths:
       - in: query
         name: path
         schema:
-          default: '%'
+          default:
+          - '%'
+          items:
+            type: string
           title: Path
-          type: string
-        description: The test path to query for. SQL Wildcard can be used.
+          type: array
+        description: A list of test paths to query for. SQL Wildcard can be used.
       tags:
       - kci-summary
       security:


### PR DESCRIPTION
The approach used for querying for different like clauses was using `LIKE ANY (ARRAY[])`, I'm open to other approaches.

## Changes
- Changes the use of paths from a single string to an array of strings, allowing for multiple paths to be used _in a single report_
- Changed the path parameter of kciSummary endpoint to receive an array of paths as well

## How to test
For the notification command, change some tree file to use an array of paths (isolating the file is ideal for debugging) and run the notification command. Be aware of the intervals in the queries as well.
Also check the kciSummary endpoint, passing a tree and multiple paths and checking the return.

Closes #1217 