### PR TITLE
Fix: arch card not updating

### DIFF
--- a/dashboard/src/components/Tabs/Tests/ErrorsSummary.tsx
+++ b/dashboard/src/components/Tabs/Tests/ErrorsSummary.tsx
@@ -35,7 +35,7 @@ const ErrorsSummary = ({
             const currentCompilers = [e.compiler];
             return (
               <MemoizedSummaryItem
-                key={e.arch}
+                key={e.arch + e.compiler}
                 diffFilter={diffFilter}
                 arch={{
                   text: e.arch,


### PR DESCRIPTION
Fixes a visual bug where the architecture summary card wasn't updating in the tests tab. The bug was caused by a memoization problem where rows with the same key wouldn't leave the screen.

This can be seen in the tests tab (which doesn't group the arch/compilers like the build tab does) that had more than one compiler per architecture. Since the key of the rows was only the arch name, it ended up creating rows with the same key.

In those trees, if you filter by some arch, the arch that you selected would be shown, as well as at least one of each repeated arch. Removing the filter would also create duplicates of those items.

Example:
In [production stable/linux-5.15.y](https://dashboard.kernelci.org/tree/stable/linux-5.15.y/3dea0e7f549ee8ce3ce9d058d6d5c494d9ad02dc?i=9&p=t), there are 4 archs with more than one compiler (arm64, x86_64, arm, i386):
![image](https://github.com/user-attachments/assets/d94195b2-7ee7-40a4-9fc4-c247ea6038ba)

After filtering by some arch, the ones that had more than one compiler would stay in the screen:
![image](https://github.com/user-attachments/assets/d1af404d-d48f-4f7c-b52c-d091c831a7f5)


## Changes
- Fixed the key in the arch summary card component

## How to test
Find a tree with an arch with more than one compiler in the test tab (such as localhost [stable/linux-5.15.y](http://localhost:5173/tree/stable/linux-5.15.y/3dea0e7f549ee8ce3ce9d058d6d5c494d9ad02dc?i=9&p=t)) and compare with staging/production
Also, it is possible to see in the Error section of the console in debug tools that there were messages about duplicate keys, but after the PR's change they are gone.

Closes #1268