### PR TITLE
Fix: avoid backend exit

### DIFF
--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -484,15 +484,21 @@ def run_checkout_summary(
         for tree_report in tree_report_list:
             path = tree_report["path"] if "path" in tree_report else "%"
 
-            new_issues, fixed_issues, unstable_tests = evaluate_test_results(
-                origin=origin,
-                giturl=giturl,
-                branch=branch,
-                commit_hash=commit_hash,
-                path=path,
-                interval="7 days",
-                group_size=5,
-            )
+            # In case an error happens in the query, we don't want to send an empty report
+            try:
+                new_issues, fixed_issues, unstable_tests = evaluate_test_results(
+                    origin=origin,
+                    giturl=giturl,
+                    branch=branch,
+                    commit_hash=commit_hash,
+                    path=path,
+                    interval="7 days",
+                    group_size=5,
+                )
+            except Exception as e:
+                log_message("Error while evaluating test results")
+                log_message(f"Query execution failed: {e}")
+                sys.exit()
 
             always = (
                 True

--- a/backend/kernelCI_app/queries/notifications.py
+++ b/backend/kernelCI_app/queries/notifications.py
@@ -586,4 +586,9 @@ def kcidb_tests_results(
             start_time DESC NULLS LAST;
         """
 
-    return kcidb_execute_query(query, params)
+    with connection.cursor() as cursor:
+        cursor.execute(query, params)
+        # TODO: check if it is possible to remove dict_fetchall.
+        # dict_fetchall has a performance impact and this query returns many rows,
+        # so they shouldn't be together
+        return dict_fetchall(cursor=cursor)

--- a/backend/kernelCI_app/views/kciSummaryView.py
+++ b/backend/kernelCI_app/views/kciSummaryView.py
@@ -73,17 +73,17 @@ class KciSummary(APIView):
                 &ti%7Ct={tree_name}
                 &o={origin}"""
 
-        new_issues, fixed_issues, unstable_tests = evaluate_test_results(
-            origin=origin,
-            giturl=git_url,
-            branch=git_branch,
-            commit_hash=commit_hash,
-            path=params.path,
-            interval="1 day",
-            group_size=params.group_size,
-        )
-
         try:
+            new_issues, fixed_issues, unstable_tests = evaluate_test_results(
+                origin=origin,
+                giturl=git_url,
+                branch=git_branch,
+                commit_hash=commit_hash,
+                path=params.path,
+                interval="1 day",
+                group_size=params.group_size,
+            )
+
             valid_response = KciSummaryResponse(
                 dashboard_url=dashboard_url,
                 git_url=git_url,
@@ -100,5 +100,10 @@ class KciSummary(APIView):
             )
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+        except Exception as e:
+            return create_api_error_response(
+                error_message=str(e),
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
 
         return Response(valid_response.model_dump())


### PR DESCRIPTION
The kcidb_execute_query allows for a sys.exit since it was only used in a command context. Since it is now used in the full backend context, it should be avoided in order to allow for an error 500 instead of exiting the backend

## Changes
- Replaced `kcidb_execute_query` with the usual cursor and dictfetchall

## How to test
- Go to the kciSummary endpoint and compare queries on staging and locally, they should both still work
- Also compare the notifications command before and after the change

Closes #1328