### PR TITLE
Fix: getlist param in kciSummaryView

### DIFF
--- a/backend/kernelCI_app/views/kciSummaryView.py
+++ b/backend/kernelCI_app/views/kciSummaryView.py
@@ -33,7 +33,7 @@ class KciSummary(APIView):
                 origin=request.GET.get("origin", DEFAULT_ORIGIN),
                 git_branch=request.GET.get("git_branch"),
                 git_url=request.GET.get("git_url"),
-                path=request.GET.get("path", DEFAULT_PATH_SEARCH),
+                path=request.GET.getlist("path", DEFAULT_PATH_SEARCH),
                 group_size=request.GET.get("group_size", DEFAULT_GROUP_SIZE),
             )
             origin = params.origin


### PR DESCRIPTION
The `.get` method gets list values from conventional dicts, _but with django GET request_ the `.get` method only returns the last item in a list. For list parameters, it is necessary to use the `.getlist` method, as seen in an age old question [here](https://code.djangoproject.com/ticket/1130).

Also, the `.get` on `request.GET` will return a single value, hence why even with a single element it is still crashing the endpoint (a string is not a list).

## Changes
- Used getlist instead of get for the path parameter

## How to test
- Give some tries to the endpoint, and check with the staging equivalent

Closes #1329