### PR TITLE
backend: notifications: Add git tags to issue reports

### DIFF
--- a/backend/kernelCI_app/management/commands/templates/issue_boot.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/issue_boot.txt.j2
@@ -14,6 +14,9 @@ New boot regression found on {{ issue["tree_name"] }}/{{ issue["git_repository_b
 - dashboard: https://d.kernelci.org/i/{{ issue["id"] }}
 - giturl: {{ issue["git_repository_url"]}}
 - commit HEAD:  {{ issue["git_commit_hash"] }}
+{% if issue["git_commit_tags"] -%}
+- tags: {% for tag in issue["git_commit_tags"] %}{{tag}}{% if not loop.last %},{% endif %}{% endfor %}
+{%- endif %}
 
 {% if "misc" in issue.keys() and "logspec" in issue["misc"].keys() %}
 Log excerpt:

--- a/backend/kernelCI_app/management/commands/templates/issue_build.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/issue_build.txt.j2
@@ -13,6 +13,9 @@ New build issue found on {{ issue["tree_name"] }}/{{ issue["git_repository_branc
 - dashboard: https://d.kernelci.org/i/{{ issue["id"] }}
 - giturl: {{ issue["git_repository_url"]}}
 - commit HEAD:  {{ issue["git_commit_hash"] }}
+{% if issue["git_commit_tags"] -%}
+- tags: {% for tag in issue["git_commit_tags"] %}{{tag}}{% if not loop.last %},{% endif %}{% endfor %}
+{%- endif %}
 
 {% if "misc" in issue.keys() and "logspec" in issue["misc"].keys() %}
 Log excerpt:

--- a/backend/kernelCI_app/queries/notifications.py
+++ b/backend/kernelCI_app/queries/notifications.py
@@ -187,6 +187,7 @@ def kcidb_issue_details(issue_id):
                c.git_repository_branch,
                c.git_commit_hash,
                c.git_commit_name,
+               c.git_commit_tags,
                ROW_NUMBER() OVER (PARTITION BY inc.issue_id ORDER BY inc._timestamp ASC) as incident_rn
            FROM incidents inc
            JOIN builds b ON inc.build_id = b.id
@@ -205,6 +206,7 @@ def kcidb_issue_details(issue_id):
                c.git_repository_branch,
                c.git_commit_hash,
                c.git_commit_name,
+               c.git_commit_tags,
                ROW_NUMBER() OVER (PARTITION BY inc.issue_id ORDER BY inc._timestamp ASC) as incident_rn
            FROM incidents inc
            JOIN tests t ON inc.test_id = t.id
@@ -226,6 +228,7 @@ def kcidb_issue_details(issue_id):
             fi.git_repository_branch,
             fi.git_commit_hash,
             fi.git_commit_name,
+            fi.git_commit_tags,
             COUNT(inc.id) AS incident_count
         FROM our_issue n
         LEFT JOIN first_incidents fi ON n.id = fi.issue_id AND fi.incident_rn = 1
@@ -242,7 +245,8 @@ def kcidb_issue_details(issue_id):
             fi.tree_name,
             fi.git_repository_branch,
             fi.git_commit_hash,
-            fi.git_commit_name
+            fi.git_commit_name,
+            fi.git_commit_tags
     """
 
     return kcidb_execute_query(query, params)


### PR DESCRIPTION
Readers benefit from seeing the git tag as well in the reports so we are adding these from now on.