### PR TITLE
fix(breadcrumbs): adjust LogViewer, Build Details and Test Details breadcrumb for new URL structure

### DIFF
--- a/dashboard/src/components/Log/LogViewerCard.tsx
+++ b/dashboard/src/components/Log/LogViewerCard.tsx
@@ -2,7 +2,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useMemo, type JSX } from 'react';
 
-import { Link } from '@tanstack/react-router';
+import { Link, useRouterState } from '@tanstack/react-router';
 
 import { SearchIcon } from '@/components/Icons/SearchIcon';
 import { StatusIcon } from '@/components/Icons/StatusIcons';
@@ -61,6 +61,23 @@ export const LogViewerCard = ({
     }
   }, [logUrl]);
 
+  const { treeName, branch, id } = useRouterState({
+    select: s => s.location.state,
+  });
+
+  const logDataTreeName = logData?.tree_name;
+  const logDataBranch = logData?.git_repository_branch;
+  const logDataHash = logData?.git_commit_hash;
+
+  const stateIsSetted = treeName && branch && id;
+  const stateParams = useMemo(
+    () =>
+      !stateIsSetted
+        ? { treeName: logDataTreeName, branch: logDataBranch, id: logDataHash }
+        : {},
+    [stateIsSetted, logDataTreeName, logDataBranch, logDataHash],
+  );
+
   const linkComponent = useMemo(() => {
     if (logUrl) {
       return (
@@ -74,7 +91,7 @@ export const LogViewerCard = ({
               type: itemType,
               origin: s.origin,
             })}
-            state={s => s}
+            state={s => ({ ...s, ...stateParams })}
           >
             <FormattedMessage
               id="logViewer.viewFullLog"
@@ -93,7 +110,7 @@ export const LogViewerCard = ({
         </div>
       );
     }
-  }, [logUrl, itemId, itemType, fileName]);
+  }, [logUrl, itemId, itemType, fileName, stateParams]);
 
   const hardwareLabel = useMemo(() => {
     return `${hardware} (${architecture})`;

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -109,8 +109,8 @@ const TestDetailsSections = ({
       linkTo = '/hardware/$hardwareId/build/$buildId';
       linkParams = { hardwareId: historyState.id, buildId: test.build_id };
     } else if (historyState.from === RedirectFrom.Tree && historyState.id) {
-      linkTo = '/tree/$treeId/build/$buildId';
-      linkParams = { treeId: historyState.id, buildId: test.build_id };
+      linkTo = '/build/$buildId';
+      linkParams = { buildId: test.build_id };
     } else {
       linkParams = { buildId: test.build_id };
     }

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -108,11 +108,19 @@ const getLinkProps = (
         }),
       };
 
+  const stateParams = canGoDirect
+    ? {
+        treeName: tree_name,
+        branch: branch,
+        id: hash,
+      }
+    : { id: hash };
+
   return {
     ...urlDirection,
     state: s => ({
       ...s,
-      id: hash,
+      ...stateParams,
       from: RedirectFrom.Tree,
       treeStatusCount: {
         builds: statusCountToRequiredStatusCount({

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -42,6 +42,8 @@ declare module '@tanstack/react-router' {
   interface HistoryState {
     id?: string;
     from?: RedirectFrom;
+    treeName?: string;
+    branch?: string;
     treeStatusCount?: {
       builds?: RequiredStatusCount;
       boots?: RequiredStatusCount;

--- a/dashboard/src/pages/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/pages/BuildDetails/BuildDetails.tsx
@@ -26,6 +26,7 @@ const BuildDetailsPage = (): JSX.Element => {
         testId: testId,
       },
       search: s => s,
+      state: s => s,
     }),
     [],
   );

--- a/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
+++ b/dashboard/src/pages/TreeBuildDetails/TreeBuildDetails.tsx
@@ -27,6 +27,7 @@ const TreeBuildDetails = (): JSX.Element => {
         treeId: treeId,
       },
       search: s => s,
+      state: s => s,
     }),
     [treeId],
   );

--- a/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/Build/TreeDetailsBuildsTable.tsx
@@ -1,7 +1,12 @@
-import { useCallback, type JSX } from 'react';
+import { useCallback, useMemo, type JSX } from 'react';
 
 import type { LinkProps } from '@tanstack/react-router';
-import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+import {
+  useNavigate,
+  useParams,
+  useRouterState,
+  useSearch,
+} from '@tanstack/react-router';
 
 import { BuildsTable } from '@/components/BuildsTable/BuildsTable';
 import {
@@ -12,6 +17,7 @@ import {
   treeDetailsFromMap,
 } from '@/types/tree/TreeDetails';
 import { getStringParam } from '@/utils/utils';
+import { RedirectFrom } from '@/types/general';
 
 export interface TTreeDetailsBuildsTable {
   buildItems: AccordionItemBuilds[];
@@ -26,21 +32,49 @@ export function TreeDetailsBuildsTable({
   const { tableFilter } = useSearch({ from: urlFrom });
   const navigate = useNavigate({ from: treeDetailsFromMap[urlFrom] });
 
-  const treeId =
+  const { treeName, branch, id } = useRouterState({
+    select: s => s.location.state,
+  });
+  const paramsTreeName = getStringParam(params, 'treeName');
+  const paramsBranch = getStringParam(params, 'branch');
+  const paramsHash =
     getStringParam(params, 'treeId') || getStringParam(params, 'hash');
 
+  const stateIsSetted = treeName && branch && id;
+  const stateParams = useMemo(
+    () =>
+      !stateIsSetted
+        ? { treeName: paramsTreeName, branch: paramsBranch, id: paramsHash }
+        : {},
+    [stateIsSetted, paramsTreeName, paramsBranch, paramsHash],
+  );
+
+  const canGoDirect = paramsTreeName && paramsBranch && paramsHash;
+
   const getRowLink = useCallback(
-    (buildId: string): LinkProps => ({
-      to: '/tree/$treeId/build/$buildId',
-      params: {
-        buildId: buildId,
-        treeId: treeId,
-      },
-      search: s => ({
-        origin: s.origin,
-      }),
-    }),
-    [treeId],
+    (buildId: string): LinkProps =>
+      canGoDirect
+        ? {
+            to: '/build/$buildId',
+            params: {
+              buildId: buildId,
+            },
+            search: s => ({
+              origin: s.origin,
+            }),
+            state: s => ({ ...s, ...stateParams, from: RedirectFrom.Tree }),
+          }
+        : {
+            to: '/tree/$treeId/build/$buildId',
+            params: {
+              buildId: buildId,
+              treeId: paramsHash,
+            },
+            search: s => ({
+              origin: s.origin,
+            }),
+          },
+    [stateParams, canGoDirect, paramsHash],
   );
 
   const onClickFilter = useCallback(

--- a/dashboard/src/routes/_main/tree/$treeId/build/$buildId/index.tsx
+++ b/dashboard/src/routes/_main/tree/$treeId/build/$buildId/index.tsx
@@ -4,12 +4,12 @@ import { RedirectFrom } from '@/types/general';
 
 export const Route = createFileRoute('/_main/tree/$treeId/build/$buildId/')({
   loaderDeps: ({ search }) => ({ search }),
-  loader: async ({ params, deps }) => {
+  loader: async ({ params, deps, location }) => {
     throw redirect({
       to: '/build/$buildId',
       params: { buildId: params.buildId },
       search: deps.search,
-      state: { id: params.treeId, from: RedirectFrom.Tree },
+      state: { ...location.state, id: params.treeId, from: RedirectFrom.Tree },
     });
   },
 });

--- a/dashboard/src/routes/_main/tree/$treeId/test/$testId/index.tsx
+++ b/dashboard/src/routes/_main/tree/$treeId/test/$testId/index.tsx
@@ -4,12 +4,12 @@ import { RedirectFrom } from '@/types/general';
 
 export const Route = createFileRoute('/_main/tree/$treeId/test/$testId/')({
   loaderDeps: ({ search }) => ({ search }),
-  loader: async ({ params, deps }) => {
+  loader: async ({ params, deps, location }) => {
     throw redirect({
       to: '/test/$testId',
       params: { testId: params.testId },
       search: deps.search,
-      state: { id: params.treeId, from: RedirectFrom.Tree },
+      state: { ...location.state, id: params.treeId, from: RedirectFrom.Tree },
     });
   },
 });


### PR DESCRIPTION
## Description
This PR fixes the breadcrumb links for the BuildDetails, TestDetails and LogViewer pages to accommodate the updated URL structure.
Previously, breadcrumbs were not resolving correctly due to changes in the route parameters.
With this fix, the breadcrumb now accurately reflects the current path

## Changes
- [x] Remanaged the routerState in pages like LogViewer, BuildDetails, and TestDetails
- [x] Updated breadcrumb logic to consistently resolve to the correct TreeDetails url

## How to test
1. Navigate to a TreeDetails page via TreeListing or directly via URL
1. From there, open related pages such as LogViewer, BuildDetails and TestDetails
1. Verify that the breadcrumb displays correctly in each case and accurately reflects the full path back to the TreeDetails
1. Ensure no breadcrumb segment is broken or missing

Closes #1314