### PR TITLE
Fix: use default validators in endpoints

### DIFF
--- a/backend/kernelCI_app/typeModels/common.py
+++ b/backend/kernelCI_app/typeModels/common.py
@@ -1,6 +1,6 @@
 from typing import Optional, TypedDict
 
-from pydantic import BaseModel
+from pydantic import BaseModel, BeforeValidator
 
 from kernelCI_app.helpers.logger import log_message
 
@@ -39,3 +39,7 @@ class GroupedStatus(TypedDict):
     success: int
     failed: int
     inconclusive: int
+
+
+def make_default_validator(default) -> BeforeValidator:
+    return BeforeValidator(lambda var: default if var is None else var)

--- a/backend/kernelCI_app/typeModels/commonListing.py
+++ b/backend/kernelCI_app/typeModels/commonListing.py
@@ -1,8 +1,9 @@
 from typing import Annotated
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, Field
 
 from kernelCI_app.constants.general import DEFAULT_INTERVAL_IN_DAYS, DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
+from kernelCI_app.typeModels.common import make_default_validator
 
 
 class ListingInterval(BaseModel):
@@ -13,6 +14,7 @@ class ListingInterval(BaseModel):
             gt=0,
             description=DocStrings.DEFAULT_INTERVAL_DESCRIPTION,
         ),
+        make_default_validator(DEFAULT_INTERVAL_IN_DAYS),
     ]
 
 
@@ -23,5 +25,5 @@ class ListingQueryParameters(ListingInterval):
             default=DEFAULT_ORIGIN,
             description=DocStrings.LISTING_QUERY_ORIGIN_DESCRIPTION,
         ),
-        BeforeValidator(lambda o: DEFAULT_ORIGIN if o is None else o),
+        make_default_validator(DEFAULT_ORIGIN),
     ]

--- a/backend/kernelCI_app/typeModels/kciSummary.py
+++ b/backend/kernelCI_app/typeModels/kciSummary.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 from typing import TypedDict
+from typing_extensions import Annotated
 from pydantic import BaseModel, Field
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
-from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.common import StatusCount, make_default_validator
 from kernelCI_app.typeModels.databases import Test__Id, Test__StartTime, Test__Status
 from kernelCI_app.typeModels.treeListing import TestStatusCount
 
@@ -13,19 +14,39 @@ DEFAULT_GROUP_SIZE = 3
 
 
 class KciSummaryQueryParameters(BaseModel):
-    origin: str = Field(
-        default=DEFAULT_ORIGIN, description=DocStrings.TREE_QUERY_ORIGIN_DESCRIPTION
-    )
-    git_branch: str = Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION)
-    git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
-    path: list[str] = Field(
-        default=DEFAULT_PATH_SEARCH, description=DocStrings.KCI_SUMMARY_PATH_DESCRIPTION
-    )
-    group_size: int = Field(
-        gt=0,
-        default=DEFAULT_GROUP_SIZE,
-        description=DocStrings.KCI_SUMMARY_GROUP_SIZE_DESCRIPTION,
-    )
+    origin: Annotated[
+        str,
+        Field(
+            default=DEFAULT_ORIGIN,
+            description=DocStrings.TREE_QUERY_ORIGIN_DESCRIPTION,
+        ),
+        make_default_validator(DEFAULT_ORIGIN),
+    ]
+    git_branch: Annotated[
+        str,
+        Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION),
+    ]
+    git_url: Annotated[
+        str,
+        Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION),
+    ]
+    path: Annotated[
+        list[str],
+        Field(
+            default=DEFAULT_PATH_SEARCH,
+            description=DocStrings.KCI_SUMMARY_PATH_DESCRIPTION,
+        ),
+        make_default_validator(DEFAULT_PATH_SEARCH),
+    ]
+    group_size: Annotated[
+        int,
+        Field(
+            gt=0,
+            default=DEFAULT_GROUP_SIZE,
+            description=DocStrings.KCI_SUMMARY_GROUP_SIZE_DESCRIPTION,
+        ),
+        make_default_validator(DEFAULT_GROUP_SIZE),
+    ]
 
 
 class RegressionHistoryItem(TypedDict):

--- a/backend/kernelCI_app/views/kciSummaryView.py
+++ b/backend/kernelCI_app/views/kciSummaryView.py
@@ -7,15 +7,12 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from pydantic import ValidationError
 
-from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.trees import sanitize_tree
 from kernelCI_app.management.commands.helpers.summary import TreeKey
 from kernelCI_app.management.commands.notifications import evaluate_test_results
 from kernelCI_app.queries.notifications import get_checkout_summary_data
 from kernelCI_app.typeModels.kciSummary import (
-    DEFAULT_GROUP_SIZE,
-    DEFAULT_PATH_SEARCH,
     KciSummaryQueryParameters,
     KciSummaryResponse,
 )
@@ -30,11 +27,11 @@ class KciSummary(APIView):
     def get(self, request: HttpRequest):
         try:
             params = KciSummaryQueryParameters(
-                origin=request.GET.get("origin", DEFAULT_ORIGIN),
+                origin=request.GET.get("origin"),
                 git_branch=request.GET.get("git_branch"),
                 git_url=request.GET.get("git_url"),
-                path=request.GET.getlist("path", DEFAULT_PATH_SEARCH),
-                group_size=request.GET.get("group_size", DEFAULT_GROUP_SIZE),
+                path=request.GET.getlist("path"),
+                group_size=request.GET.get("group_size"),
             )
             origin = params.origin
             git_url = params.git_url


### PR DESCRIPTION
When an endpoint is accessed without a parameter, the request.GET.get() will return None and pass it to the class. Since some value was passed, the basic 'default' won't be used (it's only used if there is no value being passed). In order to provide a centralized and working default value, validators are used in the query parameters, altering the value if it is None.

## Changes
- Added a helper function to return the BeforeValidator to query param classes
- Used that function in tree listing endpoints to add a real default fallback
- Used that function in kci-summary to avoid repeating the use of default values in the model and then the endpoint

## How to test
- Go to the tree listing and kci-summary endpoints without passing optional parameters and check that they are being assigned a default value. Compare that to the staging equivalent.

Closes #1340