### PR TITLE
fix(logviewer): handle logexcerpt as direct content or URL

### DIFF
--- a/dashboard/src/api/logViewer.ts
+++ b/dashboard/src/api/logViewer.ts
@@ -2,6 +2,9 @@ import pako from 'pako';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import { minutesToMilliseconds } from 'date-fns';
+import { useIntl } from 'react-intl';
+
+import { LOG_EXCERPT_ALLOWED_DOMAINS } from '@/utils/constants/log_excerpt_allowed_domain';
 
 import { RequestData } from './commonRequest';
 
@@ -53,6 +56,51 @@ export const useLogViewer = (
     queryKey: ['logs', url],
     queryFn: () => fetchAndDecompressLog(url),
     enabled: !!url,
+    staleTime: STALE_DURATION_MS,
+    refetchOnWindowFocus: false,
+  });
+};
+
+const isAllowedUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return LOG_EXCERPT_ALLOWED_DOMAINS.includes(url.hostname);
+  } catch {
+    return false;
+  }
+};
+
+const fetchLogExcerptContent = async (
+  logExcerpt: string | null | undefined,
+  errorMessage: string,
+): Promise<{ content: string }> => {
+  if (!logExcerpt) {
+    return { content: '' };
+  }
+
+  if (!isAllowedUrl(logExcerpt)) {
+    return { content: logExcerpt };
+  }
+
+  try {
+    const content = await fetchAndDecompressLog(logExcerpt);
+    return content;
+  } catch {
+    return { content: errorMessage };
+  }
+};
+
+export const useLogExcerpt = (
+  logExcerpt?: string,
+): UseQueryResult<{ content: string }> => {
+  const { formatMessage } = useIntl();
+  const errorMessage = formatMessage(
+    { id: 'logViewer.errorFetchingLogExcerpt' },
+    { logExcerpt },
+  );
+  return useQuery({
+    queryKey: ['logExcerpt', logExcerpt, errorMessage],
+    queryFn: () => fetchLogExcerptContent(logExcerpt, errorMessage),
     staleTime: STALE_DURATION_MS,
     refetchOnWindowFocus: false,
   });

--- a/dashboard/src/components/Sheet/LogOrJsonSheetContent.tsx
+++ b/dashboard/src/components/Sheet/LogOrJsonSheetContent.tsx
@@ -13,9 +13,11 @@ import { MemoizedMoreDetailsButton } from '@/components/Button/MoreDetailsButton
 
 import { LogViewerCard } from '@/components/Log/LogViewerCard';
 import { LogExcerpt } from '@/components/Log/LogExcerpt';
+import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import IssueSection from '@/components/Issue/IssueSection';
 import type { TIssue } from '@/types/issues';
 import type { LogData } from '@/hooks/useLogData';
+import { useLogExcerpt } from '@/api/logViewer';
 
 export type SheetType = 'log' | 'json';
 
@@ -47,6 +49,10 @@ export const LogOrJsonSheetContent = ({
   status,
   error,
 }: ILogSheet): JSX.Element => {
+  const logExcerpt = logData?.log_excerpt;
+  const { data: logExcerptData, status: logExcerptStatus } =
+    useLogExcerpt(logExcerpt);
+
   return (
     <WrapperSheetContent
       sheetTitle={type === 'log' ? 'logSheet.title' : 'jsonSheet.title'}
@@ -63,11 +69,13 @@ export const LogOrJsonSheetContent = ({
             logData={logData}
             isLoading={navigationLogsActions?.isLoading}
           />
-          <LogExcerpt
-            logExcerpt={logData?.log_excerpt}
-            isLoading={navigationLogsActions?.isLoading}
-            variant="default"
-          />
+          <QuerySwitcher data={logExcerptData} status={logExcerptStatus}>
+            <LogExcerpt
+              logExcerpt={logExcerptData?.content}
+              isLoading={navigationLogsActions?.isLoading}
+              variant="default"
+            />
+          </QuerySwitcher>
 
           {!hideIssueSection && (
             <IssueSection

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -241,6 +241,8 @@ export const messages = {
     'logViewer.disabledHighlight':
       'The text highlight was disabled in this log due to the log size',
     'logViewer.download': 'Download full log',
+    'logViewer.errorFetchingLogExcerpt':
+      'Error fetching logExcerpt at: {logExcerpt}',
     'logViewer.viewFullLog': 'View full log for {fileName}',
     'logspec.info':
       "This is the same logspec data that's in the misc data section",

--- a/dashboard/src/utils/constants/log_excerpt_allowed_domain.ts
+++ b/dashboard/src/utils/constants/log_excerpt_allowed_domain.ts
@@ -1,0 +1,4 @@
+export const LOG_EXCERPT_ALLOWED_DOMAINS = [
+  'files.kernelci.org',
+  'files-staging.kernelci.org',
+];


### PR DESCRIPTION
## Description
This PR updates the behavior of the logexcerpt field to support both inline string content and remote file URLs.
In the new schema, the logexcerpt field may be either a string (with content to display directly) or a URL pointing to the file.
This update ensures the UI handles both cases properly by conditionally parsing the value based on its format.

## Changes
- [x] Updated LogViewerCard logic to detect whether logexcerpt is a raw string or a URL
- [x] If the value is a URL, the content is fetched and displayed dynamically
- [x] If it’s a string, it is rendered directly in the UI

## How to test
1. Navigate to a tree details page where the logExcerpt field is present
1. Click on any build, boot or test details
1. Confirm that if the logexcerpt is a raw string, it displays as expected

The current production data does not include a logexcerpt as a URL
To test URL handling:
1. Go to `src/components/Sheet/LogOrJsonSheetContent.tsx`
1. Simulate a logexcerpt as a URL by changing the variable `const logExcerpt = logData?.log_excerpt ?? '';`
to
`const logExcerpt = 'https://files-staging.kernelci.org/logexcerpt/f0cec57a87733305dacda1348784379f5f7980a3fd2906f47eaf34d2fb918ebf/logexcerpt.txt.gz';`
1. Reload the page and verify that the remote content is fetched and rendered properly

Closes #1331