### PR TITLE
refactor(api): rename kci-summary endpoint to tree-report

### DIFF
--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -83,23 +83,22 @@ class DocStrings:
     BOOT_STATUS_SUMMARY_DESCRIPTION = "Summary of boot test statuses"
     TEST_STATUS_SUMMARY_DESCRIPTION = "Summary of test statuses"
 
-    # KCI Summary related descriptions
     REGRESSIONS_GROUP = "Regressions are grouped by hardware, config, and path."
-    KCI_SUMMARY_PATH_DESCRIPTION = (
+    TREE_REPORT_PATH_DESCRIPTION = (
         "A list of test paths to query for. SQL Wildcard can be used."
     )
-    KCI_SUMMARY_DASHBOARD_URL_DESCRIPTION = (
+    TREE_REPORT_DASHBOARD_URL_DESCRIPTION = (
         "The dashboard url of this tree/branch/commit"
     )
-    KCI_SUMMARY_POSSIBLE_REGRESSIONS_DESCRIPTION = (
+    TREE_REPORT_POSSIBLE_REGRESSIONS_DESCRIPTION = (
         "History of tests that are possible regressions." + REGRESSIONS_GROUP
     )
-    KCI_SUMMARY_FIXED_REGRESSIONS_DESCRIPTION = (
+    TREE_REPORT_FIXED_REGRESSIONS_DESCRIPTION = (
         "History of tests that are fixed regressions." + REGRESSIONS_GROUP
     )
-    KCI_SUMMARY_UNSTABLE_TESTS_DESCRIPTION = (
+    TREE_REPORT_UNSTABLE_TESTS_DESCRIPTION = (
         "History of tests that are unstable. " + REGRESSIONS_GROUP
     )
-    KCI_SUMMARY_GROUP_SIZE_DESCRIPTION = (
+    TREE_REPORT_GROUP_SIZE_DESCRIPTION = (
         "Maximum number of entries to be retrieved in a test history."
     )

--- a/backend/kernelCI_app/typeModels/treeReport.py
+++ b/backend/kernelCI_app/typeModels/treeReport.py
@@ -13,7 +13,7 @@ DEFAULT_PATH_SEARCH = ["%"]
 DEFAULT_GROUP_SIZE = 3
 
 
-class KciSummaryQueryParameters(BaseModel):
+class TreeReportQueryParameters(BaseModel):
     origin: Annotated[
         str,
         Field(
@@ -34,7 +34,7 @@ class KciSummaryQueryParameters(BaseModel):
         list[str],
         Field(
             default=DEFAULT_PATH_SEARCH,
-            description=DocStrings.KCI_SUMMARY_PATH_DESCRIPTION,
+            description=DocStrings.TREE_REPORT_PATH_DESCRIPTION,
         ),
         make_default_validator(DEFAULT_PATH_SEARCH),
     ]
@@ -43,7 +43,7 @@ class KciSummaryQueryParameters(BaseModel):
         Field(
             gt=0,
             default=DEFAULT_GROUP_SIZE,
-            description=DocStrings.KCI_SUMMARY_GROUP_SIZE_DESCRIPTION,
+            description=DocStrings.TREE_REPORT_GROUP_SIZE_DESCRIPTION,
         ),
         make_default_validator(DEFAULT_GROUP_SIZE),
     ]
@@ -59,9 +59,9 @@ type RegressionData = dict[str, dict[str, dict[str, list[RegressionHistoryItem]]
 """The history of tests is grouped by hardware, then config, then path."""
 
 
-class KciSummaryResponse(BaseModel):
+class TreeReportResponse(BaseModel):
     dashboard_url: str = Field(
-        description=DocStrings.KCI_SUMMARY_DASHBOARD_URL_DESCRIPTION
+        description=DocStrings.TREE_REPORT_DASHBOARD_URL_DESCRIPTION
     )
     git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
     git_branch: str = Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION)
@@ -80,11 +80,11 @@ class KciSummaryResponse(BaseModel):
         description=DocStrings.TEST_STATUS_SUMMARY_DESCRIPTION
     )
     possible_regressions: RegressionData = Field(
-        description=DocStrings.KCI_SUMMARY_POSSIBLE_REGRESSIONS_DESCRIPTION,
+        description=DocStrings.TREE_REPORT_POSSIBLE_REGRESSIONS_DESCRIPTION,
     )
     fixed_regressions: RegressionData = Field(
-        description=DocStrings.KCI_SUMMARY_FIXED_REGRESSIONS_DESCRIPTION
+        description=DocStrings.TREE_REPORT_FIXED_REGRESSIONS_DESCRIPTION
     )
     unstable_tests: RegressionData = Field(
-        description=DocStrings.KCI_SUMMARY_UNSTABLE_TESTS_DESCRIPTION,
+        description=DocStrings.TREE_REPORT_UNSTABLE_TESTS_DESCRIPTION,
     )

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -151,5 +151,5 @@ urlpatterns = [
     ),
     path("proxy/", views.ProxyView.as_view(), name="proxyView"),
     path("origins/", views.OriginsView.as_view(), name="originsView"),
-    path("kci-summary/", views.KciSummary.as_view(), name="kciSummary"),
+    path("tree-report/", views.TreeReport.as_view(), name="treeReportView"),
 ]

--- a/backend/kernelCI_app/views/treeReportView.py
+++ b/backend/kernelCI_app/views/treeReportView.py
@@ -12,21 +12,21 @@ from kernelCI_app.helpers.trees import sanitize_tree
 from kernelCI_app.management.commands.helpers.summary import TreeKey
 from kernelCI_app.management.commands.notifications import evaluate_test_results
 from kernelCI_app.queries.notifications import get_checkout_summary_data
-from kernelCI_app.typeModels.kciSummary import (
-    KciSummaryQueryParameters,
-    KciSummaryResponse,
+from kernelCI_app.typeModels.treeReport import (
+    TreeReportQueryParameters,
+    TreeReportResponse,
 )
 
 
-class KciSummary(APIView):
+class TreeReport(APIView):
     @extend_schema(
-        responses=KciSummaryResponse,
-        parameters=[KciSummaryQueryParameters],
+        responses=TreeReportResponse,
+        parameters=[TreeReportQueryParameters],
         methods=["GET"],
     )
     def get(self, request: HttpRequest):
         try:
-            params = KciSummaryQueryParameters(
+            params = TreeReportQueryParameters(
                 origin=request.GET.get("origin"),
                 git_branch=request.GET.get("git_branch"),
                 git_url=request.GET.get("git_url"),
@@ -81,7 +81,7 @@ class KciSummary(APIView):
                 group_size=params.group_size,
             )
 
-            valid_response = KciSummaryResponse(
+            valid_response = TreeReportResponse(
                 dashboard_url=dashboard_url,
                 git_url=git_url,
                 git_branch=branch,

--- a/backend/requests/tree-report-get.sh
+++ b/backend/requests/tree-report-get.sh
@@ -1,4 +1,4 @@
-http "http://localhost:8000/api/kci-summary/" git_branch==for-kernelci git_url==https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git origin==maestro
+http "http://localhost:8000/api/tree-report/" git_branch==for-kernelci git_url==https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git origin==maestro
 
 # HTTP/1.1 200 OK
 # Allow: GET, HEAD, OPTIONS

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -479,62 +479,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/IssueExtraDetailsResponse'
           description: ''
-  /api/kci-summary/:
-    get:
-      operationId: kci_summary_retrieve
-      parameters:
-      - in: query
-        name: git_branch
-        schema:
-          title: Git Branch
-          type: string
-        description: Git branch name of the tree
-        required: true
-      - in: query
-        name: git_url
-        schema:
-          title: Git Url
-          type: string
-        description: Git repository URL of the tree
-        required: true
-      - in: query
-        name: group_size
-        schema:
-          default: 3
-          exclusiveMinimum: 0
-          title: Group Size
-          type: integer
-        description: Maximum number of entries to be retrieved in a test history.
-      - in: query
-        name: origin
-        schema:
-          default: maestro
-          title: Origin
-          type: string
-        description: Origin of the tree
-      - in: query
-        name: path
-        schema:
-          default:
-          - '%'
-          items:
-            type: string
-          title: Path
-          type: array
-        description: A list of test paths to query for. SQL Wildcard can be used.
-      tags:
-      - kci-summary
-      security:
-      - cookieAuth: []
-      - basicAuth: []
-      - {}
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/KciSummaryResponse'
-          description: ''
   /api/log-downloader/:
     get:
       operationId: log_downloader_retrieve
@@ -931,6 +875,62 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TreeListingFastResponse'
+          description: ''
+  /api/tree-report/:
+    get:
+      operationId: tree_report_retrieve
+      parameters:
+      - in: query
+        name: git_branch
+        schema:
+          title: Git Branch
+          type: string
+        description: Git branch name of the tree
+        required: true
+      - in: query
+        name: git_url
+        schema:
+          title: Git Url
+          type: string
+        description: Git repository URL of the tree
+        required: true
+      - in: query
+        name: group_size
+        schema:
+          default: 3
+          exclusiveMinimum: 0
+          title: Group Size
+          type: integer
+        description: Maximum number of entries to be retrieved in a test history.
+      - in: query
+        name: origin
+        schema:
+          default: maestro
+          title: Origin
+          type: string
+        description: Origin of the tree
+      - in: query
+        name: path
+        schema:
+          default:
+          - '%'
+          items:
+            type: string
+          title: Path
+          type: array
+        description: A list of test paths to query for. SQL Wildcard can be used.
+      tags:
+      - tree-report
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TreeReportResponse'
           description: ''
   /api/tree/{commit_hash}/boots:
     get:
@@ -2855,69 +2855,6 @@ components:
       - type: 'null'
     Issue__Version:
       type: integer
-    KciSummaryResponse:
-      properties:
-        dashboard_url:
-          description: The dashboard url of this tree/branch/commit
-          title: Dashboard Url
-          type: string
-        git_url:
-          description: Git repository URL of the tree
-          title: Git Url
-          type: string
-        git_branch:
-          description: Git branch name of the tree
-          title: Git Branch
-          type: string
-        commit_hash:
-          description: Commit hash of the tree
-          title: Commit Hash
-          type: string
-        origin:
-          description: Origin of the tree
-          title: Origin
-          type: string
-        checkout_start_time:
-          description: Start time of the checkout
-          format: date-time
-          title: Checkout Start Time
-          type: string
-        build_status_summary:
-          $ref: '#/components/schemas/StatusCount'
-          description: Summary of build statuses
-        boot_status_summary:
-          $ref: '#/components/schemas/TestStatusCount'
-          description: Summary of boot test statuses
-        test_status_summary:
-          $ref: '#/components/schemas/TestStatusCount'
-          description: Summary of test statuses
-        possible_regressions:
-          $ref: '#/components/schemas/RegressionData'
-          description: History of tests that are possible regressions.Regressions
-            are grouped by hardware, config, and path.
-        fixed_regressions:
-          $ref: '#/components/schemas/RegressionData'
-          description: History of tests that are fixed regressions.Regressions are
-            grouped by hardware, config, and path.
-        unstable_tests:
-          $ref: '#/components/schemas/RegressionData'
-          description: History of tests that are unstable. Regressions are grouped
-            by hardware, config, and path.
-      required:
-      - dashboard_url
-      - git_url
-      - git_branch
-      - commit_hash
-      - origin
-      - checkout_start_time
-      - build_status_summary
-      - boot_status_summary
-      - test_status_summary
-      - possible_regressions
-      - fixed_regressions
-      - unstable_tests
-      title: KciSummaryResponse
-      type: object
     LocalFilters:
       properties:
         issues:
@@ -3703,6 +3640,69 @@ components:
         $ref: '#/components/schemas/Checkout'
       title: TreeListingResponse
       type: array
+    TreeReportResponse:
+      properties:
+        dashboard_url:
+          description: The dashboard url of this tree/branch/commit
+          title: Dashboard Url
+          type: string
+        git_url:
+          description: Git repository URL of the tree
+          title: Git Url
+          type: string
+        git_branch:
+          description: Git branch name of the tree
+          title: Git Branch
+          type: string
+        commit_hash:
+          description: Commit hash of the tree
+          title: Commit Hash
+          type: string
+        origin:
+          description: Origin of the tree
+          title: Origin
+          type: string
+        checkout_start_time:
+          description: Start time of the checkout
+          format: date-time
+          title: Checkout Start Time
+          type: string
+        build_status_summary:
+          $ref: '#/components/schemas/StatusCount'
+          description: Summary of build statuses
+        boot_status_summary:
+          $ref: '#/components/schemas/TestStatusCount'
+          description: Summary of boot test statuses
+        test_status_summary:
+          $ref: '#/components/schemas/TestStatusCount'
+          description: Summary of test statuses
+        possible_regressions:
+          $ref: '#/components/schemas/RegressionData'
+          description: History of tests that are possible regressions.Regressions
+            are grouped by hardware, config, and path.
+        fixed_regressions:
+          $ref: '#/components/schemas/RegressionData'
+          description: History of tests that are fixed regressions.Regressions are
+            grouped by hardware, config, and path.
+        unstable_tests:
+          $ref: '#/components/schemas/RegressionData'
+          description: History of tests that are unstable. Regressions are grouped
+            by hardware, config, and path.
+      required:
+      - dashboard_url
+      - git_url
+      - git_branch
+      - commit_hash
+      - origin
+      - checkout_start_time
+      - build_status_summary
+      - boot_status_summary
+      - test_status_summary
+      - possible_regressions
+      - fixed_regressions
+      - unstable_tests
+      title: TreeReportResponse
+      type: object
     TreeSetItem:
       properties:
         tree_name:


### PR DESCRIPTION
## Description
This PR renames the kci-summary endpoint to tree-report.
It includes changes to the endpoint route, view name, type model identifiers, and schema definitions where the previous name was used.

## Changes

- [x] Renamed the kci-summary route in the API
- [x] Updated the associated view class name
- [x] Renamed type models that referenced kci-summary
- [x] Updated schema metadata to reflect the new naming

## How to test
1. Run the backend server and open the Swagger UI at /api/schema/swagger-ui/
1. Locate the renamed endpoint and confirm it is listed with the new name and correct description
1. Send a request to the endpoint and verify the response remains unchanged in structure and correctness
1. Check that there are no remaining references to the old kci-summary name in the codebase

Closes #1344