### PR TITLE
feat(api): Add time-based filtering to origin endpoint

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -317,3 +317,7 @@ if DEBUG_SQL_QUERY:
             },
         },
     }
+
+DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS = get_json_env_var(
+    "DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS", 30
+)

--- a/backend/kernelCI_app/typeModels/origins.py
+++ b/backend/kernelCI_app/typeModels/origins.py
@@ -1,6 +1,16 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from kernelCI.settings import DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS
+from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.databases import Origin
+
+
+class OriginsQueryParameters(BaseModel):
+    interval_in_days: int = Field(
+        default=DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS,
+        gt=0,
+        description=DocStrings.DEFAULT_INTERVAL_DESCRIPTION,
+    )
 
 
 class OriginsResponse(BaseModel):


### PR DESCRIPTION
## Description
This PR adds a time-based filter to the origin endpoint to ensure only active origins are returned.
Previously, the endpoint returned all origins ever seen in the database, including legacy ones no longer in use.
To address this, a new query parameter interval_in_days was introduced, defaulting to DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS=30, to filter out inactive origins based on recent checkout activity. This default can be modified by a environment variable with the same name.

## Changes
- [x] Added interval_in_days query parameter to the /origin endpoint
- [x] Defaults to 30 days if the parameter is not explicitly provided in query parameter
- [x] Filters out origins with no checkout activity in the selected time window
- [x] Keeps hardcoded logic for test origins unchanged due to potential performance concerns

## How to test
1. Run the backend and access the /origin endpoint
1. Verify that only origins with recent checkout activity (within the last 30 days) are returned
1. Override the default by passing a custom interval (e.g., ?interval_in_days=1). Test with negative and with no interval_in_days.
1. Confirm that legacy or inactive origins are excluded appropriately
1. Ensure that test origins continue to return correctly

Closes #1322