### PR TITLE
refactor(tree): separate views and parameters per endpoint

### DIFF
--- a/backend/kernelCI_app/typeModels/treeCommits.py
+++ b/backend/kernelCI_app/typeModels/treeCommits.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, RootModel
 
+from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.treeListing import TestStatusCount
@@ -13,13 +14,9 @@ from kernelCI_app.typeModels.databases import (
 )
 
 
-class TreeCommitsQueryParameters(BaseModel):
-    origin: str = Field(description=DocStrings.TREE_COMMIT_ORIGIN_DESCRIPTION)
-    git_url: Optional[str] = Field(
-        None, description=DocStrings.TREE_COMMIT_GIT_URL_DESCRIPTION
-    )
-    git_branch: Optional[str] = Field(
-        None, description=DocStrings.TREE_COMMIT_GIT_BRANCH_DESCRIPTION
+class DirectTreeCommitsQueryParameters(BaseModel):
+    origin: str = Field(
+        DEFAULT_ORIGIN, description=DocStrings.TREE_COMMIT_ORIGIN_DESCRIPTION
     )
     start_time_stamp_in_seconds: Optional[str] = Field(
         None, description=DocStrings.TREE_COMMIT_START_TS_DESCRIPTION
@@ -28,6 +25,15 @@ class TreeCommitsQueryParameters(BaseModel):
         None, description=DocStrings.TREE_COMMIT_END_TS_DESCRIPTION
     )
     # TODO: Add filters field in this model
+
+
+class TreeCommitsQueryParameters(DirectTreeCommitsQueryParameters):
+    git_branch: Optional[str] = Field(
+        description=DocStrings.TREE_COMMIT_GIT_BRANCH_DESCRIPTION
+    )
+    git_url: Optional[str] = Field(
+        description=DocStrings.TREE_COMMIT_GIT_URL_DESCRIPTION
+    )
 
 
 class TreeCommitsData(BaseModel):

--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -50,10 +50,15 @@ class TreeDetailsBuildsResponse(BaseModel):
     builds: List[BuildHistoryItem]
 
 
-class TreeQueryParameters(BaseModel):
-    origin: str = Field(description=DocStrings.TREE_QUERY_ORIGIN_DESCRIPTION)
-    git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
+class DirectTreeQueryParameters(BaseModel):
+    origin: str = Field(
+        DEFAULT_ORIGIN, description=DocStrings.TREE_QUERY_ORIGIN_DESCRIPTION
+    )
+
+
+class TreeQueryParameters(DirectTreeQueryParameters):
     git_branch: str = Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION)
+    git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
 
 
 class TreeDetailsFullResponse(

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -57,27 +57,27 @@ urlpatterns = [
     ),
     path(
         "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>/commits",
-        view_cache(views.TreeCommitsHistory),
+        view_cache(views.TreeCommitsHistoryDirect),
         name="treeCommitsDirectView",
     ),
     path(
         "tree/<str:tree_name>/<str:git_branch>",
-        view_cache(views.TreeLatest),
+        view_cache(views.TreeLatestCheckout),
         name="treeLatest",
     ),
     path(
         "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>",
-        view_cache(views.TreeLatest),
+        view_cache(views.TreeCheckoutInfo),
         name="treeLatestHash",
     ),
     path(
         "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>/full",
-        views.TreeDetails.as_view(),
+        views.TreeDetailsDirect.as_view(),
         name="treeDetailsDirectView",
     ),
     path(
         "tree/<str:tree_name>/<str:git_branch>/<str:commit_hash>/summary",
-        views.TreeDetailsSummary.as_view(),
+        views.TreeDetailsSummaryDirect.as_view(),
         name="treeDetailsDirectSummaryView",
     ),
     path("build/<str:build_id>", view_cache(views.BuildDetails), name="buildDetails"),

--- a/backend/kernelCI_app/views/treeLatest.py
+++ b/backend/kernelCI_app/views/treeLatest.py
@@ -12,6 +12,11 @@ from pydantic import ValidationError
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.queries.tree import get_latest_tree
+from kernelCI_app.typeModels.commonOpenApiParameters import (
+    COMMIT_HASH_PATH_PARAM,
+    GIT_BRANCH_PATH_PARAM,
+    TREE_NAME_PATH_PARAM,
+)
 from kernelCI_app.typeModels.treeDetails import (
     TreeLatestPathParameters,
     TreeLatestResponse,
@@ -20,12 +25,8 @@ from kernelCI_app.typeModels.treeDetails import (
 from kernelCI_app.constants.localization import ClientStrings
 
 
-class TreeLatest(APIView):
-    @extend_schema(
-        responses=TreeLatestResponse,
-        parameters=[TreeLatestQueryParameters],
-        methods=["GET"],
-    )
+class BaseTreeLatest(APIView):
+
     def get(
         self,
         request,
@@ -105,3 +106,48 @@ class TreeLatest(APIView):
             return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         return Response(valid_response.model_dump())
+
+
+class TreeCheckoutInfo(BaseTreeLatest):
+    @extend_schema(
+        responses=TreeLatestResponse,
+        parameters=[
+            COMMIT_HASH_PATH_PARAM,
+            TREE_NAME_PATH_PARAM,
+            GIT_BRANCH_PATH_PARAM,
+            TreeLatestQueryParameters,
+        ],
+        methods=["GET"],
+    )
+    def get(
+        self,
+        request,
+        tree_name: str,
+        git_branch: str,
+        commit_hash: str,
+    ) -> JsonResponse:
+        return super().get(
+            request=request,
+            commit_hash=commit_hash,
+            tree_name=tree_name,
+            git_branch=git_branch,
+        )
+
+
+class TreeLatestCheckout(BaseTreeLatest):
+    @extend_schema(
+        responses=TreeLatestResponse,
+        parameters=[
+            TREE_NAME_PATH_PARAM,
+            GIT_BRANCH_PATH_PARAM,
+            TreeLatestQueryParameters,
+        ],
+        methods=["GET"],
+    )
+    def get(
+        self,
+        request,
+        tree_name: str,
+        git_branch: str,
+    ) -> JsonResponse:
+        return super().get(request=request, tree_name=tree_name, git_branch=git_branch)

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -506,6 +506,15 @@ paths:
   /api/origins/:
     get:
       operationId: origins_retrieve
+      parameters:
+      - in: query
+        name: interval_in_days
+        schema:
+          default: 30
+          exclusiveMinimum: 0
+          title: Interval In Days
+          type: integer
+        description: Interval in days for the listing
       tags:
       - origins
       security:
@@ -959,10 +968,10 @@ paths:
       - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin of the tree
-        required: true
       tags:
       - tree
       security:
@@ -1003,10 +1012,10 @@ paths:
       - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin of the tree
-        required: true
       tags:
       - tree
       security:
@@ -1028,6 +1037,7 @@ paths:
         name: commit_hash
         schema:
           type: string
+        description: Commit hash of the tree
         required: true
       - in: query
         name: end_time_stamp_in_seconds
@@ -1044,25 +1054,25 @@ paths:
           anyOf:
           - type: string
           - type: 'null'
-          default: null
           title: Git Branch
         description: Git branch name to retrieve the tree commits
+        required: true
       - in: query
         name: git_url
         schema:
           anyOf:
           - type: string
           - type: 'null'
-          default: null
           title: Git Url
         description: Git repository URL to retrieve the tree commits
+        required: true
       - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin to retrieve the tree commits
-        required: true
       - in: query
         name: start_time_stamp_in_seconds
         schema:
@@ -1093,6 +1103,7 @@ paths:
         name: commit_hash
         schema:
           type: string
+        description: Commit hash of the tree
         required: true
       - in: query
         name: git_branch
@@ -1111,10 +1122,10 @@ paths:
       - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin of the tree
-        required: true
       tags:
       - tree
       security:
@@ -1136,6 +1147,7 @@ paths:
         name: commit_hash
         schema:
           type: string
+        description: Commit hash of the tree
         required: true
       - in: query
         name: git_branch
@@ -1154,10 +1166,10 @@ paths:
       - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin of the tree
-        required: true
       tags:
       - tree
       security:
@@ -1198,10 +1210,10 @@ paths:
       - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin of the tree
-        required: true
       tags:
       - tree
       security:
@@ -1223,6 +1235,7 @@ paths:
         name: git_branch
         schema:
           type: string
+        description: Git branch name of the tree
         required: true
       - in: query
         name: origin
@@ -1235,6 +1248,7 @@ paths:
         name: tree_name
         schema:
           type: string
+        description: Name of the tree
         required: true
       tags:
       - tree
@@ -1257,11 +1271,13 @@ paths:
         name: commit_hash
         schema:
           type: string
+        description: Commit hash of the tree
         required: true
       - in: path
         name: git_branch
         schema:
           type: string
+        description: Git branch name of the tree
         required: true
       - in: query
         name: origin
@@ -1274,6 +1290,7 @@ paths:
         name: tree_name
         schema:
           type: string
+        description: Name of the tree
         required: true
       tags:
       - tree
@@ -1296,6 +1313,7 @@ paths:
         name: commit_hash
         schema:
           type: string
+        description: Commit hash of the tree
         required: true
       - in: query
         name: end_time_stamp_in_seconds
@@ -1310,32 +1328,15 @@ paths:
         name: git_branch
         schema:
           type: string
+        description: Git branch name of the tree
         required: true
-      - in: query
-        name: git_branch
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          default: null
-          title: Git Branch
-        description: Git branch name to retrieve the tree commits
-      - in: query
-        name: git_url
-        schema:
-          anyOf:
-          - type: string
-          - type: 'null'
-          default: null
-          title: Git Url
-        description: Git repository URL to retrieve the tree commits
       - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin to retrieve the tree commits
-        required: true
       - in: query
         name: start_time_stamp_in_seconds
         schema:
@@ -1349,6 +1350,7 @@ paths:
         name: tree_name
         schema:
           type: string
+        description: Name of the tree
         required: true
       tags:
       - tree
@@ -1371,37 +1373,26 @@ paths:
         name: commit_hash
         schema:
           type: string
+        description: Commit hash of the tree
         required: true
       - in: path
         name: git_branch
         schema:
-          type: string
-        required: true
-      - in: query
-        name: git_branch
-        schema:
-          title: Git Branch
           type: string
         description: Git branch name of the tree
         required: true
       - in: query
-        name: git_url
-        schema:
-          title: Git Url
-          type: string
-        description: Git repository URL of the tree
-        required: true
-      - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin of the tree
-        required: true
       - in: path
         name: tree_name
         schema:
           type: string
+        description: Name of the tree
         required: true
       tags:
       - tree
@@ -1424,37 +1415,26 @@ paths:
         name: commit_hash
         schema:
           type: string
+        description: Commit hash of the tree
         required: true
       - in: path
         name: git_branch
         schema:
-          type: string
-        required: true
-      - in: query
-        name: git_branch
-        schema:
-          title: Git Branch
           type: string
         description: Git branch name of the tree
         required: true
       - in: query
-        name: git_url
-        schema:
-          title: Git Url
-          type: string
-        description: Git repository URL of the tree
-        required: true
-      - in: query
         name: origin
         schema:
+          default: maestro
           title: Origin
           type: string
         description: Origin of the tree
-        required: true
       - in: path
         name: tree_name
         schema:
           type: string
+        description: Name of the tree
         required: true
       tags:
       - tree


### PR DESCRIPTION
## Description
This PR refactors the `/tree` endpoints to use dedicated views for each specific route, replacing the previously shared view logic.
Previously, multiple `/tree` endpoints shared the same view, which led to generic and inconsistent parameter handling. Some parameters were required in certain contexts but not in others, which complicated both logic and documentation.

## Changes
- [x] Created a dedicated view for each endpoint;
- [x] Defined route-specific `Query` and `Path` parameters
- [x] Updated schema to reflect required/optional parameters properly

## How to test
1. Explore the /tree/... endpoints and verify that:
    1.1. Parameters are clearly defined and validated
    1.2. Required fields are marked correctly
    1.3. Descriptions are present and accurate
1. Make API requests to different `/tree` endpoints to confirm they work independently and return the expected data.
1. Navigate through the website and check if no errors are returned in the back-end.

Closes #1317