### PR TITLE
Feat: Add env var to switch to new db

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/..."
 docker compose up --build
 ```
 
-> Last Tip: You can set the env Debug=True in the docker-compose.yml file if you want to get a better understanding of what is happening.
+> [Note] If you are going to run using only a dump of the database, the DB_DEFAULT_NAME should be `dashboard` and the `DB_DEFAULT_USER` and `DB_DEFAULT_PASSWORD` should be `admin` (for now).
+> After you define those values, also set the env var `USE_DASHBOARD_DB` to True, setting the local database as the default one.
+> You can also skip the cloud-proxy on such case.
 
 
 ## Deploying to production

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -193,43 +193,62 @@ BACKEND_VOLUME_DIR = get_json_env_var("BACKEND_VOLUME_DIR", "volume_data")
 
 DATABASE_ROUTERS = ["kernelCI_app.routers.databaseRouter.DatabaseRouter"]
 
-DATABASES = {
-    "default": get_json_env_var(
-        "DB_DEFAULT",
-        {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": "kernelci",
-            "USER": "kernelci",
-            "PASSWORD": "kernelci-db-password",
-            "HOST": "127.0.0.1",
-            "OPTIONS": {
-                "connect_timeout": 5,
-            },
-        },
-    ),
-    "dashboard_db": {
+# Database definition configurations
+kcidb_config = get_json_env_var(
+    "DB_DEFAULT",
+    {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "dashboard",
-        "USER": get_json_env_var("DASH_DB_USER", "dev"),
-        "PASSWORD": get_json_env_var("DASH_DB_PASSWORD", "dev"),
-        "HOST": get_json_env_var("DASH_DB_HOST", "127.0.0.1"),
-        "PORT": get_json_env_var("DASH_DB_PORT", 5434),
+        "NAME": "kernelci",
+        "USER": "kernelci",
+        "PASSWORD": "kernelci-db-password",
+        "HOST": "127.0.0.1",
         "OPTIONS": {
             "connect_timeout": 5,
         },
     },
-    "cache": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BACKEND_VOLUME_DIR, "cache.sqlite3"),
-    },
-    "notifications": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BACKEND_VOLUME_DIR, "notifications.sqlite3"),
+)
+
+dashboard_db_config = {
+    "ENGINE": "django.db.backends.postgresql",
+    "NAME": "dashboard",
+    "USER": get_json_env_var("DASH_DB_USER", "dev"),
+    "PASSWORD": get_json_env_var("DASH_DB_PASSWORD", "dev"),
+    "HOST": get_json_env_var("DASH_DB_HOST", "127.0.0.1"),
+    "PORT": get_json_env_var("DASH_DB_PORT", 5434),
+    "OPTIONS": {
+        "connect_timeout": 5,
     },
 }
 
+# Common databases
+cache_db_config = {
+    "ENGINE": "django.db.backends.sqlite3",
+    "NAME": os.path.join(BACKEND_VOLUME_DIR, "cache.sqlite3"),
+}
+
+notifications_db_config = {
+    "ENGINE": "django.db.backends.sqlite3",
+    "NAME": os.path.join(BACKEND_VOLUME_DIR, "notifications.sqlite3"),
+}
+
+USE_DASHBOARD_DB = os.environ.get("USE_DASHBOARD_DB", False)
+if is_boolean_or_string_true(USE_DASHBOARD_DB):
+    DATABASES = {
+        "default": dashboard_db_config,
+        "kcidb": kcidb_config,
+        "cache": cache_db_config,
+        "notifications": notifications_db_config,
+    }
+else:
+    DATABASES = {
+        "default": kcidb_config,
+        "dashboard_db": dashboard_db_config,
+        "cache": cache_db_config,
+        "notifications": notifications_db_config,
+    }
+
 if DEBUG:
-    print("DEBUG: DEFAULT DATABASE:", DATABASES)
+    print("DEBUG: DATABASES:", DATABASES)
 
 
 REDIS_HOST = get_json_env_var("REDIS_HOST", "127.0.0.1")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
             - DASH_DB_PASSWORD=${DASH_DB_PASSWORD:-admin}
             - DASH_DB_HOST=dashboard_db
             - DASH_DB_PORT=${DASH_DB_PORT:-5432}
+            - USE_DASHBOARD_DB=${USE_DASHBOARD_DB:-False}
 
     dashboard:
         build: ./dashboard


### PR DESCRIPTION
## Changes
- Adds an environment variable to quick switch between using kcidb and using the new dashboard_db
- Updates de `update_db` management command to make use of this new variable
- Adds a 0-results fallback in the select methods of `update_db` so that they don't try to make the query when they don't need to

## How to test
If you are running in docker, simply start the dashboard without the `USE_NEW_DB` env var set, check that it is using kcidb, then set it to True in the .env and restart the dashboard; it should now use the local database.
If you are running locally, set the `DASH_DB_` variables as they appear in the backend service of the docker compose, then also try out the `USE_NEW_DB` variable.
Also check if the `update_db` command still works on both scenarios

