### PR TITLE
Feat: add min/max age to tree-report

### DIFF
--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -14,6 +14,10 @@ class ClientStrings:
     TREE_NO_RESULTS = "No results available for this tree/branch/commit"
     TREE_TESTS_NO_RESULTS = "No tests available for this tree/branch/commit"
     TREE_COMMITS_HISTORY_NOT_FOUND = "History of tree commits not found"
+    TREE_NOT_FOUND_IN_INTERVAL = "Tree not found in the given interval"
+    TREE_REPORT_MIN_MAX_AGE = (
+        "Minimum age can't be greater than or equal to the maximum age"
+    )
     TEST_STATUS_HISTORY_NOT_FOUND = "Test status history not found"
     TEST_ISSUES_NOT_FOUND = "No issues were found for this test"
     TEST_NOT_FOUND = "Test not found"
@@ -139,3 +143,7 @@ class DocStrings:
     TREE_REPORT_GROUP_SIZE_DESCRIPTION = (
         "Maximum number of entries to be retrieved in a test history."
     )
+    TREE_REPORT_MAX_AGE = (
+        "Maximum age for the queried checkout and related tests in hours"
+    )
+    TREE_REPORT_MIN_AGE = "Minimum age of the queried checkout in hours"

--- a/backend/kernelCI_app/typeModels/treeReport.py
+++ b/backend/kernelCI_app/typeModels/treeReport.py
@@ -11,6 +11,9 @@ from kernelCI_app.typeModels.treeListing import TestStatusCount
 
 DEFAULT_PATH_SEARCH = ["%"]
 DEFAULT_GROUP_SIZE = 3
+DEFAULT_MAX_AGE_HOURS = 24
+DEFAULT_MIN_AGE_HOURS = 0
+LIMIT_MAX_AGE_HOURS = 720  # 30 days
 
 
 class TreeReportQueryParameters(BaseModel):
@@ -46,6 +49,25 @@ class TreeReportQueryParameters(BaseModel):
             description=DocStrings.TREE_REPORT_GROUP_SIZE_DESCRIPTION,
         ),
         make_default_validator(DEFAULT_GROUP_SIZE),
+    ]
+    min_age_in_hours: Annotated[
+        int,
+        Field(
+            default=DEFAULT_MIN_AGE_HOURS,
+            gte=0,
+            description=DocStrings.TREE_REPORT_MIN_AGE,
+        ),
+        make_default_validator(DEFAULT_MIN_AGE_HOURS),
+    ]
+    max_age_in_hours: Annotated[
+        int,
+        Field(
+            default=DEFAULT_MAX_AGE_HOURS,
+            gt=0,
+            le=LIMIT_MAX_AGE_HOURS,
+            description=DocStrings.TREE_REPORT_MAX_AGE,
+        ),
+        make_default_validator(DEFAULT_MAX_AGE_HOURS),
     ]
 
 


### PR DESCRIPTION
## Changes
- Exposed time limit to the tree report endpoint queries in the form of min and max age in hours. The limit for max age is 720 hours (30 days) in order to avoid responses way too long.
- Small changes to the returned strings

## How to test
Go to the [swagger ui](http://localhost:8000/api/schema/swagger-ui/#/tree-report/tree_report_retrieve) (or make requests by hand) and fetch the tree report endpoint for a tree in a certain period.

Closes #1356