### PR TITLE
notifications: add option to set In-Reply-To header

### DIFF
--- a/backend/kernelCI_app/helpers/email.py
+++ b/backend/kernelCI_app/helpers/email.py
@@ -14,7 +14,9 @@ def smtp_setup_connection():
     return get_connection()
 
 
-def smtp_send_email(connection, sender_email, to, subject, message_text, cc, reply_to):
+def smtp_send_email(
+    connection, sender_email, to, subject, message_text, cc, reply_to, in_reply_to=None
+):
     """Send an email using Django's SMTP backend.
 
     Args:
@@ -25,6 +27,7 @@ def smtp_send_email(connection, sender_email, to, subject, message_text, cc, rep
         message_text: Email body content
         cc: CC recipients
         reply_to: Reply-to address
+        in_reply_to: Message ID to set in In-Reply-To header (optional)
 
     Returns:
         Message ID of the sent email
@@ -48,6 +51,9 @@ def smtp_send_email(connection, sender_email, to, subject, message_text, cc, rep
         # Generate a unique message ID for tracking
         message_id = make_msgid()
         email.extra_headers["Message-ID"] = message_id
+
+        if in_reply_to:
+            email.extra_headers["In-Reply-To"] = in_reply_to
 
         # Send the email
         result = email.send()

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -144,7 +144,14 @@ def send_email_report(
     print(f"sending {subject}.")
 
     return smtp_send_email(
-        service, sender_email, to, subject, message_text, cc, reply_to
+        service,
+        sender_email,
+        to,
+        subject,
+        message_text,
+        cc,
+        reply_to,
+        email_args.in_reply_to,
     )
 
 
@@ -649,6 +656,11 @@ class Command(BaseCommand):
         parser.add_argument("--to", type=str, help="Recipient To: of the email")
         parser.add_argument("--cc", type=str, help="Recipient CC: of the email")
         parser.add_argument(
+            "--in-reply-to",
+            type=str,
+            help="Message ID to reply to (sets In-Reply-To header)",
+        )
+        parser.add_argument(
             "--add-mailing-lists",
             action="store_true",
             help="Add community mailing lists to recipients (See docs).",
@@ -729,6 +741,7 @@ class Command(BaseCommand):
         email_args.yes = options.get("yes", False)
         email_args.to = options.get("to")
         email_args.cc = options.get("cc")
+        email_args.in_reply_to = options.get("in_reply_to")
         email_args.ignore_recipients = options.get("ignore_recipients", False)
         email_args.add_mailing_lists = options.get("add_mailing_lists", False)
         email_args.regression_report = False


### PR DESCRIPTION
Sometimes we want our test report to land on a specific mail thread, so add --in-reply-to to configure that.