### PR TITLE
Feat: sort summary cards by fail count

### DIFF
--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -412,6 +412,7 @@ def handle_build_summary(
             and compiler not in builds_summary.architectures.get(arch).compilers
         ):
             builds_summary.architectures[arch].compilers.append(compiler)
+            builds_summary.architectures[arch].compilers.sort()
 
     if origin := build.origin:
         build_origin_summary = builds_summary.origins.get(origin)

--- a/backend/kernelCI_app/viewCommon.py
+++ b/backend/kernelCI_app/viewCommon.py
@@ -31,6 +31,7 @@ def create_details_build_summary(builds: list[BuildHistoryItem]) -> BaseBuildSum
             compiler = build.compiler
             if compiler and compiler not in status.compilers:
                 status.compilers.append(compiler)
+            status.compilers.sort()
 
         if origin := build.origin:
             status = origin_summ.setdefault(origin, StatusCount())

--- a/dashboard/src/components/Cards/HardwareTested.tsx
+++ b/dashboard/src/components/Cards/HardwareTested.tsx
@@ -1,4 +1,4 @@
-import { memo, type JSX } from 'react';
+import { memo, useMemo, type JSX } from 'react';
 
 import type { IBaseCard } from '@/components/Cards/BaseCard';
 import BaseCard from '@/components/Cards/BaseCard';
@@ -24,13 +24,26 @@ const HardwareTested = ({
   title,
   diffFilter,
 }: IHardwareTested): JSX.Element => {
+  const sortedEnvironmentCompatibleNames = useMemo(() => {
+    return Object.keys(environmentCompatible).sort((a, b) => {
+      const failA = environmentCompatible[a].FAIL ?? 0;
+      const failB = environmentCompatible[b].FAIL ?? 0;
+
+      if (failB !== failA) {
+        return failB - failA;
+      }
+
+      return a.localeCompare(b);
+    });
+  }, [environmentCompatible]);
+
   return (
     <BaseCard
       title={title}
       content={
         <ScrollArea className="h-[350px]">
           <DumbListingContent>
-            {Object.keys(environmentCompatible).map(hardwareTestedName => {
+            {sortedEnvironmentCompatibleNames.map(hardwareTestedName => {
               const { DONE, FAIL, ERROR, MISS, PASS, SKIP, NULL } =
                 environmentCompatible[hardwareTestedName];
 

--- a/dashboard/src/components/Tabs/Builds/BuildCards.tsx
+++ b/dashboard/src/components/Tabs/Builds/BuildCards.tsx
@@ -22,6 +22,21 @@ const ErrorsSummaryBuild = ({
   toggleFilterBySection,
   diffFilter,
 }: IErrorsSummaryBuild): JSX.Element => {
+  const sortedSummaryBody = useMemo(
+    () =>
+      summaryBody.sort((a, b) => {
+        const errorsA = a.arch.errors ?? 0;
+        const errorsB = b.arch.errors ?? 0;
+
+        if (errorsB !== errorsA) {
+          return errorsB - errorsA;
+        }
+
+        return a.arch.text.localeCompare(b.arch.text);
+      }),
+    [summaryBody],
+  );
+
   const summaryHeaders = useMemo(
     () => [
       <FormattedMessage key="global.arch" id="global.arch" />,
@@ -35,7 +50,7 @@ const ErrorsSummaryBuild = ({
       title={<FormattedMessage id="global.summary" />}
       content={
         <DumbSummary summaryHeaders={summaryHeaders}>
-          {summaryBody?.map(row => {
+          {sortedSummaryBody?.map(row => {
             return (
               <MemoizedSummaryItem
                 key={row.arch.text}

--- a/dashboard/src/components/Tabs/Builds/ConfigsCard.tsx
+++ b/dashboard/src/components/Tabs/Builds/ConfigsCard.tsx
@@ -21,10 +21,25 @@ interface IConfigsCard {
 }
 
 const ConfigsCard = ({ configs, diffFilter }: IConfigsCard): JSX.Element => {
+  const sortedConfigs = useMemo(
+    () =>
+      configs.sort((a, b) => {
+        const errorsA = a.errors ?? 0;
+        const errorsB = b.errors ?? 0;
+
+        if (errorsB !== errorsA) {
+          return errorsB - errorsA;
+        }
+
+        return a.text.localeCompare(b.text);
+      }),
+    [configs],
+  );
+
   const content = useMemo(() => {
     return (
       <DumbListingContent>
-        {configs.map((item, i) => (
+        {sortedConfigs.map((item, i) => (
           <FilterLink
             key={i}
             filterSection="configs"
@@ -45,7 +60,7 @@ const ConfigsCard = ({ configs, diffFilter }: IConfigsCard): JSX.Element => {
         ))}
       </DumbListingContent>
     );
-  }, [configs, diffFilter]);
+  }, [sortedConfigs, diffFilter]);
 
   return (
     <BaseCard

--- a/dashboard/src/components/Tabs/Tests/ConfigsList.tsx
+++ b/dashboard/src/components/Tabs/Tests/ConfigsList.tsx
@@ -1,4 +1,4 @@
-import { memo, type JSX } from 'react';
+import { memo, useMemo, type JSX } from 'react';
 
 import type { IBaseCard } from '@/components/Cards/BaseCard';
 import BaseCard from '@/components/Cards/BaseCard';
@@ -20,12 +20,27 @@ const ConfigsList = ({
   title,
   diffFilter,
 }: IConfigList): JSX.Element => {
+  const sortedConfigStatusCounts = useMemo(
+    () =>
+      Object.keys(configStatusCounts).sort((a, b) => {
+        const failA = configStatusCounts[a].FAIL ?? 0;
+        const failB = configStatusCounts[b].FAIL ?? 0;
+
+        if (failB !== failA) {
+          return failB - failA;
+        }
+
+        return a.localeCompare(b);
+      }),
+    [configStatusCounts],
+  );
+
   return (
     <BaseCard
       title={title}
       content={
         <DumbListingContent>
-          {Object.keys(configStatusCounts).map(configName => {
+          {sortedConfigStatusCounts.map(configName => {
             const { DONE, FAIL, ERROR, MISS, PASS, SKIP, NULL } =
               configStatusCounts[configName];
             return (

--- a/dashboard/src/components/Tabs/Tests/ErrorsSummary.tsx
+++ b/dashboard/src/components/Tabs/Tests/ErrorsSummary.tsx
@@ -1,4 +1,4 @@
-import { memo, type JSX } from 'react';
+import { memo, useMemo, type JSX } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import type { IBaseCard } from '@/components/Cards/BaseCard';
@@ -25,12 +25,27 @@ const ErrorsSummary = ({
   title,
   diffFilter,
 }: IErrorsSummary): JSX.Element => {
+  const sortedArchCompilerErrors = useMemo(
+    () =>
+      archCompilerErrors.sort((a, b) => {
+        const failA = a.status.FAIL ?? 0;
+        const failB = b.status.FAIL ?? 0;
+
+        if (failB !== failA) {
+          return failB - failA;
+        }
+
+        return a.arch.localeCompare(b.arch);
+      }),
+    [archCompilerErrors],
+  );
+
   return (
     <BaseCard
       title={title}
       content={
         <DumbSummary summaryHeaders={summaryHeaders}>
-          {archCompilerErrors.map(e => {
+          {sortedArchCompilerErrors.map(e => {
             const statusCounts = e.status;
             const currentCompilers = [e.compiler];
             return (


### PR DESCRIPTION
# Changes

- On the FE, sort the tree and hardware details cards (hardware, config, and architecture) by two conditions:
  - Fail count
  - Alphabetically by name
- On the BE, sort the compilers from the architectures for tree and hardware build details.

# How to test

- Navigate to the tree details page and for the build, boots, and tests tabs check the following cards:
  - Architecture cards should be ordered by fail count and alphabetically if the count is the same. If there are multiple compilers, they should also be ordered alphabetically
  - Configs and hardware cards should be ordered by fail count and alphabetically if the count is the same
- Navigate to the hardware details page and check if the same conditions apply
- Make a request to the `/tree/.../summary` and `/hardware/.../summary` endpoints and check if the compilers are alphabetically sorted