### PR TITLE
Refactor: correct issue extras response

### DIFF
--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -36,7 +36,9 @@ class ClientStrings:
     NO_ISSUE_FOUND = "No issues found"
     INVALID_JSON_BODY = "Invalid body, request body must be a valid json string"
     ISSUE_EMPTY_LIST = "Invalid body, the issue list must not be empty"
-    ISSUE_NO_EXTRA_DETAILS = "No extra details found"
+    ISSUE_NO_EXTRA_DETAILS = (
+        "No extra details found. Issue id has no incident or doesn't exist."
+    )
     ISSUE_TESTS_NOT_FOUND = "No tests found for this issue"
     ISSUE_BUILDS_NOT_FOUND = "No builds found for this issue"
     NO_HARDWARE_FOUND = "No hardware found"

--- a/backend/kernelCI_app/helpers/issueExtras.py
+++ b/backend/kernelCI_app/helpers/issueExtras.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
-from typing import Dict, List, Set, Tuple
+from typing import List, Tuple
 
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.queries.issues import get_issue_first_seen_data, get_issue_trees_data
 from kernelCI_app.typeModels.issues import (
+    ExtraIssuesData,
     IssueWithExtraInfo,
     ProcessedExtraDetailedIssues,
     TreeSetItem,
@@ -43,44 +44,39 @@ def assign_issue_first_seen(
     """
     Assigns the first seen data to the processed_issues_table by querying with the issue_key_list.
     """
-    issue_id_list: List[str] = []
-    versions_per_issue: Dict[str, Set[int]] = defaultdict(set)
-    for issue_key in issue_key_list:
-        issue_id, issue_version = issue_key
-        issue_id_list.append(issue_id)
+    issue_id_set: set[str] = set()
+    versions_per_issue: dict[str, set[int]] = defaultdict(set)
+
+    for issue_id, issue_version in issue_key_list:
+        issue_id_set.add(issue_id)
         versions_per_issue[issue_id].add(issue_version)
 
-    incident_records = get_issue_first_seen_data(issue_id_list=issue_id_list)
+    incident_records = get_issue_first_seen_data(issue_id_list=list(issue_id_set))
 
     for record in incident_records:
         record_issue_id = record["issue_id"]
         first_seen = record["first_seen"]
-        first_git_commit_hash = record["git_commit_hash"]
-        first_git_repository_url = record["git_repository_url"]
-        first_git_repository_branch = record["git_repository_branch"]
-        first_git_commit_name = record["git_commit_name"]
-        first_tree_name = record["tree_name"]
 
-        processed_issue_from_id = processed_issues_table.get(record_issue_id)
-        if processed_issue_from_id is None:
-            processed_issues_table[record_issue_id] = {}
-            processed_issue_from_id = processed_issues_table[record_issue_id]
-            processed_issue_from_id["first_incident"] = FirstIncident(
-                first_seen=first_seen,
-                git_commit_hash=first_git_commit_hash,
-                git_repository_url=first_git_repository_url,
-                git_repository_branch=first_git_repository_branch,
-                git_commit_name=first_git_commit_name,
-                tree_name=first_tree_name,
-            )
+        processed_issue_from_id = processed_issues_table.setdefault(
+            record_issue_id,
+            ExtraIssuesData(
+                first_incident=FirstIncident(
+                    first_seen=first_seen,
+                    git_commit_hash=record["git_commit_hash"],
+                    git_repository_url=record["git_repository_url"],
+                    git_repository_branch=record["git_repository_branch"],
+                    git_commit_name=record["git_commit_name"],
+                    tree_name=record["tree_name"],
+                    issue_version=record["issue_version"],
+                ),
+                versions={},
+            ),
+        )
 
+        # Initialize the versions table with null because that version may or may not exist.
+        # If an issue_version exists, the trees can be assigned with `assign_issue_trees`
         for version in versions_per_issue[record_issue_id]:
-            processed_issue_from_version = processed_issue_from_id.get(version)
-            processed_issue_from_id["versions"] = {}
-            if processed_issue_from_version is None:
-                processed_issue_from_id["versions"][version] = IssueWithExtraInfo(
-                    id=record_issue_id, version=version, first_seen=first_seen
-                )
+            processed_issue_from_id.versions.setdefault(version, None)
 
 
 def assign_issue_trees(
@@ -91,27 +87,39 @@ def assign_issue_trees(
     trees_records = get_issue_trees_data(issue_key_list=issue_key_list)
 
     for record in trees_records:
-        issue_id = record.issue_id
-        issue_version = record.issue_version
-        git_repository_url = record.git_repository_url
-        git_repository_branch = record.git_repository_branch
+        issue_id = record["issue_id"]
+        issue_version = record["issue_version"]
+        git_repository_url = record["git_repository_url"]
+        git_repository_branch = record["git_repository_branch"]
+        tree_name = record["tree_name"]
 
         processed_issue_from_id = processed_issues_table.get(issue_id)
         if processed_issue_from_id is None:
-            log_message("Got tree for issue id that is not on the list")
-            continue
-
-        current_detailed_issue = processed_issue_from_id["versions"].get(issue_version)
-        if current_detailed_issue is None:
-            log_message("Got tree for issue version that is not on the list")
-            continue
-
-        current_detailed_issue.trees.append(
-            TreeSetItem(
-                tree_name=record.tree_name,
-                git_repository_branch=git_repository_branch,
+            # While in `assign_issue_first_seen` we don't care about the difference
+            # "issue exists" x "issue has no incident", here we do receive a row
+            # even if an issue had no incidents (in order to make that difference)
+            # In such case we can ignore the record since we won't return this data
+            log_message(
+                f"Got record for issue without incident {issue_id} {issue_version}"
             )
-        )
+            continue
+
+        issue_versions_map = processed_issue_from_id.versions
+
+        current_detailed_issue = issue_versions_map.get(issue_version)
+        if current_detailed_issue is None:
+            issue_versions_map[issue_version] = IssueWithExtraInfo(
+                id=issue_id, version=issue_version
+            )
+            current_detailed_issue = issue_versions_map[issue_version]
+
+        if tree_name is not None and git_repository_branch is not None:
+            current_detailed_issue.trees.append(
+                TreeSetItem(
+                    tree_name=record["tree_name"],
+                    git_repository_branch=git_repository_branch,
+                )
+            )
 
         match (git_repository_url, git_repository_branch):
             case (TagUrls.MAINLINE_URL, "master"):

--- a/backend/kernelCI_app/typeModels/issues.py
+++ b/backend/kernelCI_app/typeModels/issues.py
@@ -1,9 +1,10 @@
-from typing import Dict, List, Literal, Optional, Set, Tuple, Annotated
+from typing import Literal, Optional, Annotated
 from pydantic import BaseModel, Field
 
 from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.databases import (
+    Issue__Version,
     Timestamp,
     Checkout__GitCommitHash,
     Checkout__GitRepositoryUrl,
@@ -28,7 +29,7 @@ class Issue(IssueKeys):
     incidents_info: StatusCount
 
 
-type IssueDict = Dict[Tuple[str, int], Issue]
+type IssueDict = dict[tuple[str, int], Issue]
 
 
 type PossibleIssueTags = Literal["mainline", "stable", "linux-next"]
@@ -40,12 +41,12 @@ class TreeSetItem(BaseModel):
 
 
 class IssueWithExtraInfo(IssueKeys):
-    trees: Optional[List[TreeSetItem]] = []
-    tags: Optional[Set[PossibleIssueTags]] = set()
+    trees: Optional[list[TreeSetItem]] = []
+    tags: Optional[set[PossibleIssueTags]] = set()
 
 
 class IssueExtraDetailsRequest(BaseModel):
-    issues: List[Tuple[str, int]] = Field(
+    issues: list[tuple[str, int]] = Field(
         description=DocStrings.ISSUE_EXTRA_ID_LIST_DESCRIPTION
     )
 
@@ -57,15 +58,16 @@ class FirstIncident(BaseModel):
     git_repository_branch: Optional[Checkout__GitRepositoryBranch]
     git_commit_name: Optional[Checkout__GitCommitName]
     tree_name: Optional[Checkout__TreeName]
+    issue_version: Optional[Issue__Version]
 
 
 class ExtraIssuesData(BaseModel):
     first_incident: FirstIncident
-    versions: Dict[int, IssueWithExtraInfo]
+    versions: dict[int, Optional[IssueWithExtraInfo]]
 
 
 type ProcessedExtraDetailedIssues = Annotated[
-    Dict[str, ExtraIssuesData],
+    dict[str, ExtraIssuesData],
     Field(
         description="Extra info about issues, grouped by ID when it's version-agnostic",
         examples=[

--- a/backend/kernelCI_app/views/issueExtrasView.py
+++ b/backend/kernelCI_app/views/issueExtrasView.py
@@ -35,6 +35,19 @@ class IssueExtraDetails(APIView):
         methods=["POST"],
     )
     def post(self, request) -> Response:
+        """
+        Returns the information about the first incident and the trees where a list of issues appeared.
+        Some tags are also added in case the issue appeared on specific trees.
+
+        If an issue id exists and has incidents, the first incident will be returned
+        considering the issues' first version
+
+        If an issue id doesn't exist or had no incidents, it won't be present in the returned list.
+
+        If an issue id exists and has incidents but the search version doesn't exist,
+        then the version of that issue will be marked as `null`.
+        If the version exists but had no incidents, it will simply have an empty list of trees.
+        """
         try:
             body = json.loads(request.body)
             valid_body = IssueExtraDetailsRequest(**body)

--- a/backend/kernelCI_app/views/issueView.py
+++ b/backend/kernelCI_app/views/issueView.py
@@ -82,7 +82,7 @@ class IssueView(APIView):
         issues_without_trees = set()
         processed_extras_with_trees = {}
         for issue_id, issue_extras_data in self.processed_extra_issue_details.items():
-            for info in issue_extras_data["versions"].values():
+            for info in issue_extras_data.versions.values():
                 if not info.trees:
                     issues_without_trees.add(issue_id)
                 else:
@@ -101,7 +101,7 @@ class IssueView(APIView):
             issue_extras_id,
             issue_extras_data,
         ) in self.processed_extra_issue_details.items():
-            self.first_incidents[issue_extras_id] = issue_extras_data["first_incident"]
+            self.first_incidents[issue_extras_id] = issue_extras_data.first_incident
 
     @extend_schema(
         parameters=[IssueListingQueryParameters],

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -454,6 +454,18 @@ paths:
   /api/issue/extras/:
     post:
       operationId: issue_extras_create
+      description: |-
+        Returns the information about the first incident and the trees where a list of issues appeared.
+        Some tags are also added in case the issue appeared on specific trees.
+
+        If an issue id exists and has incidents, the first incident will be returned
+        considering the issues' first version
+
+        If an issue id doesn't exist or had no incidents, it won't be present in the returned list.
+
+        If an issue id exists and has incidents but the search version doesn't exist,
+        then the version of that issue will be marked as `null`.
+        If the version exists but had no incidents, it will simply have an empty list of trees.
       tags:
       - issue
       requestBody:
@@ -911,6 +923,23 @@ paths:
           title: Group Size
           type: integer
         description: Maximum number of entries to be retrieved in a test history.
+      - in: query
+        name: max_age_in_hours
+        schema:
+          default: 24
+          exclusiveMinimum: 0
+          maximum: 720
+          title: Max Age In Hours
+          type: integer
+        description: Maximum age for the queried checkout and related tests in hours
+      - in: query
+        name: min_age_in_hours
+        schema:
+          default: 0
+          gte: 0
+          title: Min Age In Hours
+          type: integer
+        description: Minimum age of the queried checkout in hours
       - in: query
         name: origin
         schema:
@@ -2043,7 +2072,9 @@ components:
           $ref: '#/components/schemas/FirstIncident'
         versions:
           additionalProperties:
-            $ref: '#/components/schemas/IssueWithExtraInfo'
+            anyOf:
+            - $ref: '#/components/schemas/IssueWithExtraInfo'
+            - type: 'null'
           title: Versions
           type: object
       required:
@@ -2075,6 +2106,10 @@ components:
           anyOf:
           - $ref: '#/components/schemas/Checkout__TreeName'
           - type: 'null'
+        issue_version:
+          anyOf:
+          - $ref: '#/components/schemas/Issue__Version'
+          - type: 'null'
       required:
       - first_seen
       - git_commit_hash
@@ -2082,6 +2117,7 @@ components:
       - git_repository_branch
       - git_commit_name
       - tree_name
+      - issue_version
       title: FirstIncident
       type: object
     GlobalFilters:


### PR DESCRIPTION
## Changes
- Adds issue version to the `first_incident` field
- Fixes problem where adding two issue versions with the same issue id would only return the data for the first one
- Altered the response of the endpoint, if an issue version exists but has no incidents, it will return an object with 0 trees; if it doesn't exist, it will return as null. More comments were added in the code.

## How to test
Fetch some data from the issue_extras endpoint (I recommend using the [localhost swagger ui](http://localhost:8000/api/schema/swagger-ui/#/issue/issue_extras_create)) and test with issues that exist, that don't exist, that have 0 and more incidents, and other cases.
Also test the dashboard for the issue listing and issue details pages, everything should still be working as before.

Closes #1335 