### PR TITLE
feat(settings): add CORS_ALLOWED_ORIGINS as env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ If you are going to use a database user other than `kernelci`, set it to `DB_DEF
 export DB_DEFAULT_USER=<user>
 ```
 
+If you are setting up instance different than production KernelCI dashboard, you need to define CORS_ALLOWED_ORIGINS.
+
+docker-compose example:
+```yaml
+services:
+  backend:
+    environment:
+      CORS_ALLOWED_ORIGINS: ["https://d.kernelci.org","https://dashboard.kernelci.org"]
+```
+or .env file example:
+```
+CORS_ALLOWED_ORIGINS=["https://d.kernelci.org","https://dashboard.kernelci.org"]
+```
+
 > For other optional envs, check the [backend README](backend/README.md).
 
 Startup the services:

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -307,7 +307,13 @@ MIGRATION_MODULES = {
     "kernelCI_cache": "kernelCI_cache.migrations",
 }
 
-CORS_ALLOW_ALL_ORIGINS = False
+CORS_ALLOWED_ORIGINS = get_json_env_var(
+    "CORS_ALLOWED_ORIGINS",
+    [],
+)
+CORS_ALLOW_ALL_ORIGINS = is_boolean_or_string_true(
+    os.environ.get("CORS_ALLOW_ALL_ORIGINS", False)
+)
 
 CACHE_TIMEOUT = int(get_json_env_var("CACHE_TIMEOUT", "180"))
 


### PR DESCRIPTION
Make CORS_ALLOWED_ORIGINS configurable via environment variable to allow for setting up instances of the dashboard for different domains.

CORS_ALLOW_ALL_ORIGINS is now also configurable via an environment variable, defaulting to 'False'.

Updated README.md with instructions on how to use the new env var.