### PR TITLE
Fix: correct endpoint timeout

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -49,5 +49,5 @@ VOLUME ${BACKEND_VOLUME_DIR}
 # gunicorn is added here but is run at the end of the entrypoint.
 # This was done here such that we can run a custom command
 # in the backend container without using gunicorn
-CMD ["gunicorn", "kernelCI.wsgi:application", "--workers=5", "--forwarded-allow-ips=*", "--bind=0.0.0.0:8000", "--timeout=240"]
+CMD ["gunicorn", "kernelCI.wsgi:application", "--workers=5", "--forwarded-allow-ips=*", "--bind=0.0.0.0:8000", "--timeout=250"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,2 +1,4 @@
+# Use port 8000 to go directly to the backend/gunicorn.
+# Use port 80 to go through Nginx (proxy service on Docker)
 VITE_API_BASE_URL=http://localhost:8000
 VITE_FEATURE_FLAG_SHOW_DEV=false

--- a/proxy/etc/nginx/templates/default.conf.template
+++ b/proxy/etc/nginx/templates/default.conf.template
@@ -1,8 +1,12 @@
 server {
     location /api {
         proxy_pass ${PROXY_TARGET};
+        proxy_connect_timeout 240s;
+        proxy_read_timeout 240s;
+        proxy_send_timeout 240s;
+        send_timeout 240s;
     }
-    location /{
+    location / {
         root /data/static;
         try_files $uri /index.html;
     }


### PR DESCRIPTION
## Description
The Nginx proxy had the default timeout while Gunicorn had the increased timeout as we wanted. The problem is that for some endpoints (such as tree-report), users were receiving a timeout way before intended since the Nginx was the one with trouble.

This PR proposes to not only increase the timeout of Nginx, but also make it timeout _before_ Gunicorn (because Gunicorn returns error code 500 while Nginx returns 504, which is more descriptive).

The frontend was also bypassing Nginx on localhost because of an environment variable. A note was added in order to avoid this confusion.

## Changes
- Increased the timeout in the Nginx config file
- Increased the timeout of Gunicorn to be slightly more than Nginx
- Added note on .env.example for the frontend

## How to test
- Go to a slow endpoint such as tree-report for mainline/master (or mock it with a `time.sleep()`) and wait for it to timeout. Check when was the timeout, allowing you to know if it was Nginx (240s) or Gunicorn (250s).
- Compare with staging (which times out at 60s from Nginx)

Closes #1392