### PR TITLE
Feat: save sent checkout reports and skip recently sent reports

### DIFF
--- a/backend/kernelCI_app/management/commands/helpers/summary.py
+++ b/backend/kernelCI_app/management/commands/helpers/summary.py
@@ -1,5 +1,5 @@
 import os
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from django.conf import settings
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
@@ -11,6 +11,9 @@ type PossibleReportOptions = Literal["ignore_default_recipients"]
 
 type TreeKey = tuple[str, str, str]
 """A tuple (branch, giturl, origin)"""
+
+type ReportConfigs = list[dict[str, Any]]
+"""A list of dictionaries containing the definition/configuration of a report"""
 
 SUMMARY_SIGNUP_FOLDER = "notifications/subscriptions/"
 
@@ -32,7 +35,7 @@ def process_submissions_files(
     base_dir: Optional[str] = None,
     signup_folder: Optional[str] = None,
     summary_origins: Optional[list[str]] = None,
-) -> tuple[set[TreeKey], dict[TreeKey, list[dict]]]:
+) -> tuple[set[TreeKey], dict[TreeKey, ReportConfigs]]:
     """Processes all submission files and returns the set of TreeKey and
     the dict linking each tree to its report props"""
     (base_dir, signup_folder) = _assign_default_folders(
@@ -40,7 +43,7 @@ def process_submissions_files(
     )
 
     tree_key_set: set[TreeKey] = set()
-    tree_prop_map: dict[TreeKey, list[dict]] = {}
+    tree_prop_map: dict[TreeKey, ReportConfigs] = {}
     """Example:
     tree_prop_map[(master, <mainline_url>, maestro)] = [
         {

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -558,7 +558,12 @@ def run_checkout_summary(
 
             if msg_id and email_args.update:
                 mark_checkout_notification_as_sent(
-                    checkout_id=record["checkout_id"], msg_id=msg_id
+                    msg_id=msg_id,
+                    checkout_id=record["checkout_id"],
+                    git_repository_branch=branch,
+                    git_repository_url=giturl,
+                    origin=origin,
+                    path=path,
                 )
 
 

--- a/backend/kernelCI_app/routers/databaseRouter.py
+++ b/backend/kernelCI_app/routers/databaseRouter.py
@@ -15,7 +15,7 @@ class DatabaseRouter:
         if model_name in ["checkoutscache"]:
             return db == "cache"
         if hints.get("run_always", False):
-            return app_label == "kernelci_cache"
+            return app_label == "kernelCI_cache"
         if app_label == "kernelCI_app":
             return db == "dashboard_db" and not settings.USE_DASHBOARD_DB
 

--- a/backend/kernelCI_cache/migrations/0012_add_checkout_report_identification_fields.py
+++ b/backend/kernelCI_cache/migrations/0012_add_checkout_report_identification_fields.py
@@ -1,0 +1,119 @@
+from django.db import connections, migrations, models
+from kernelCI import settings
+
+_TEMP_DEFAULT = "none"
+
+
+def populate_checkout_fields(apps, schema_editor):
+    """
+    Updates checkouts in the NotificationsCheckout table for anyone that has
+    a null branch or git_repository_url using the kcidb data.
+    """
+    # Get checkouts that need updating from notifications database
+    notifications_connection = connections["notifications"]
+    notifications_query = """
+        SELECT
+            id, checkout_id, git_repository_branch, git_repository_url, origin
+        FROM
+            notifications_checkout
+        WHERE
+            git_repository_branch = %(temp_default)s
+            OR git_repository_url = %(temp_default)s
+    """
+    params = {"temp_default": _TEMP_DEFAULT}
+
+    with notifications_connection.cursor() as cursor:
+        cursor.execute(notifications_query, params)
+        checkouts_to_update = cursor.fetchall()
+
+    if not checkouts_to_update:
+        return
+
+    # Queries in kcidb for the missing data
+    kcidb_connection = (
+        connections["kcidb"] if settings.USE_DASHBOARD_DB else connections["default"]
+    )
+
+    checkout_ids = [checkout[1] for checkout in checkouts_to_update]
+    placeholders = ",".join(["%s"] * len(checkout_ids))
+    kcidb_query = f"""
+        SELECT
+            id, git_repository_branch, git_repository_url, origin
+        FROM checkouts
+        WHERE
+            id IN ({placeholders})
+            -- in theory, all checkouts from the notifications table have branch and url not null,
+            -- but this condition is used just to really guarantee that it won't break
+            AND git_repository_branch IS NOT NULL
+            AND git_repository_url IS NOT NULL
+    """
+    kcidb_checkouts_data = {}
+    with kcidb_connection.cursor() as cursor:
+        cursor.execute(kcidb_query, checkout_ids)
+        kcidb_checkouts_data = cursor.fetchall()
+
+    # Updates the notification checkouts with the kcidb data
+    kcidb_checkouts_data_map = {data[0]: data for data in kcidb_checkouts_data}
+    checkouts_for_bulk_update: list[tuple[str, str, str, str]] = []
+    for checkout in checkouts_to_update:
+        notification_id = checkout[0]
+        n_checkout_id = checkout[1]
+        n_branch = checkout[2]
+        n_url = checkout[3]
+        if n_checkout_id in kcidb_checkouts_data_map:
+            data = kcidb_checkouts_data_map[n_checkout_id]
+            n_branch = data[1]
+            n_url = data[2]
+            n_origin = data[3]
+            checkouts_for_bulk_update.append(
+                (notification_id, n_branch, n_url, n_origin)
+            )
+
+    if checkouts_for_bulk_update:
+        with notifications_connection.cursor() as cursor:
+            for checkout in checkouts_for_bulk_update:
+                notification_id = checkout[0]
+                n_branch = checkout[1]
+                n_url = checkout[2]
+                n_origin = checkout[3]
+                cursor.execute(
+                    """
+                    UPDATE notifications_checkout
+                    SET git_repository_branch = %s, git_repository_url = %s, origin = %s
+                    WHERE id = %s
+                    """,
+                    [n_branch, n_url, n_origin, notification_id],
+                )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("kernelCI_cache", "0011_copy_data_from_cache_if_exists"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="notificationscheckout",
+            name="git_repository_branch",
+            field=models.TextField(default=_TEMP_DEFAULT),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="notificationscheckout",
+            name="git_repository_url",
+            field=models.TextField(default=_TEMP_DEFAULT),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="notificationscheckout",
+            name="origin",
+            field=models.TextField(default="maestro", null=True),
+        ),
+        migrations.AddField(
+            model_name="notificationscheckout",
+            name="path",
+            field=models.TextField(null=True),
+        ),
+        migrations.RunPython(populate_checkout_fields, hints={"run_always": True}),
+    ]

--- a/backend/kernelCI_cache/models.py
+++ b/backend/kernelCI_cache/models.py
@@ -1,5 +1,7 @@
 from django.db import models
 
+from kernelCI_app.constants.general import DEFAULT_ORIGIN
+
 
 class CheckoutsCache(models.Model):
     field_timestamp = models.DateTimeField(db_column="_timestamp")
@@ -60,9 +62,11 @@ class CheckoutsCache(models.Model):
 class NotificationsCheckout(models.Model):
     notification_message_id = models.TextField()
     notification_sent = models.DateTimeField()
-    checkout_id = (
-        models.TextField()
-    )  # Not necessarily unique, 1 checkout can have n notifications
+    checkout_id = models.TextField()
+    git_repository_branch = models.TextField()
+    git_repository_url = models.TextField()
+    origin = models.TextField(null=True, default=DEFAULT_ORIGIN)
+    path = models.TextField(null=True)  # A list[str] stored as a json-like string
 
     class Meta:
         db_table = "notifications_checkout"

--- a/backend/kernelCI_cache/queries/notifications.py
+++ b/backend/kernelCI_cache/queries/notifications.py
@@ -6,15 +6,23 @@ from kernelCI_app.helpers.logger import log_message
 
 def mark_checkout_notification_as_sent(
     *,
-    checkout_id: str,
     msg_id: str,
+    checkout_id: str,
+    git_repository_branch: str,
+    git_repository_url: str,
+    origin: str,
+    path: str,
 ) -> bool:
     try:
         timestamp = get_current_timestamp_kcidb_format()
         NotificationsCheckout.objects.using("notifications").create(
-            checkout_id=checkout_id,
             notification_message_id=msg_id,
             notification_sent=timestamp,
+            checkout_id=checkout_id,
+            git_repository_branch=git_repository_branch,
+            git_repository_url=git_repository_url,
+            origin=origin,
+            path=path,
         )
         return True
     except Exception as e:


### PR DESCRIPTION
## Description
Previously we were just saving when a notification was sent, its message id and checkout id. Those fields don't define a report, so we weren't able to discern if a specific report had been sent or not. This knowledge is useful in order to be able to not query for all reports all the time, allowing us to skip heavy reports and only re-send them after some time.

## Changes
- Added more fields to the NotificationCheckouts table in order to identify a unique report
  - Updates old entries with a specific `RunPython` migration piece
- Added check to see which reports where sent in the last 12 hours (possible to change with a global variable)
- Added ability to skip reports that were already sent in that interval, defaulted to true

## How to test
- Run the migration with `poetry run python3 manage.py migrate --database=notifications`
- Run the summary command with `poetry run python3 manage.py notifications --action summary`
- Mock the "mark as sent" by commenting the line with `if msg_id and email_args.update` and let some reports be marked as sent with whatever msg_id
- Run the summary command again, this time you'll see a log saying that some of the reports were skipped due to being already sent recently

Closes #1216 