### PR TITLE
fix(dashboard): Install rsync in Docker image

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -15,6 +15,8 @@ FROM alpine:3.20
 
 VOLUME ["/data/static/"]
 
+RUN apk add --no-cache rsync
+
 COPY --from=builder /dashboard/dist /files
 
 CMD rsync -azvi --checksum --exclude='*.map' /files/ /data/static/


### PR DESCRIPTION
The dashboard container was failing to start because the `rsync` command was not found in the alpine image. This change adds `rsync` to the list of installed packages in the Dockerfile to ensure the container runs correctly.