### PR TITLE
Feat: split ci tests

### DIFF
--- a/.github/actions/setup-backend/action.yaml
+++ b/.github/actions/setup-backend/action.yaml
@@ -1,0 +1,19 @@
+name: Shared setup backend
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install Poetry
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+      shell: bash
+
+    - name: Install dependencies
+      working-directory: ./backend
+      run: poetry install
+      shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,27 +104,15 @@ jobs:
         run: pnpm build
         working-directory: ./dashboard
 
-  build-django:
+  lint-and-unit-test-django:
     if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-
-      - name: Install Poetry
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-
-      - name: Install dependencies
-        run: poetry install
-        working-directory: ./backend
+      - name: Setup Backend
+        uses: ./.github/actions/setup-backend
 
       - name: Lint
         run: poetry run flake8
@@ -133,6 +121,20 @@ jobs:
       - name: Check Format
         run: poetry run black --check .
         working-directory: ./backend
+
+      - name: Run unit tests
+        run: poetry run pytest -m unit
+        working-directory: ./backend
+
+  integration-test-django:
+    if: github.event.pull_request.draft != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Backend
+        uses: ./.github/actions/setup-backend
 
       - name: Configure credentials variables
         run: |
@@ -163,11 +165,11 @@ jobs:
                 break
             fi
             echo "Waiting for backend to be ready... $i"
-            sleep 10
+            sleep 5
           done
 
-      - name: Run tests
-        run: poetry run pytest --run-all
+      - name: Run integration tests
+        run: poetry run pytest -m "integration" --run-all
         working-directory: ./backend
 
       - name: Clean containers
@@ -179,7 +181,8 @@ jobs:
     needs:
       - lint-js
       - build-front
-      - build-django
+      - lint-and-unit-test-django
+      - integration-test-django
     steps:
       - name: Configure staging host authenticity
         run: |

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,4 +1,69 @@
+import tomllib
+from pytest import Item
+import os
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--run-all", action="store_true", default=False, help="run all test cases"
     )
+
+
+def get_test_markers() -> list[str]:
+    try:
+        pyproject_path = os.path.join(os.path.dirname(__file__), "pyproject.toml")
+
+        with open(pyproject_path, "rb") as f:
+            pyproject_data = tomllib.load(f)
+
+        markers: list[str] = (
+            pyproject_data.get("tool", {})
+            .get("pytest", {})
+            .get("ini_options", {})
+            .get("markers", [])
+        )
+
+        marker_names = []
+        for marker in markers:
+            if ":" in marker:
+                marker_name = marker.split(":")[0].strip()
+                marker_names.append(marker_name)
+
+        if not marker_names:
+            raise ValueError("No markers found in pyproject.toml")
+
+        return marker_names
+
+    except FileNotFoundError:
+        raise FileNotFoundError("pyproject.toml not found")
+    except Exception as e:
+        raise e(f"Error reading markers from pyproject.toml: {e}")
+
+
+def pytest_collection_modifyitems(items: list[Item]):
+    test_markers = get_test_markers()
+
+    for item in items:
+        parent_folder = item.path.parent.name.lower()
+
+        matched_markers = [marker for marker in test_markers if marker in parent_folder]
+        match len(matched_markers):
+            case 0:
+                raise Exception(
+                    """Test %s must have a type.
+                    Place the test in a folder whose name contains 'unit' or 'integration'."""
+                    % item.name
+                )
+            case 1:
+                item.add_marker(matched_markers[0])
+            case _:
+                raise Exception(
+                    """Test %s can only be of a single type (one of %s),
+                        but found multiple markers (%s) at folder %s"""
+                    % (
+                        item.name,
+                        test_markers,
+                        matched_markers,
+                        parent_folder,
+                    )
+                )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,6 +36,10 @@ pytest-rerunfailures = "^15.0"
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "kernelCI.settings"
 addopts = "-n 4 --dist loadscope --reruns 4 -x"
+markers = [
+    "unit: marks tests as unit tests (fast, no external dependencies)",
+    "integration: marks tests as integration tests (slow, connects to the database)"
+]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Description
Because the integrations tests and linting+formatting+unit tests were in a single job, we weren't able to identify which of them failed if just one of them did. This occurred specially when we expect the integration tests to fail in PRs from forks, but then we didn't see that the linting and formatting had also failed.

## Changes
- Adds a pytest marker to the tests in order to tell which ones are unit tests (we can then run tests which are simply "not unit", meaning integration tests)
- Adds a composite action to setup the backend
- Splits the `build-django` job into `lint-and-unit-tests-django` and `integration-tests-django`, both using the composite action

## How to test
Check the CI on this PR, and see that it passes


Closes #1402 