### PR TITLE
Fix: tree report group size hint

### DIFF
--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -144,6 +144,7 @@ class DocStrings:
     )
     TREE_REPORT_GROUP_SIZE_DESCRIPTION = (
         "Maximum number of entries to be retrieved in a test history."
+        " A group size of at least two is required in order for tests to be classified."
     )
     TREE_REPORT_MAX_AGE = (
         "Maximum age for the queried checkout and related tests in hours"

--- a/backend/kernelCI_app/typeModels/treeReport.py
+++ b/backend/kernelCI_app/typeModels/treeReport.py
@@ -44,7 +44,7 @@ class TreeReportQueryParameters(BaseModel):
     group_size: Annotated[
         int,
         Field(
-            gt=0,
+            gt=1,
             default=DEFAULT_GROUP_SIZE,
             description=DocStrings.TREE_REPORT_GROUP_SIZE_DESCRIPTION,
         ),


### PR DESCRIPTION
When the tree-report query returns a test group that only has 1 test in it, then that means the test can't be classified as neither "regression", "fixed", nor "unstable", so it is discarded. If we allowed test groups of 1 to be returned and group them just by their status, this would allow returning mainline/master's 16k tests at once, not to mention linaro's 100k trees.
Pruning small test groups is the best move for now.

## Changes
- Increased the param limitation from greater than 0 to greater than 1
- Added better hinting in the param description

## How to test
- Go to the swagger UI, see the new hint,  and test the tree-report endpoint with a group_size of 1 and more

Closes #1405