### PR TITLE
Fix: repeated hardware commits

### DIFF
--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -326,14 +326,17 @@ class BaseTreeCommitsHistory(APIView):
             )
             build_misc = handle_build_misc(row["build_misc"])
 
-            hardware_filter = None
+            hardware_filter = []
             if row["hardware_compatibles"] is not None:
                 hardware_filter = row["hardware_compatibles"]
-            elif test_environment_misc is not None:
-                hardware_filter = [
-                    env_misc_value_or_default(test_environment_misc).get("platform")
-                ]
-            else:
+            if test_environment_misc is not None:
+                platform = env_misc_value_or_default(test_environment_misc).get(
+                    "platform"
+                )
+                if len(hardware_filter) == 0 or platform != UNKNOWN_STRING:
+                    hardware_filter.append(platform)
+            # Only consider build platform if there is neither compatibles nor env platform
+            if len(hardware_filter) == 0:
                 hardware_filter = [
                     build_misc_value_or_default(build_misc).get("platform")
                 ]


### PR DESCRIPTION
## Description
In some cases, the commit hash for the selector in the trees table for the hardware details page was being repeated multiple times. This problem occurred because some trees appear on multiple origins, and the query wasn't limiting by origin. Not only that, but filtering by platform on the tree commit history wasn't working (this appeared on hardware details pages where the hardware was a platform and not a compatible)

## Changes
- Added origin condition and more description to the hardware commits query
- Restructured hardware filter on tree commit history

## How to test
Go to a hardware details page such as [localhost acer-R721T-grunt](http://localhost:5173/hardware/acer-R721T-grunt?et=1756490400&st=1756058400) and compare it with [production acer-R721T-grunt](https://dashboard.kernelci.org/hardware/acer-R721T-grunt?et=1756490400&st=1756058400). Check the mainline commit selector and see that the repetition was fixed.
Go to a hardware details page such as [localhost imx6q-sabrelite](http://localhost:5173/hardware/imx6q-sabrelite?et=1756490400&st=1756058400&x[]=4) and compare it with [production imx6q-sabrelite](https://dashboard.kernelci.org/hardware/imx6q-sabrelite?et=1756490400&st=1756058400&x[]=4) and check that the commit graph now shows the correct data for that platform.

Closes #1445 