### PR TITLE
feat: ensure tree report includes build issues

### DIFF
--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -152,6 +152,11 @@ class DocStrings:
     TREE_REPORT_UNSTABLE_TESTS_DESCRIPTION = (
         "History of tests that are unstable. " + REGRESSIONS_GROUP
     )
+    TREE_REPORT_ISSUES_DESCRIPTION = "Issues information for this checkout."
+    TREE_REPORT_BUILD_DESCRIPTION = (
+        "Build issues found in this checkout,"
+        " including both new and pre-existing issues."
+    )
     TREE_REPORT_GROUP_SIZE_DESCRIPTION = (
         "Maximum number of entries to be retrieved in a test history."
         " A group size of at least two is required in order for tests to be classified."

--- a/backend/kernelCI_app/management/commands/helpers/summary.py
+++ b/backend/kernelCI_app/management/commands/helpers/summary.py
@@ -160,6 +160,6 @@ def get_build_issues_from_checkout(
                 is_new_issue=first_checkout_id == checkout_id,
             )
 
-            result_checkout_issues[checkout_issue.checkout_id].append(checkout_issue)
+            result_checkout_issues[checkout_id].append(checkout_issue)
 
     return result_checkout_issues, checkout_builds_without_issues

--- a/backend/kernelCI_app/typeModels/treeReport.py
+++ b/backend/kernelCI_app/typeModels/treeReport.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import TypedDict
+from kernelCI_app.typeModels.issues import CheckoutIssue
 from typing_extensions import Annotated
 from pydantic import BaseModel, Field
 
@@ -81,32 +82,52 @@ type RegressionData = dict[str, dict[str, dict[str, list[RegressionHistoryItem]]
 """The history of tests is grouped by hardware, then config, then path."""
 
 
+class TreeReportIssues(BaseModel):
+    builds: Annotated[
+        list[CheckoutIssue],
+        Field(description=DocStrings.TREE_REPORT_BUILD_DESCRIPTION),
+    ]
+
+
 class TreeReportResponse(BaseModel):
-    dashboard_url: str = Field(
-        description=DocStrings.TREE_REPORT_DASHBOARD_URL_DESCRIPTION
-    )
-    git_url: str = Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
-    git_branch: str = Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION)
-    commit_hash: str = Field(description=DocStrings.COMMIT_HASH_PATH_DESCRIPTION)
-    origin: str = Field(description=DocStrings.TREE_QUERY_ORIGIN_DESCRIPTION)
-    checkout_start_time: datetime = Field(
-        description=DocStrings.CHECKOUT_START_TIME_DESCRIPTION
-    )
-    build_status_summary: StatusCount = Field(
-        description=DocStrings.BUILD_STATUS_SUMMARY_DESCRIPTION,
-    )
-    boot_status_summary: TestStatusCount = Field(
-        description=DocStrings.BOOT_STATUS_SUMMARY_DESCRIPTION
-    )
-    test_status_summary: TestStatusCount = Field(
-        description=DocStrings.TEST_STATUS_SUMMARY_DESCRIPTION
-    )
-    possible_regressions: RegressionData = Field(
-        description=DocStrings.TREE_REPORT_POSSIBLE_REGRESSIONS_DESCRIPTION,
-    )
-    fixed_regressions: RegressionData = Field(
-        description=DocStrings.TREE_REPORT_FIXED_REGRESSIONS_DESCRIPTION
-    )
-    unstable_tests: RegressionData = Field(
-        description=DocStrings.TREE_REPORT_UNSTABLE_TESTS_DESCRIPTION,
-    )
+    dashboard_url: Annotated[
+        str, Field(description=DocStrings.TREE_REPORT_DASHBOARD_URL_DESCRIPTION)
+    ]
+    git_url: Annotated[
+        str, Field(description=DocStrings.TREE_QUERY_GIT_URL_DESCRIPTION)
+    ]
+    git_branch: Annotated[
+        str, Field(description=DocStrings.DEFAULT_GIT_BRANCH_DESCRIPTION)
+    ]
+    commit_hash: Annotated[
+        str, Field(description=DocStrings.COMMIT_HASH_PATH_DESCRIPTION)
+    ]
+    origin: Annotated[str, Field(description=DocStrings.TREE_QUERY_ORIGIN_DESCRIPTION)]
+    checkout_start_time: Annotated[
+        datetime, Field(description=DocStrings.CHECKOUT_START_TIME_DESCRIPTION)
+    ]
+    build_status_summary: Annotated[
+        StatusCount, Field(description=DocStrings.BUILD_STATUS_SUMMARY_DESCRIPTION)
+    ]
+    boot_status_summary: Annotated[
+        TestStatusCount, Field(description=DocStrings.BOOT_STATUS_SUMMARY_DESCRIPTION)
+    ]
+    test_status_summary: Annotated[
+        TestStatusCount, Field(description=DocStrings.TEST_STATUS_SUMMARY_DESCRIPTION)
+    ]
+    possible_regressions: Annotated[
+        RegressionData,
+        Field(description=DocStrings.TREE_REPORT_POSSIBLE_REGRESSIONS_DESCRIPTION),
+    ]
+    fixed_regressions: Annotated[
+        RegressionData,
+        Field(description=DocStrings.TREE_REPORT_FIXED_REGRESSIONS_DESCRIPTION),
+    ]
+    unstable_tests: Annotated[
+        RegressionData,
+        Field(description=DocStrings.TREE_REPORT_UNSTABLE_TESTS_DESCRIPTION),
+    ]
+    issues: Annotated[
+        TreeReportIssues,
+        Field(description=DocStrings.TREE_REPORT_ISSUES_DESCRIPTION),
+    ]

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -2026,6 +2026,53 @@ components:
       - git_commit_tags
       title: CheckoutFast
       type: object
+    CheckoutIssue:
+      description: Represents a build issue found in a checkout.
+      properties:
+        issue_id:
+          title: Issue Id
+          type: string
+        build_id:
+          title: Build Id
+          type: string
+        version:
+          title: Version
+          type: integer
+        comment:
+          title: Comment
+          type: string
+        report_url:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Report Url
+        culprit_code:
+          title: Culprit Code
+          type: boolean
+        culprit_tool:
+          title: Culprit Tool
+          type: boolean
+        culprit_harness:
+          title: Culprit Harness
+          type: boolean
+        first_seen:
+          $ref: '#/components/schemas/Timestamp'
+        is_new_issue:
+          title: Is New Issue
+          type: boolean
+      required:
+      - issue_id
+      - build_id
+      - version
+      - comment
+      - culprit_code
+      - culprit_tool
+      - culprit_harness
+      - first_seen
+      - is_new_issue
+      title: CheckoutIssue
+      type: object
     Checkout__GitCommitHash:
       anyOf:
       - type: string
@@ -3814,6 +3861,19 @@ components:
         $ref: '#/components/schemas/Checkout'
       title: TreeListingResponse
       type: array
+    TreeReportIssues:
+      properties:
+        builds:
+          description: Build issues found in this checkout, including both new and
+            pre-existing issues.
+          items:
+            $ref: '#/components/schemas/CheckoutIssue'
+          title: Builds
+          type: array
+      required:
+      - builds
+      title: TreeReportIssues
+      type: object
     TreeReportResponse:
       properties:
         dashboard_url:
@@ -3862,6 +3922,9 @@ components:
           $ref: '#/components/schemas/RegressionData'
           description: History of tests that are unstable. Regressions are grouped
             by hardware, config, and path.
+        issues:
+          $ref: '#/components/schemas/TreeReportIssues'
+          description: Issues information for this checkout.
       required:
       - dashboard_url
       - git_url
@@ -3875,6 +3938,7 @@ components:
       - possible_regressions
       - fixed_regressions
       - unstable_tests
+      - issues
       title: TreeReportResponse
       type: object
     TreeSetItem:


### PR DESCRIPTION
- Update tree report response to use `Annotated`
- Include build issues in the tree report

## Related issues

- Closes #1449 

## Visual Reference

<img width="1547" height="770" alt="image" src="https://github.com/user-attachments/assets/a648f281-36e8-407b-a91e-4f9c88c6bbe2" />
