### PR TITLE
Update KCIDB tests grouping

### DIFF
--- a/backend/kernelCI_app/management/commands/templates/summary.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/summary.txt.j2
@@ -4,11 +4,14 @@
 {% macro render_issues(issues) -%}
 {%- for platform, configs in issues.items() %}
 Hardware: {{ platform }}
-    {%- for config_name, paths in configs.items() %}
-            {%- for path, test_group in paths.items() %}
-- {{path}} ({{config_name}})
-  last run: https://d.kernelci.org/test/{{test_group[0]["id"]}}
-  history:  {% for t in test_group | reverse -%}
+  {%- for config_name, arch_compilers in configs.items() %}
+  > Config: {{config_name}}
+    {%- for arch_compiler, paths in arch_compilers.items() %}
+    - Architecture/compiler: {{arch_compiler}}
+      {%- for path, test_group in paths.items() %}
+      - {{path}}
+      last run: https://d.kernelci.org/test/{{test_group[0]["id"]}}
+      history:  {% for t in test_group | reverse -%}
                 {%- if t["status"] == "PASS" -%}
                     {{- "> ✅  " -}}
                 {%- elif t["status"] == "FAIL" -%}
@@ -18,6 +21,7 @@ Hardware: {{ platform }}
                 {%- endif -%}
             {%- endfor %}
             {% endfor %}
+          {%- endfor %}
     {%- endfor -%}
 {%- endfor -%}
 {%- endmacro %}

--- a/backend/kernelCI_app/queries/notifications.py
+++ b/backend/kernelCI_app/queries/notifications.py
@@ -551,7 +551,9 @@ def kcidb_tests_results(
                         PARTITION BY
                             path,
                             platform,
-                            config_name
+                            config_name,
+                            architecture,
+                            compiler
                         ORDER BY
                             start_time DESC NULLS LAST
                     ) AS rn,
@@ -559,7 +561,9 @@ def kcidb_tests_results(
                         PARTITION BY
                             path,
                             platform,
-                            config_name
+                            config_name,
+                            architecture,
+                            compiler
                         ORDER BY
                             start_time DESC NULLS LAST
                     ) AS first_hash_by_group
@@ -586,6 +590,8 @@ def kcidb_tests_results(
             path,
             platform,
             config_name,
+            architecture,
+            compiler,
             start_time DESC NULLS LAST;
         """
 

--- a/backend/kernelCI_app/typeModels/treeReport.py
+++ b/backend/kernelCI_app/typeModels/treeReport.py
@@ -78,8 +78,11 @@ class RegressionHistoryItem(TypedDict):
     status: Test__Status
 
 
-type RegressionData = dict[str, dict[str, dict[str, list[RegressionHistoryItem]]]]
-"""The history of tests is grouped by hardware, then config, then path."""
+type RegressionData = dict[
+    str, dict[str, dict[str, dict[str, list[RegressionHistoryItem]]]]
+]
+"""The history of tests is grouped by hardware, then architecture/compiler string,
+then config, then path."""
 
 
 class TreeReportIssues(BaseModel):


### PR DESCRIPTION
- Update `kcidb_test_results` to fetch architecture and compiler information for tests
- Take architecture and compiler into account while grouping tests in `evaluate_test_results`