### PR TITLE
feat: ensure all hardware details trees can be deslected

### DIFF
--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -21,22 +21,23 @@ import { RequestData } from './commonRequest';
 const TREE_SELECT_HEAD_VALUE = 'head';
 
 const mapIndexesToSelectedTrees = (
-  selectedIndexes: number[],
+  selectedIndexes: number[] | null,
   treeIndexesLength?: number,
   treeCommits: TTreeCommits = {},
 ): Record<string, string> => {
   const selectedTrees: Record<string, string> = {};
 
-  if (selectedIndexes.length === 0 && isEmptyObject(treeCommits)) {
+  if (selectedIndexes?.length === 0 && isEmptyObject(treeCommits)) {
     return selectedTrees;
   }
 
   const selectedArray =
-    treeIndexesLength && selectedIndexes.length === 0
+    treeIndexesLength &&
+    (selectedIndexes === null || selectedIndexes.length === 0)
       ? Array.from({ length: treeIndexesLength }, (_, i) => i)
       : selectedIndexes;
 
-  selectedArray.forEach(i => {
+  selectedArray?.forEach(i => {
     const key = i.toString();
     const value = treeCommits[key] || TREE_SELECT_HEAD_VALUE;
     selectedTrees[key] = value;
@@ -102,7 +103,7 @@ export type UseHardwareDetailsWithoutVariant = {
   endTimestampInSeconds: number;
   origin: string;
   filter: TFilter;
-  selectedIndexes: number[];
+  selectedIndexes: number[] | null;
   treeCommits: TTreeCommits;
   treeIndexesLength?: number;
   enabled?: boolean;

--- a/dashboard/src/components/Checkbox/IndeterminateCheckbox.tsx
+++ b/dashboard/src/components/Checkbox/IndeterminateCheckbox.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useRef, type HTMLProps, type JSX } from 'react';
 
-import { cn } from '@/lib/utils';
-
 export function IndeterminateCheckbox({
   indeterminate = false,
-  className = '',
   ...rest
 }: { indeterminate?: boolean } & HTMLProps<HTMLInputElement>): JSX.Element {
   const ref = useRef<HTMLInputElement>(null!);
@@ -17,7 +14,7 @@ export function IndeterminateCheckbox({
     <input
       type="checkbox"
       ref={ref}
-      className={cn(className + ' cursor-pointer')}
+      className="size-4 cursor-pointer"
       {...rest}
     />
   );

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -197,6 +197,9 @@ export const messages = {
       'Search by hardware name or platform with a regex',
     'hardwareDetails.notFound': 'Hardware not found',
     'hardwareDetails.platforms': 'Platforms',
+    'hardwareDetails.selectTreeMessage':
+      'Please select one or more trees from the table above to view detailed information about builds, boots, and tests for this hardware.',
+    'hardwareDetails.selectTreeTitle': 'No Tree Selected',
     'hardwareDetails.timeFrame':
       'Results from {startDate} and {startTime} to {endDate} {endTime}',
     'hardwareListing.description': 'List of hardware from kernel tests',

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -124,7 +124,7 @@ function HardwareDetails(): JSX.Element {
 
   const reqFilter = mapFilterToReq(diffFilter);
 
-  const updateTreeFilters = useCallback((selectedIndexes: number[]) => {
+  const updateTreeFilters = useCallback((selectedIndexes: number[] | null) => {
     navigate({
       search: previousSearch => ({
         ...previousSearch,
@@ -174,7 +174,7 @@ function HardwareDetails(): JSX.Element {
       endTimestampInSeconds: endTimestampInSeconds,
       origin: origin,
       filter: reqFilter,
-      selectedIndexes: treeIndexes ?? [],
+      selectedIndexes: treeIndexes,
       treeCommits: treeCommits,
       treeIndexesLength: treeIndexesLength,
     });
@@ -347,6 +347,8 @@ function HardwareDetails(): JSX.Element {
     ],
   );
 
+  const hasSelectedTrees = treeIndexes === null || treeIndexes.length > 0;
+
   const hardwareTitle = useMemo(() => {
     return formatMessage(
       { id: 'title.hardwareDetails' },
@@ -438,16 +440,18 @@ function HardwareDetails(): JSX.Element {
               </>
             )}
             <div className="flex flex-col pb-2">
-              <div className="sticky top-[4.5rem] z-10">
-                <div className="absolute top-2 right-0 py-4">
-                  <HardwareDetailsFilter
-                    paramFilter={diffFilter}
-                    hardwareName={hardwareId}
-                    data={summaryResponse.data}
-                    selectedTrees={treeIndexes}
-                  />
+              {hasSelectedTrees && (
+                <div className="sticky top-[4.5rem] z-10">
+                  <div className="absolute top-2 right-0 py-4">
+                    <HardwareDetailsFilter
+                      paramFilter={diffFilter}
+                      hardwareName={hardwareId}
+                      data={summaryResponse.data}
+                      selectedTrees={treeIndexes}
+                    />
+                  </div>
                 </div>
-              </div>
+              )}
               {summaryResponse.data && (
                 <HardwareDetailsTabs
                   hardwareId={hardwareId}
@@ -455,6 +459,7 @@ function HardwareDetails(): JSX.Element {
                   countElements={tabsCounts}
                   summaryData={summaryResponse.data}
                   fullDataResult={fullResponse}
+                  hasSelectedTrees={hasSelectedTrees}
                 />
               )}
             </div>

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsFilter.tsx
@@ -27,7 +27,7 @@ interface IHardwareDetailsFilter {
   paramFilter: TFilter;
   hardwareName: string;
   data: HardwareDetailsSummary | undefined;
-  selectedTrees?: number[];
+  selectedTrees: number[] | null;
 }
 
 type TFilterCreate = TFilter & {
@@ -207,7 +207,7 @@ const HardwareDetailsFilter = ({
 
   useEffect(() => {
     const initialTrees =
-      selectedTrees && selectedTrees?.length > 0
+      selectedTrees && selectedTrees.length > 0
         ? selectedTrees
         : filter.treeIndexes;
 

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -1,5 +1,7 @@
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
+import { FormattedMessage } from 'react-intl';
+
 import type { JSX } from 'react';
 import { useCallback, useMemo } from 'react';
 
@@ -25,6 +27,7 @@ export interface IHardwareDetailsTab {
   countElements: TabRightElementRecord;
   fullDataResult?: UseQueryResult<THardwareDetails>;
   summaryData: HardwareDetailsSummary;
+  hasSelectedTrees: boolean;
 }
 
 const HardwareDetailsTabs = ({
@@ -33,6 +36,7 @@ const HardwareDetailsTabs = ({
   countElements,
   fullDataResult,
   summaryData,
+  hasSelectedTrees,
 }: IHardwareDetailsTab): JSX.Element => {
   const { currentPageTab } = useSearch({
     from: '/_main/hardware/$hardwareId',
@@ -108,6 +112,21 @@ const HardwareDetailsTabs = ({
       countElements,
     ],
   );
+
+  if (!hasSelectedTrees) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-center">
+          <h3 className="text-lg font-medium">
+            <FormattedMessage id="hardwareDetails.selectTreeTitle" />
+          </h3>
+          <p className="m-4 mx-auto max-w-lg">
+            <FormattedMessage id="hardwareDetails.selectTreeMessage" />
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <Tabs

--- a/dashboard/src/routes/_main/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/_main/hardware/$hardwareId/route.tsx
@@ -21,7 +21,7 @@ import {
 const defaultValues = {
   origin: DEFAULT_ORIGIN,
   currentPageTab: defaultValidadorValues.tab,
-  treeIndexes: [],
+  treeIndexes: null,
   treeCommits: {},
   tableFilter: zTableFilterInfoDefault,
   diffFilter: DEFAULT_DIFF_FILTER,
@@ -29,7 +29,7 @@ const defaultValues = {
 const hardwareDetailsSearchSchema = z.object({
   origin: zOrigin,
   currentPageTab: zPossibleTabValidator,
-  treeIndexes: z.array(z.number().int()).default([]),
+  treeIndexes: z.array(z.number().int()).nullable().default(null),
   treeCommits: zTreeCommits,
   tableFilter: zTableFilterInfoValidator,
   diffFilter: zDiffFilter,


### PR DESCRIPTION
Users must deselect all hardware details trees at once.

When no trees are selected, a message is displayed to inform the user that no tree has been selected.

## Related Issue
- Closes #614 

## Visual Reference
https://github.com/user-attachments/assets/04871913-37f1-4fa7-a1ab-f93ccb3c28e6

## How to test it

Go to hardware section and choose once to see the details, deselect all trees