### PR TITLE
backend: Add mounts for ingester service

### DIFF
--- a/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
+++ b/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
@@ -31,7 +31,7 @@ STORAGE_BASE_URL = os.environ.get(
     "STORAGE_BASE_URL", "https://files-staging.kernelci.org"
 )
 
-TREES_FILE = "/app/trees.yaml"
+TREES_FILE = "/app/trees.yml"
 
 logger = logging.getLogger("ingester")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
                 BACKEND_VOLUME_DIR: ${BACKEND_VOLUME_DIR:-/volume_data}
         volumes:
             - backend-data:${BACKEND_VOLUME_DIR:-/volume_data}
+            - ../data:/app
+            - ../spool:/app/spool
         restart: always
         container_name: dashboard_backend_service
         networks:


### PR DESCRIPTION
One of mounts provide trees.yaml, another path to default spool directory.
Also rename trees.yaml to correct filename, to match kcidb-ng