### PR TITLE
fix: ensure search bar does not freeze 

### DIFF
--- a/dashboard/src/components/Table/ConditionalTableCell.tsx
+++ b/dashboard/src/components/Table/ConditionalTableCell.tsx
@@ -1,0 +1,125 @@
+import type { Cell } from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
+import type { LinkProps } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
+import { memo, useMemo, type JSX } from 'react';
+
+import { TableCell, TableCellWithLink } from '@/components/ui/table';
+import CopyButton from '@/components/Button/CopyButton';
+import { gitCommitValueSelector } from '@/components/Tooltip/CommitTagTooltip';
+import type { TreeTableBody } from '@/types/tree/Tree';
+import type { HardwareItem } from '@/types/hardware';
+
+interface ConditionalTableCellProps<T = TreeTableBody | HardwareItem> {
+  cell: Cell<T, unknown>;
+  linkProps: LinkProps;
+  linkClassName?: string;
+}
+
+type ColumnType = 'status' | 'git_commit_tags' | 'regular';
+
+const isTreeTableBody = (data: unknown): data is TreeTableBody => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'git_commit_hash' in data &&
+    'git_commit_name' in data &&
+    'git_commit_tags' in data
+  );
+};
+
+/**
+ * Adaptive table cell component that automatically handles different cell types:
+ * - Status columns: Uses TableCell without wrapper link (prevents nested <a> tags)
+ * - Git commit tags: Uses TableCell with custom link + copy button
+ * - Regular columns: Uses TableCellWithLink for navigation
+ */
+const ConditionalTableCellComponent = <T = TreeTableBody | HardwareItem,>({
+  cell,
+  linkProps,
+  linkClassName = 'w-full inline-block h-full',
+}: ConditionalTableCellProps<T>): JSX.Element => {
+  const cellContent = useMemo(() => {
+    return flexRender(cell.column.columnDef.cell, cell.getContext());
+  }, [cell]);
+
+  const columnType = useMemo((): ColumnType => {
+    const statusColumnIds = ['build_status', 'boot_status', 'test_status'];
+    const columnId = cell.column.id;
+    const columnDefId = cell.column.columnDef.id;
+
+    if (statusColumnIds.some(statusId => columnId.includes(statusId))) {
+      return 'status';
+    }
+
+    if (columnDefId === 'git_commit_tags') {
+      return 'git_commit_tags';
+    }
+
+    return 'regular';
+  }, [cell.column.id, cell.column.columnDef.id]);
+
+  const gitCommitValue = useMemo(() => {
+    if (columnType !== 'git_commit_tags') {
+      return null;
+    }
+
+    const rowData = cell.row.original;
+    if (!isTreeTableBody(rowData)) {
+      return null;
+    }
+
+    return gitCommitValueSelector({
+      commitHash: rowData.git_commit_hash,
+      commitName: rowData.git_commit_name,
+      commitTags: rowData.git_commit_tags,
+    }).content;
+  }, [columnType, cell.row.original]);
+
+  switch (columnType) {
+    case 'status':
+      return (
+        <TableCell key={cell.id} className="p-4">
+          {cellContent}
+        </TableCell>
+      );
+
+    case 'git_commit_tags':
+      if (gitCommitValue) {
+        // The CopyButton is defined outside of the cell column because I couldn't find
+        // a way to include it within the cell definition while also using it outside of
+        // a Link component. I attempted to modify CommitTagTooltip to wrap the tooltip
+        // inside a Link component, but this would require the column cell to be a function
+        // that receives LinkProps and returns the CommitTagTooltip component. However,
+        // I couldn't figure out how to achieve this using TanStack Table, as
+        // `cell.getValue()` would return an array instead of the expected function.
+        return (
+          <TableCell key={cell.id}>
+            <Link className="inline-block" {...linkProps}>
+              {cellContent}
+            </Link>
+            <CopyButton value={gitCommitValue} />
+          </TableCell>
+        );
+      }
+      return <TableCell key={cell.id}>{cellContent}</TableCell>;
+
+    case 'regular':
+    default:
+      return (
+        <TableCellWithLink
+          key={cell.id}
+          linkClassName={linkClassName}
+          linkProps={linkProps}
+        >
+          {cellContent}
+        </TableCellWithLink>
+      );
+  }
+};
+
+export const ConditionalTableCell = memo(ConditionalTableCellComponent) as <
+  T = TreeTableBody | HardwareItem,
+>(
+  props: ConditionalTableCellProps<T>,
+) => JSX.Element;

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -18,7 +18,7 @@ import { useCallback, useMemo, useState, type JSX } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import type { LinkProps } from '@tanstack/react-router';
-import { Link, useNavigate, useSearch } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 
@@ -33,12 +33,8 @@ import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
 import { usePaginationState } from '@/hooks/usePaginationState';
 
 import BaseTable, { TableHead } from '@/components/Table/BaseTable';
-import {
-  TableBody,
-  TableCell,
-  TableCellWithLink,
-  TableRow,
-} from '@/components/ui/table';
+import { TableBody, TableCell, TableRow } from '@/components/ui/table';
+import { ConditionalTableCell } from '@/components/Table/ConditionalTableCell';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
 
@@ -47,11 +43,7 @@ import { sanitizeTableValue } from '@/components/Table/tableUtils';
 import { GroupedTestStatusWithLink } from '@/components/Status/Status';
 import { TableHeader } from '@/components/Table/TableHeader';
 import { PaginationInfo } from '@/components/Table/PaginationInfo';
-import {
-  CommitTagTooltip,
-  gitCommitValueSelector,
-} from '@/components/Tooltip/CommitTagTooltip';
-import CopyButton from '@/components/Button/CopyButton';
+import { CommitTagTooltip } from '@/components/Tooltip/CommitTagTooltip';
 
 import type { ListingTableColumnMeta } from '@/types/table';
 
@@ -455,39 +447,13 @@ export function TreeTable({ treeTableRows }: ITreeTable): JSX.Element {
             const tabTarget = (
               cell.column.columnDef.meta as ListingTableColumnMeta
             ).tabTarget;
-            // The CopyButton is defined outside of the cell column because I couldn't find
-            // a way to include it within the cell definition while also using it outside of
-            // a Link component. I attempted to modify CommitTagTooltip to wrap the tooltip
-            // inside a Link component, but this would require the column cell to be a function
-            // that receives LinkProps and returns the CommitTagTooltip component. However,
-            // I couldn't figure out how to achieve this using TanStack Table, as
-            // `cell.getValue()` would return an array instead of the expected function.
-            return cell.column.columnDef.id === 'git_commit_tags' ? (
-              <TableCell key={cell.id}>
-                <Link
-                  className="inline-block"
-                  {...getLinkProps(row, origin, tabTarget)}
-                >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </Link>
-                <CopyButton
-                  value={
-                    gitCommitValueSelector({
-                      commitHash: cell.row.original.git_commit_hash,
-                      commitName: cell.row.original.git_commit_name,
-                      commitTags: cell.row.original.git_commit_tags,
-                    }).content
-                  }
-                />
-              </TableCell>
-            ) : (
-              <TableCellWithLink
+            return (
+              <ConditionalTableCell
                 key={cell.id}
-                linkClassName="w-full inline-block h-full"
+                cell={cell}
                 linkProps={getLinkProps(row, origin, tabTarget)}
-              >
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </TableCellWithLink>
+                linkClassName="w-full inline-block h-full"
+              />
             );
           })}
         </TableRow>

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -24,12 +24,8 @@ import BaseTable, { TableHead } from '@/components/Table/BaseTable';
 
 import { formattedBreakLineValue } from '@/locales/messages';
 
-import {
-  TableBody,
-  TableCell,
-  TableCellWithLink,
-  TableRow,
-} from '@/components/ui/table';
+import { TableBody, TableCell, TableRow } from '@/components/ui/table';
+import { ConditionalTableCell } from '@/components/Table/ConditionalTableCell';
 
 import { GroupedTestStatusWithLink } from '@/components/Status/Status';
 import { TableHeader } from '@/components/Table/TableHeader';
@@ -410,18 +406,17 @@ export function HardwareTable({
               cell.column.columnDef.meta as ListingTableColumnMeta
             ).tabTarget;
             return (
-              <TableCellWithLink
+              <ConditionalTableCell
                 key={cell.id}
-                linkClassName="w-full inline-block h-full"
+                cell={cell}
                 linkProps={getLinkProps(
                   row,
                   startTimestampInSeconds,
                   endTimestampInSeconds,
                   tabTarget,
                 )}
-              >
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </TableCellWithLink>
+                linkClassName="w-full inline-block h-full"
+              />
             );
           })}
         </TableRow>


### PR DESCRIPTION
### First commit: Search bar freeze

- Updated checkout delay to 0.5s.
- Added a new condition to verify the last searched value.
- This ensures that the search bar no longer freezes when searching for trees, issues, or hardware.

### Second commit: Nested links in table cells
- Removed TableCellWithLink for cases where the content already had a link (e.g., boot, build, and test statuses).
- The issue was happening in both hardware and tree views.
- This avoids nested <a> tags that caused hydration errors:

```
table.tsx:117 <a> cannot contain a nested <a>
Status.tsx:98 In HTML, <a> cannot be a descendant of <a>
```

## Related Issue

- Closes #1466
- Closes #1470 