### PR TITLE
Feat: improve notifications code

### DIFF
--- a/.env.backend.example
+++ b/.env.backend.example
@@ -16,3 +16,7 @@ DASH_DB_HOST=dashboard_db
 DASH_DB_PORT=${DASH_DB_PORT:-5432}
 
 USE_DASHBOARD_DB=${USE_DASHBOARD_DB:-False}
+
+## Variables used for the notifications command. Check docs/notifications.md
+# EMAIL_HOST_USER="youruser@host" # (optional)
+# EMAIL_HOST_PASSWORD="yourpassword"

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -174,14 +174,14 @@ CRONJOBS = [
 ]
 
 # Email settings for SMTP backend
-EMAIL_BACKEND = get_json_env_var(
+EMAIL_BACKEND = os.environ.get(
     "EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"
 )
-EMAIL_HOST = get_json_env_var("EMAIL_HOST", "smtp.gmail.com")
-EMAIL_PORT = get_json_env_var("EMAIL_PORT", 587)
-EMAIL_USE_TLS = get_json_env_var("EMAIL_USE_TLS", True)
-EMAIL_HOST_USER = get_json_env_var("EMAIL_HOST_USER", "bot@kernelci.org")
-EMAIL_HOST_PASSWORD = get_json_env_var("EMAIL_HOST_PASSWORD", "")
+EMAIL_HOST = os.environ.get("EMAIL_HOST", "smtp.gmail.com")
+EMAIL_PORT = os.environ.get("EMAIL_PORT", 587)
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", True)
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "bot@kernelci.org")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
@@ -202,7 +202,7 @@ kcidb_config = get_json_env_var(
         "PASSWORD": "kernelci-db-password",
         "HOST": "127.0.0.1",
         "OPTIONS": {
-            "connect_timeout": 5,
+            "connect_timeout": 16,
         },
     },
 )
@@ -215,7 +215,7 @@ dashboard_db_config = {
     "HOST": os.environ.get("DASH_DB_HOST", "127.0.0.1"),
     "PORT": os.environ.get("DASH_DB_PORT", 5434),
     "OPTIONS": {
-        "connect_timeout": 5,
+        "connect_timeout": 16,
     },
 }
 

--- a/backend/kernelCI_app/helpers/system.py
+++ b/backend/kernelCI_app/helpers/system.py
@@ -3,22 +3,9 @@ from django.conf import settings
 
 from kernelCI_app.constants.general import PRODUCTION_HOST
 
-
-# TODO: combine with the function below once it is verified
-# that this way of identifying the production instance works
-def is_production_instance():
-    if not hasattr(settings, "CORS_ALLOWED_ORIGINS"):
-        return False
-    if PRODUCTION_HOST in settings.CORS_ALLOWED_ORIGINS:
-        return True
-    return False
-
-
 type PossibleHosts = Literal["production", "staging"]
 
 
-# TODO: verify if this is the correct way to identify
-# the production instance
 def get_running_instance() -> PossibleHosts | None:
     if (
         hasattr(settings, "CORS_ALLOWED_ORIGINS")

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -12,7 +12,7 @@ from urllib.parse import quote_plus
 from django.core.management.base import BaseCommand
 
 from kernelCI_app.helpers.logger import log_message
-from kernelCI_app.helpers.system import is_production_instance
+from kernelCI_app.helpers.system import get_running_instance
 
 from kernelCI_app.helpers.email import (
     smtp_setup_connection,
@@ -199,7 +199,8 @@ def exclude_already_found_and_store(issues: list[dict]) -> list[dict]:
 
 
 def look_for_new_issues(*, service, signup_folder, email_args):
-    if is_production_instance():
+    if get_running_instance() == "staging":
+        print("This command only runs on production or dev environments.")
         return
 
     issues = kcidb_new_issues()
@@ -499,7 +500,6 @@ def discard_sent_reports(
 
 
 # TODO: lower the complexity of this function, we are at the limit
-# flake8: noqa: C901
 def run_checkout_summary(
     *,
     service,
@@ -508,7 +508,8 @@ def run_checkout_summary(
     email_args,
     skip_sent_reports: bool = True,
 ):
-    if is_production_instance():
+    if get_running_instance() == "staging":
+        print("This command only runs on production or dev environments.")
         return
 
     tree_key_set, tree_prop_map = process_submissions_files(


### PR DESCRIPTION
## Changes
- Refactored notification conditions so that it only runs on production or dev environments instead of only on staging;
- Removed now unecessary is_production_instance function;
- Refactored getting email env vars in settings and added them to the example env;
- Slightly increased the default timeout for both databases.

## How to test
The changes are mostly code-only, but you can test them by running the notifications command.