### PR TITLE
test: add unit tests for typeModels

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -44,9 +44,11 @@ def pytest_collection_modifyitems(items: list[Item]):
     test_markers = get_test_markers()
 
     for item in items:
-        parent_folder = item.path.parent.name.lower()
-
-        matched_markers = [marker for marker in test_markers if marker in parent_folder]
+        path_parts = [part.lower() for part in item.path.parts]
+        matched_markers = []
+        for marker in test_markers:
+            if any(marker in part for part in path_parts):
+                matched_markers.append(marker)
         match len(matched_markers):
             case 0:
                 raise Exception(
@@ -59,11 +61,10 @@ def pytest_collection_modifyitems(items: list[Item]):
             case _:
                 raise Exception(
                     """Test %s can only be of a single type (one of %s),
-                        but found multiple markers (%s) at folder %s"""
+                        but found multiple markers (%s)"""
                     % (
                         item.name,
                         test_markers,
                         matched_markers,
-                        parent_folder,
                     )
                 )

--- a/backend/kernelCI_app/tests/unitTests/typeModels/commonDetails_test.py
+++ b/backend/kernelCI_app/tests/unitTests/typeModels/commonDetails_test.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from kernelCI_app.typeModels.commonDetails import (
+    BuildHistoryItem,
+)
+
+
+class TestBuildHistoryItem:
+    """Test cases for BuildHistoryItem class."""
+
+    def test_build_history_item_misc_variations(self):
+        """Test BuildHistoryItem with different misc field variations."""
+        base_data = {
+            "id": "build123",
+            "origin": "origin1",
+            "architecture": "x86_64",
+            "config_name": "config1",
+            "config_url": "http://example.com/config",
+            "compiler": "gcc",
+            "status": "PASS",
+            "duration": 300,
+            "log_url": "http://example.com/log",
+            "start_time": datetime.now(),
+            "git_repository_url": "https://git.example.com/repo",
+            "git_repository_branch": "main",
+        }
+
+        build_with_misc_dict = BuildHistoryItem(
+            **base_data, misc={"key": "value", "number": 1}
+        )
+        assert build_with_misc_dict.misc == {"key": "value", "number": 1}
+
+        build_with_misc_string = BuildHistoryItem(
+            **base_data, misc='{"key": "value", "number": 42}'
+        )
+        assert build_with_misc_string.misc == {"key": "value", "number": 42}
+
+        build_with_misc_invalid_json = BuildHistoryItem(
+            **base_data, misc="not_valid_json"
+        )
+        assert build_with_misc_invalid_json.misc is None
+
+        build_with_misc_none = BuildHistoryItem(**base_data, misc=None)
+        assert build_with_misc_none.misc is None
+
+        build_with_misc_int = BuildHistoryItem(**base_data, misc=123)
+        assert build_with_misc_int.misc is None

--- a/backend/kernelCI_app/tests/unitTests/typeModels/common_test.py
+++ b/backend/kernelCI_app/tests/unitTests/typeModels/common_test.py
@@ -1,0 +1,70 @@
+from kernelCI_app.typeModels.common import (
+    StatusCount,
+    GroupedStatus,
+    make_default_validator,
+)
+
+
+class TestStatusCount:
+    """Test cases for StatusCount class."""
+
+    def test_status_count_increment_valid(self):
+        """Test StatusCount increment with valid status."""
+        status = StatusCount()
+        status.increment("PASS")
+        assert status.PASS == 1
+
+    def test_status_count_increment_none(self):
+        """Test StatusCount increment with None status."""
+        status = StatusCount()
+        status.increment(None)
+        assert status.NULL == 1
+
+    def test_status_count_increment_unknown(self):
+        """Test StatusCount increment with unknown status."""
+        status = StatusCount()
+        status.increment("UNKNOWN_STATUS")
+        # Should not raise exception, just log the error
+        assert status.PASS == 0
+        assert status.ERROR == 0
+        assert status.FAIL == 0
+        assert status.SKIP == 0
+        assert status.MISS == 0
+        assert status.DONE == 0
+        assert status.NULL == 0
+
+    def test_status_count_addition(self):
+        """Test StatusCount addition."""
+        status1 = StatusCount(PASS=5, FAIL=1)
+        status2 = StatusCount(PASS=3, ERROR=2)
+
+        result = status1 + status2
+
+        assert result.PASS == 8
+        assert result.FAIL == 1
+        assert result.ERROR == 2
+
+
+class TestGroupedStatus:
+    """Test cases for GroupedStatus."""
+
+    def test_grouped_status_creation(self):
+        """Test GroupedStatus creation."""
+        grouped = GroupedStatus(success=3, failed=2, inconclusive=1)
+        assert grouped["success"] == 3
+        assert grouped["failed"] == 2
+        assert grouped["inconclusive"] == 1
+
+
+class TestMakeDefaultValidator:
+    """Test cases for make_default_validator function."""
+
+    def test_make_default_validator(self):
+        """Test make_default_validator function."""
+        validator = make_default_validator("default_value")
+
+        result = validator.func(None)
+        assert result == "default_value"
+
+        result = validator.func("actual_value")
+        assert result == "actual_value"

--- a/backend/kernelCI_app/tests/unitTests/typeModels/treeListing_unit_test.py
+++ b/backend/kernelCI_app/tests/unitTests/typeModels/treeListing_unit_test.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+from kernelCI_app.typeModels.treeListing import (
+    TestStatusCount,
+    Checkout,
+)
+from kernelCI_app.typeModels.common import StatusCount
+
+
+class TestCheckout:
+    """Test cases for Checkout class."""
+
+    def test_checkout_creation(self):
+        """Test Checkout with all fields."""
+        build_status = StatusCount(PASS=5, FAIL=1)
+        test_status = TestStatusCount(
+            **{"pass": 3}, error=0, fail=1, skip=0, miss=0, done=0, null=0
+        )
+        boot_status = TestStatusCount(
+            **{"pass": 2}, error=1, fail=0, skip=0, miss=0, done=0, null=0
+        )
+        tags = [["tag1"], ["tag2"]]
+
+        checkout = Checkout(
+            git_repository_url="https://git.example.com/repo",
+            git_commit_hash="ghi789",
+            git_commit_name="commit_name3",
+            origin="origin3",
+            git_repository_branch="develop",
+            start_time="2023-01-01T00:00:00",
+            origin_builds_finish_time="2023-01-01T01:00:00",
+            origin_tests_finish_time="2023-01-01T02:00:00",
+            checkout_id="checkout123",
+            build_status=build_status,
+            test_status=test_status,
+            boot_status=boot_status,
+            tree_name="tree1",
+            git_commit_tags=tags,
+        )
+
+        assert checkout.git_repository_url == "https://git.example.com/repo"
+        assert checkout.git_commit_hash == "ghi789"
+        assert checkout.git_commit_name == "commit_name3"
+        assert checkout.origin == "origin3"
+        assert checkout.git_repository_branch == "develop"
+        assert checkout.start_time == datetime(2023, 1, 1, 0, 0)
+        assert checkout.origin_builds_finish_time == datetime(2023, 1, 1, 1, 0)
+        assert checkout.origin_tests_finish_time == datetime(2023, 1, 1, 2, 0)
+        assert checkout.id == "checkout123"
+        assert checkout.build_status == build_status
+        assert checkout.test_status == test_status
+        assert checkout.boot_status == boot_status
+        assert checkout.tree_name == "tree1"
+        assert checkout.git_commit_tags == tags
+
+    def test_checkout_add_counts(self):
+        """Test add_counts method."""
+        checkout = Checkout(
+            git_repository_url="https://git.example.com/repo",
+            git_commit_hash="jkl012",
+            git_commit_name="commit_name4",
+            origin="origin4",
+            git_repository_branch="feature",
+            start_time="2023-01-01T00:00:00",
+            origin_builds_finish_time="2023-01-01T01:00:00",
+            origin_tests_finish_time="2023-01-01T02:00:00",
+            checkout_id="checkout456",
+            build_status=StatusCount(PASS=2, FAIL=1),
+            test_status=TestStatusCount(
+                **{"pass": 1}, error=0, fail=1, skip=0, miss=0, done=0, null=0
+            ),
+            boot_status=TestStatusCount(
+                **{"pass": 1}, error=1, fail=0, skip=0, miss=0, done=0, null=0
+            ),
+            tree_name="tree2",
+            git_commit_tags=[["tag3"]],
+        )
+
+        additional_build_status = StatusCount(PASS=1, ERROR=1)
+        additional_test_status = TestStatusCount(
+            **{"pass": 2}, error=0, fail=0, skip=1, miss=0, done=0, null=0
+        )
+        additional_boot_status = TestStatusCount(
+            **{"pass": 1}, error=0, fail=0, skip=0, miss=0, done=0, null=1
+        )
+
+        checkout.add_counts(
+            additional_build_status, additional_test_status, additional_boot_status
+        )
+
+        assert checkout.build_status.PASS == 3
+        assert checkout.build_status.FAIL == 1
+        assert checkout.build_status.ERROR == 1
+
+        assert checkout.test_status.pass_count == 3
+        assert checkout.test_status.fail_count == 1
+        assert checkout.test_status.skip_count == 1
+
+        assert checkout.boot_status.pass_count == 2
+        assert checkout.boot_status.error_count == 1
+        assert checkout.boot_status.null_count == 1

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -1,7 +1,7 @@
 import json
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Optional, Set, Union, Tuple, Any
+from typing import Optional, Union
 from typing_extensions import Annotated
 
 from pydantic import BaseModel, field_validator, Field
@@ -34,7 +34,7 @@ class TestArchSummaryItem(BaseModel):
 
 
 class BuildArchitectures(StatusCount):
-    compilers: Optional[List[str]] = []
+    compilers: Optional[list[str]] = []
 
 
 class TestHistoryItem(BaseModel):
@@ -44,7 +44,7 @@ class TestHistoryItem(BaseModel):
     duration: Optional[Union[int, float]]
     path: Optional[str]
     start_time: Optional[Union[datetime, str]]
-    environment_compatible: Optional[Union[str, List[str]]]
+    environment_compatible: Optional[Union[str, list[str]]]
     config: Optional[str]
     log_url: Optional[str]
     architecture: Optional[str]
@@ -72,9 +72,15 @@ class BuildHistoryItem(BaseModel):
 
     @field_validator("misc", mode="before")
     @classmethod
-    def to_dict(cls, value: Any) -> Any:
+    def to_dict(cls, value) -> Optional[dict]:
         if isinstance(value, str):
-            return json.loads(value)
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError as err:
+                log_message(
+                    f"Invalid misc for BuildHistoryItem;\nType: {type(value)}\nError: {err.msg}"
+                )
+                return None
         elif isinstance(value, dict):
             return value
         elif value is None:
@@ -86,15 +92,15 @@ class BuildHistoryItem(BaseModel):
 class TestSummary(BaseModel):
     status: StatusCount
     origins: dict[str, StatusCount]
-    architectures: List[TestArchSummaryItem]
-    configs: Dict[str, StatusCount]
-    issues: List[Issue]
+    architectures: list[TestArchSummaryItem]
+    configs: dict[str, StatusCount]
+    issues: list[Issue]
     unknown_issues: int
     fail_reasons: defaultdict[str, int]
-    failed_platforms: Set
-    environment_compatible: Optional[Dict] = None
-    environment_misc: Optional[Dict] = None
-    platforms: Optional[Dict[str, StatusCount]] = None
+    failed_platforms: set
+    environment_compatible: Optional[dict] = None
+    environment_misc: Optional[dict] = None
+    platforms: Optional[dict[str, StatusCount]] = None
 
 
 class BaseBuildSummary(BaseModel):
@@ -105,7 +111,7 @@ class BaseBuildSummary(BaseModel):
 
 
 class BuildSummary(BaseBuildSummary):
-    issues: List[Issue]
+    issues: list[Issue]
     unknown_issues: int
 
 
@@ -116,13 +122,13 @@ class Summary(BaseModel):
 
 
 class GlobalFilters(BaseModel):
-    configs: List[str]
-    architectures: List[str]
-    compilers: List[str]
+    configs: list[str]
+    architectures: list[str]
+    compilers: list[str]
 
 
 class LocalFilters(BaseModel):
-    issues: List[Tuple[str, Optional[int]]]
+    issues: list[tuple[str, Optional[int]]]
     origins: list[str]
     has_unknown_issue: bool
 
@@ -135,8 +141,8 @@ class DetailsFilters(BaseModel):
 
 
 class CommonDetailsTestsResponse(BaseModel):
-    tests: List[TestHistoryItem]
+    tests: list[TestHistoryItem]
 
 
 class CommonDetailsBootsResponse(BaseModel):
-    boots: List[TestHistoryItem]
+    boots: list[TestHistoryItem]

--- a/backend/kernelCI_app/typeModels/treeListing.py
+++ b/backend/kernelCI_app/typeModels/treeListing.py
@@ -72,17 +72,6 @@ class Checkout(CommonCheckouts):
         self.test_status += test_status
         self.boot_status += boot_status
 
-    def combine_tags(self, tags: list[Checkout__GitCommitTags]) -> None:
-        if not tags:
-            return
-
-        existing_tags = set(self.git_commit_tags)
-
-        for tag in tags:
-            if tag not in existing_tags:
-                existing_tags.add(tag)
-                self.git_commit_tags.append(tag)
-
 
 class CheckoutFast(CommonCheckouts):
     id: Checkout__Id


### PR DESCRIPTION
**New unit test coverage:** 44% to 45%

- Update conftest.py to include pytest for `typeModels` directory and futures
- Add unit tests for `common.py`, `commonDetails.py`, and `treeListing.py` in `typeModels`
- Remove `combine_tags` method in `treeListing.py` as it is not used and not working properly
- Update commonDetails to handle non json strings

# Related Issue
- Closes #1499