### PR TITLE
Organize logging env vars

### DIFF
--- a/.env.backend.example
+++ b/.env.backend.example
@@ -1,8 +1,14 @@
 ALLOWED_HOSTS=["backend", "localhost"]
 DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
-DEBUG=${DEBUG:-False}
 DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
 REDIS_HOST=redis
+
+SKIP_CRONJOBS=${SKIP_CRONJOBS:-False}
+
+DEBUG=${DEBUG:-False}
+DEBUG_DB_VARS=${DEBUG_DB_VARS:-False}
+ENABLE_LOGGING=${ENABLE_LOGGING:-False} # Logs all prints
+DEBUG_SQL_QUERY=${DEBUG_SQL_QUERY:-False} # Logs the SQL queries made
 
 DB_DEFAULT_PASSWORD_FILE=/run/secrets/postgres_password_secret
 DB_DEFAULT_HOST=cloudsql-proxy
@@ -15,6 +21,7 @@ DASH_DB_PASSWORD=${DASH_DB_PASSWORD:-admin}
 DASH_DB_HOST=dashboard_db
 DASH_DB_PORT=${DASH_DB_PORT:-5432}
 
+# Tells the backend to use DASH_DB as the default database
 USE_DASHBOARD_DB=${USE_DASHBOARD_DB:-False}
 
 # Check docs/monitoring.md docs for more context

--- a/backend/README.md
+++ b/backend/README.md
@@ -35,6 +35,8 @@ poetry env info --executable
 
 Start by exporting `DEBUG=True` in order to allow localhost connection and avoid CORS issues (**should NOT be set to True on production environments**).
 
+In order to check messages from the `log_message` function, also export `ENABLE_LOGGING=True`.
+
 It's possible to export `DEBUG_SQL_QUERY=True` if you want to see which SQL queries are made but it is quite verbose, so it's recommended to keep it as False unless needed.
 
 ### Databases
@@ -56,7 +58,7 @@ DB_DEFAULT="{
 }"
 ```
 > [!NOTE]
-> It is possible to have authentication issues when escaping special characters. In some cases, it is necessary to add more than one backslash, while in others, no addition is needed. To assist with this, when `DEBUG` is set to `True`, the default database info will be printed in the terminal, allowing you to determine if the characters got escaped as intended.
+> It is possible to have authentication issues when escaping special characters. In some cases, it is necessary to add more than one backslash, while in others, no addition is needed. To assist with this, you can export `DEBUG_DB_VARS=True` to check the database connection info in the terminal, allowing you to determine if the characters got escaped as intended. **This variable should NOT be set to True in production**.
 
 Along with the main database, the backend also connects to a secondary, local db made while we transition between database providers. It uses a simpler environment variable structure:
 ```sh
@@ -159,7 +161,7 @@ You can check that the cron jobs are listed inside the docker container with
 or
 ```docker exec -it dashboard-backend-1 poetry run ./manage.py crontab show```
 
-If you are a developer and want to skip the cron job setup while you're testing, you can also export the `SKIP_CRONJOBS` variable as `True` to skip cron jobs entirely.
+If you are a developer and want to skip the cron job setup while you're testing, you can also export `SKIP_CRONJOBS=True` to skip cron jobs entirely.
 
 
 ## Deploy instructions
@@ -187,9 +189,12 @@ In the `/requests` directory we have scripts that execute requests to endpoints 
 
 ## Debug
 
-For debugging we have two env variables
+For debugging we have four env variables:
 
-`DEBUG` and `DEBUG_SQL_QUERY` that can be set to `True` to enable debugging. The reason `DEBUG_SQL_QUERY` is separated is that it can be very verbose.
+- `DEBUG`: Required for local development, returns more data on errors, should not be set to True on production;
+- `DEBUG_SQL_QUERY`: logs every query made, can be verbose;
+- `DEBUG_DB_VARS`: logs the database connection vars, to check if the characters were escaped correctly, should not be set to True on production;
+- `ENABLE_LOGGING`: enables general debug logging.
 
 
 ## Discord Webhook Integration

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -191,7 +191,7 @@ EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
 
 # When running on docker it won't build without this variable,
 # the default value here is for when running locally
-BACKEND_VOLUME_DIR = get_json_env_var("BACKEND_VOLUME_DIR", "volume_data")
+BACKEND_VOLUME_DIR = os.environ.get("BACKEND_VOLUME_DIR", "volume_data")
 
 DATABASE_ROUTERS = ["kernelCI_app.routers.databaseRouter.DatabaseRouter"]
 
@@ -253,7 +253,7 @@ if DEBUG:
     print("DEBUG: DATABASES:", DATABASES)
 
 
-REDIS_HOST = get_json_env_var("REDIS_HOST", "127.0.0.1")
+REDIS_HOST = os.environ.get("REDIS_HOST", "127.0.0.1")
 
 CACHES = {
     "default": {
@@ -316,7 +316,7 @@ CORS_ALLOW_ALL_ORIGINS = is_boolean_or_string_true(
     os.environ.get("CORS_ALLOW_ALL_ORIGINS", False)
 )
 
-CACHE_TIMEOUT = int(get_json_env_var("CACHE_TIMEOUT", "180"))
+CACHE_TIMEOUT = int(os.environ.get("CACHE_TIMEOUT", "180"))
 
 if DEBUG:
     CORS_ALLOWED_ORIGIN_REGEXES = [
@@ -356,8 +356,8 @@ if DEBUG_SQL_QUERY:
         },
     }
 
-DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS = get_json_env_var(
-    "DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS", 30
+DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS = int(
+    os.environ.get("DEFAULT_ORIGIN_LISTING_INTERVAL_IN_DAYS", 30)
 )
 
 PROMETHEUS_METRICS_ENABLED = is_boolean_or_string_true(

--- a/backend/kernelCI_app/helpers/logger.py
+++ b/backend/kernelCI_app/helpers/logger.py
@@ -2,12 +2,19 @@ from django.http import HttpRequest
 
 from kernelCI_app.constants.general import PRODUCTION_HOST, STAGING_HOST
 from kernelCI_app.helpers.system import get_running_instance
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 # For logging that we care about, we create a function so we can easily use
 # a more sophisticated logging library later.
 def log_message(message: str) -> None:
-    print(message)
+    try:
+        logger.info(message)
+    except Exception:
+        print("LOGGER FAILED, using print as fallback")
+        print(message)
 
 
 def create_endpoint_notification(*, message: str, request: HttpRequest) -> str:


### PR DESCRIPTION
It should be possible to enable logging on staging and production without having to enable the `DEBUG` variable since the `DEBUG` variable also opens features that are not secure. So, a variable for logging is created and another one specific for debugging the db connection was also made.

## Changes
Adds two new env vars:
- `DEBUG_DB_VARS`: used to log the database connection, _including the connection password_, which should **not** be used in staging/production
- `ENABLE_LOGGING`: which is used to allow prints to go to the console without enabling the `DEBUG` env var (which changes more than just logging)

## How to test
- Add a log in the backend with the `log_message` function
- Export a permutation of the new variables and check if the log and the queries are being logged


Closes #1546