### PR TITLE
Fix metrics

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -365,7 +365,7 @@ PROMETHEUS_METRICS_ENABLED = is_boolean_or_string_true(
 )
 
 if PROMETHEUS_METRICS_ENABLED:
-    PROMETHEUS_METRICS_PORT = os.environ.get("PROMETHEUS_METRICS_PORT", 8001)
+    PROMETHEUS_METRICS_PORT = int(os.environ.get("PROMETHEUS_METRICS_PORT", 8001))
 
     def start_metrics_server():
         try:


### PR DESCRIPTION
This fixes are just minimal to run, they might be not right, so feel free to drop and reimplement proper ones if necessary.

1)We cannot use port 8001, as its used by staging instance, but env variable didnt work, small fix.
2)It didnt run with 5 gunicorn workers, at least i noticed errors, and this is way to lock/run metrics in first thread.