### PR TITLE
feat: break lines in hardware details results

### DIFF
--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -378,35 +378,33 @@ function HardwareDetails(): JSX.Element {
         }
       >
         <div className="flex flex-col pt-8">
-          <div className="flex items-center justify-between">
-            <div>
-              <Breadcrumb>
-                <BreadcrumbList>
-                  <BreadcrumbItem>
-                    <BreadcrumbLink
-                      to="/hardware"
-                      search={previousParams => {
-                        return {
-                          intervalInDays: previousParams.intervalInDays,
-                          origin: previousParams.origin,
-                          hardwareSearch: previousParams.hardwareSearch,
-                        };
-                      }}
-                      state={s => s}
-                    >
-                      <FormattedMessage id="hardware.path" />
-                    </BreadcrumbLink>
-                  </BreadcrumbItem>
-                  <BreadcrumbSeparator />
-                  <BreadcrumbItem>
-                    <BreadcrumbPage>
-                      <span>{hardwareId}</span>
-                    </BreadcrumbPage>
-                  </BreadcrumbItem>
-                </BreadcrumbList>
-              </Breadcrumb>
-            </div>
-            <p className="text-sm font-medium text-gray-900">
+          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between">
+            <Breadcrumb>
+              <BreadcrumbList>
+                <BreadcrumbItem>
+                  <BreadcrumbLink
+                    to="/hardware"
+                    search={previousParams => {
+                      return {
+                        intervalInDays: previousParams.intervalInDays,
+                        origin: previousParams.origin,
+                        hardwareSearch: previousParams.hardwareSearch,
+                      };
+                    }}
+                    state={s => s}
+                  >
+                    <FormattedMessage id="hardware.path" />
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbPage>
+                    <span>{hardwareId}</span>
+                  </BreadcrumbPage>
+                </BreadcrumbItem>
+              </BreadcrumbList>
+            </Breadcrumb>
+            <p className="gap-2 text-sm font-medium text-gray-900 lg:gap-0">
               <FormattedMessage
                 id="hardwareDetails.timeFrame"
                 values={{


### PR DESCRIPTION
For md and sm screens, we should break lines for better readability

## Related Issue
- closes #1431

## How to test it

See the difference between local and prod environments:
- http://localhost:5173/hardware/aaeon-UPN-EHLX4RE-A10-0864?et=1759924800&st=1759492800
- https://dashboard.kernelci.org/hardware/aaeon-UPN-EHLX4RE-A10-0864?et=1759924800&st=1759492800

## Visual Reference
**Current**
<img width="296" height="109" alt="image" src="https://github.com/user-attachments/assets/c4b50d80-ae97-487f-85ad-5301a2e9c201" />

**Before**
<img width="296" height="109" alt="image" src="https://github.com/user-attachments/assets/181576bb-ff85-429f-a8dc-61710d0f7250" />
