### PR TITLE
Feat: add tests_origin_time_platform index

### DIFF
--- a/backend/docs/database-logic.md
+++ b/backend/docs/database-logic.md
@@ -134,4 +134,6 @@ Django also creates some indexes automatically:
 - Index for foreign key as b-tree;
 - Index for foreign key as b-tree with `text_pattern_ops`, specialized for `LIKE` operations.
 
-One of the operations that we are doing benefits from this double indexes, which is the filtering of dummy builds (builds where id LIKE `maestro:_dummy%`)
+One of the operations that we are doing benefits from this double indexes, which is the filtering of dummy builds (builds where id LIKE `maestro:_dummy%`).
+
+There is only one index that diverges from model to database, which is `tests_origin_time_platform`. This is because we want an index on the json field `environment_misc ->> 'platform'` -- with `->>` -- but Django only uses `->` (check https://docs.djangoproject.com/en/5.2/topics/db/queries/#module-django.db.models.fields.json). The divergence is created in the migration where this index is added.

--- a/backend/kernelCI_app/migrations/0009_add_test_origin_start_time_platform_index.py
+++ b/backend/kernelCI_app/migrations/0009_add_test_origin_start_time_platform_index.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for `CONCURRENTLY`
+
+    dependencies = [
+        ("kernelCI_app", "0008_add_incidents_indexes"),
+    ]
+
+    operations = [
+        # Rename existing index so that we can reuse it.
+        # The existing index exceeds the maximum index name length for django (30 chars).
+        migrations.RunSQL(
+            "ALTER INDEX IF EXISTS tests_origin_start_time_platform_idx RENAME TO tests_origin_time_platform;"
+        ),
+        # Using separate operations because the indexes were already created with kcidb
+        # and we can only use `IF NOT EXISTS` with raw SQL; we then also need to tell Django
+        # that the models have been updated with the indexes.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    "CREATE INDEX CONCURRENTLY IF NOT EXISTS tests_origin_time_platform"
+                    " ON tests (origin, start_time) WHERE (environment_misc ->> 'platform') IS NOT NULL;",
+                    reverse_sql="DROP INDEX IF EXISTS tests_origin_time_platform;",
+                ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="tests",
+                    index=models.Index(
+                        condition=models.Q(
+                            ("environment_misc__platform__isnull", False)
+                        ),
+                        fields=["origin", "start_time"],
+                        name="tests_origin_time_platform",
+                    ),
+                ),
+            ],
+        ),
+    ]


### PR DESCRIPTION
This index helps in the hardware listing query, being very specific but very helpful.
At the time of coding, this index was already added manually to the database, so some workarounds have to be made. The renaming is required because Django has a limit of 30 characters for index names.

Check Django's documentation on the index condition:
- See the PostgreSQL comment on https://docs.djangoproject.com/en/5.2/topics/db/queries/#module-django.db.models.fields.json
- Also check out the next section, https://docs.djangoproject.com/en/5.2/topics/db/queries/#complex-lookups-with-q-objects

## Changes
- Added new index in tests model
- Added new migration manually
- Updated docs

## How to test
Up the database and run the migrations. You should see the new index in the tests table.
You can use the following query to see all tests indexes:
```
SELECT
    *
FROM
    pg_indexes
WHERE
    tablename = 'tests';
```
Also test when the old index name is present, it should rename it first.


Closes #1578