### PR TITLE
feat: update grafana dashboard json to have all-time and range modes

### DIFF
--- a/monitoring/dashboard.json
+++ b/monitoring/dashboard.json
@@ -301,6 +301,25 @@
               {
                 "id": "decimals",
                 "value": 3
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "match": "null",
+                      "result": {
+                        "index": 0,
+                        "text": "0"
+                      }
+                    },
+                    "type": "special"
+                  }
+                ]
+              },
+              {
+                "id": "noValue",
+                "value": "0"
               }
             ]
           },
@@ -365,7 +384,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(django_http_requests_latency_seconds_by_view_method_count{view!=\"<unnamed view>\"}) by (view, method)",
+          "expr": "(sum(django_http_requests_latency_seconds_by_view_method_count{view!=\"<unnamed view>\"}) by (view, method)  and on() label_replace(vector(1), \"mode\", \"$summary_mode\", \"\", \"\")==label_replace(vector(1), \"mode\", \"all\", \"\", \"\") or round(sum(increase(django_http_requests_latency_seconds_by_view_method_count{view!=\"<unnamed view>\"}[$__range:])) by (view, method)) and on() label_replace(vector(1), \"mode\", \"$summary_mode\", \"\", \"\")==label_replace(vector(1), \"mode\", \"range\", \"\", \"\"))",
           "format": "table",
           "instant": true,
           "legendFormat": "{{view}} - {{method}}",
@@ -378,7 +397,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(django_http_requests_latency_seconds_by_view_method_sum{view!=\"<unnamed view>\"}) by (view, method)",
+          "expr": "(sum(django_http_requests_latency_seconds_by_view_method_sum{view!=\"<unnamed view>\"}) by (view, method) and on() label_replace(vector(1), \"mode\", \"$summary_mode\", \"\", \"\")==label_replace(vector(1), \"mode\", \"all\", \"\", \"\") or sum(increase(django_http_requests_latency_seconds_by_view_method_sum{view!=\"<unnamed view>\"}[$__range:])) by (view, method) and on() label_replace(vector(1), \"mode\", \"$summary_mode\", \"\", \"\")==label_replace(vector(1), \"mode\", \"range\", \"\", \"\"))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -504,7 +523,24 @@
     "performance"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": { "selected": false, "text": "Time Range", "value": "range" },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "label": "Summary Mode",
+        "name": "summary_mode",
+        "options": [
+          { "selected": false, "text": "All Time", "value": "all" },
+          { "selected": true, "text": "Time Range", "value": "range" }
+        ],
+        "query": "all,range",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",
@@ -514,6 +550,6 @@
   "timezone": "",
   "title": "KernelCI - Performance Dashboard",
   "uid": "kernelci-performance-dashboard",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Add time range toggle functionality to the KernelCI performance monitoring dashboard, allowing to switch between "All Time" and "Time Range" metrics display modes.

### Problem Solved

The monitoring dashboard previously only showed metrics for the current time range, limiting the ability to view historical performance data.

### Key Changes

- Added summary_mode template variable with "All Time" and "Time Range" options
- Enhanced dashboard queries to handle both aggregated and time-range specific metrics
- Implemented conditional logic for metrics display based on selected mode

### How to Test

#### 1. Setup Monitoring Environment

- Follow the instructions in [monitoring.md](https://github.com/kernelci/dashboard/blob/main/docs/monitoring.md) to start the monitoring services and backend with metrics enabled.

#### 2. Test the New Time Range Toggle Feature
1. Access the Dashboard
2. Find the new "summary_mode" dropdown in the dashboard controls
4. Select "Time Range" from the dropdown
5. Verify metrics show data for the current selected time range
6. Check that latency and request count metrics display correctly
7. Select "All Time" from the dropdown
8. Verify metrics show aggregated data across all available time periods
9. Confirm that the same metrics are displayed but with different aggregation
10. Toggle between both modes and ensure metrics update dynamically

### Visual Reference

> Before, the summary mode toggle didn't exists, so it was impossible to switch the summary between all-time data and ranged, you can see the toggle working in the video below

[Screencast from 2025-10-23 15-26-48.webm](https://github.com/user-attachments/assets/58cb87b9-e174-4eea-8e32-26d4bb57e09f)

Closes #1580