### PR TITLE
Feat: add group cc to microsoft summary

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -150,6 +150,7 @@ else:
                 "notifications",
                 "--action=summary",
                 "--to=kernelcialerts@microsoft.com",
+                "--cc=kernelci-results@groups.io",
                 "--ignore-recipients",
                 "--send",
                 "--yes",

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -597,8 +597,9 @@ def run_checkout_summary(
                 boot_status_group=boot_status_group,
                 test_status_group=test_status_group,
             )
+            origin_tag = f"[{origin.upper()}]" if origin != "maestro" else ""
             report["title"] = (
-                f"[STATUS] {tree_name}/{branch} - {record["git_commit_hash"]}"
+                f"[STATUS]{origin_tag} {tree_name}/{branch} - {record["git_commit_hash"]}"
             )
 
             recipients = process_submission_options(


### PR DESCRIPTION
## Changes
- Adds cc to the mailing list on microsoft's summary notifications
- Adds an origin tag for origins different than maestro (so that users can differentiate them in the main mailing list)

Example of the new title (email subject) for origins different than maestro:
`Subject: [STATUS][MICROSOFT] mainline/master - 43e9ad0c55a369ecc84a4788d06a8a6bfa634f1c`

## How to test
- Run the notification command on the different origins and check the `to`/`cc` and also the tags at the report title


Part of #1564