### PR TITLE
Feat: add build lab table column

### DIFF
--- a/backend/kernelCI_app/helpers/misc.py
+++ b/backend/kernelCI_app/helpers/misc.py
@@ -5,10 +5,15 @@ from kernelCI_app.utils import string_to_json
 
 class Misc(TypedDict):
     platform: str
+    lab: Optional[str]
 
 
 def handle_misc(misc: Union[str, dict, None]) -> Optional[Misc]:
-    """Handle misc data (environment or build) by parsing JSON string or dict."""
+    """
+    Handle misc data (environment or build) by parsing JSON string or dict.
+    Also sets some default values and returns only the necessary fields.
+    """
+
     parsed_misc: Misc = {}
 
     if isinstance(misc, str):
@@ -19,6 +24,8 @@ def handle_misc(misc: Union[str, dict, None]) -> Optional[Misc]:
         return None
 
     parsed_misc["platform"] = misc.get("platform", UNKNOWN_STRING)
+    if "lab" in misc:
+        parsed_misc["lab"] = misc.get("lab")
 
     return parsed_misc
 

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -39,6 +39,7 @@ def get_issue_builds(*, issue_id: str, version: Optional[int]) -> list[dict]:
             B.DURATION,
             B.COMPILER,
             B.LOG_URL,
+            B.MISC,
             C.TREE_NAME,
             C.GIT_REPOSITORY_BRANCH,
             C.GIT_REPOSITORY_URL

--- a/backend/kernelCI_app/typeModels/issueDetails.py
+++ b/backend/kernelCI_app/typeModels/issueDetails.py
@@ -9,6 +9,7 @@ from kernelCI_app.typeModels.databases import (
     Build__Id,
     Build__Architecture,
     Build__ConfigName,
+    Build__Misc,
     Build__Status,
     Build__StartTime,
     Build__Duration,
@@ -60,6 +61,7 @@ class IssueBuildItem(BaseModel):
     log_url: Build__LogUrl
     tree_name: Checkout__TreeName
     git_repository_branch: Checkout__GitRepositoryBranch
+    misc: Build__Misc
 
 
 class IssueTestItem(BaseModel):

--- a/backend/kernelCI_app/views/issueDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/issueDetailsBuildsView.py
@@ -3,6 +3,7 @@ from typing import Optional
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
+from kernelCI_app.helpers.misc import handle_misc
 from kernelCI_app.typeModels.commonOpenApiParameters import ISSUE_ID_PATH_PARAM
 from kernelCI_app.typeModels.issueDetails import (
     IssueBuildsResponse,
@@ -38,6 +39,9 @@ class IssueDetailsBuilds(APIView):
         builds_data = get_issue_builds(
             issue_id=path_params.issue_id, version=query_params.version
         )
+
+        for build in builds_data:
+            build["misc"] = handle_misc(build.get("misc"))
 
         if not builds_data:
             return create_api_error_response(

--- a/dashboard/src/components/BuildsTable/DefaultBuildsColumns.tsx
+++ b/dashboard/src/components/BuildsTable/DefaultBuildsColumns.tsx
@@ -15,6 +15,7 @@ import {
   MoreDetailsTableHeader,
 } from '@/components/Table/DetailsColumn';
 import { getBuildStatusGroup } from '@/utils/status';
+import { UNKNOWN_STRING } from '@/utils/constants/backend';
 
 export const defaultBuildColumns: ColumnDef<AccordionItemBuilds>[] = [
   {
@@ -38,6 +39,16 @@ export const defaultBuildColumns: ColumnDef<AccordionItemBuilds>[] = [
     header: ({ column }): JSX.Element => (
       <TableHeader column={column} intlKey="global.compiler" />
     ),
+  },
+  {
+    id: 'lab',
+    accessorKey: 'lab',
+    header: ({ column }): JSX.Element => (
+      <TableHeader column={column} intlKey="global.lab" />
+    ),
+    cell: ({ row }): string => {
+      return row.getValue('lab') || UNKNOWN_STRING;
+    },
   },
   {
     accessorKey: 'date',

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -143,6 +143,7 @@ export const messages = {
     'global.info': 'Info',
     'global.issues': 'Issues',
     'global.kcidev': 'kci-dev',
+    'global.lab': 'Lab',
     'global.last': 'Last',
     'global.legend': 'Legend',
     'global.loading': 'Loading...',

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -83,6 +83,7 @@ export type BuildsTableBuild = Pick<
   | 'log_url'
   | 'tree_name'
   | 'git_repository_branch'
+  | 'misc'
 >;
 
 export type StatusCount = {

--- a/dashboard/src/types/tree/TreeDetails.tsx
+++ b/dashboard/src/types/tree/TreeDetails.tsx
@@ -28,6 +28,7 @@ export type AccordionItemBuilds = {
   buildLogs?: string;
   kernelConfig?: string;
   treeBranch?: string;
+  lab?: string;
 };
 
 export interface TTreeDetailsFilter

--- a/dashboard/src/utils/utils.ts
+++ b/dashboard/src/utils/utils.ts
@@ -135,6 +135,7 @@ export const sanitizeBuilds = (
     buildLogs: build.log_url,
     kernelConfig: build.config_url,
     treeBranch: buildTreeBranch(build.tree_name, build.git_repository_branch),
+    lab: typeof build.misc?.lab === 'string' ? build.misc.lab : undefined,
   }));
 };
 
@@ -152,6 +153,7 @@ export const sanitizeBuildTable = (
     status: build.status,
     buildLogs: build.log_url,
     treeBranch: buildTreeBranch(build.tree_name, build.git_repository_branch),
+    lab: typeof build.misc?.lab === 'string' ? build.misc.lab : undefined,
   }));
 };
 


### PR DESCRIPTION
## Changes
- Removed old use of some build misc fields, which were not only unused but also incorrect
- Added build lab to the build tables, wherever it appears
- Changed some backend functions to be able to retrieve the build misc lab

## How to test
Check where there are build tables (treeDetails, hardwareDetails, issueDetails) and check the new column after "compiler"

Closes #1595 

## Visual reference
<img width="1566" height="960" alt="image" src="https://github.com/user-attachments/assets/eba513d0-b3ec-4413-9944-76306d38e6a6" />
