### PR TITLE
feat(notifications): add hardware_summary action

### DIFF
--- a/backend/data/notifications/example-hardware-subscription.yaml
+++ b/backend/data/notifications/example-hardware-subscription.yaml
@@ -1,0 +1,9 @@
+# Add a subscription file for your hardware platform by following this format.
+# Place the file under: dashboard/backend/data/notifications/subscriptions
+# The file name must end with _hardware.yml or _hardware.yaml
+
+qcs9100-ride: # The hardware platform name
+  origin: maestro
+  default_recipients:
+    - Recipient One <Recipient1@example.com>
+    - Recipient Two <Recipient2@example.com>

--- a/backend/data/notifications/subscriptions/qcs615_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs615_hardware.yaml
@@ -1,0 +1,8 @@
+qcs615-ride:
+  origin: maestro
+  default_recipients:
+    - Trilok Soni <tsoni@quicinc.com>
+    - Shiraz Hashim <shashim@qti.qualcomm.com>
+    - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
+    - Yijie Yang <yijie.yang@oss.qualcomm.com>
+    - Yushan Li <yushan.li@oss.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs6490_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs6490_hardware.yaml
@@ -1,0 +1,8 @@
+qcs6490-rb3gen2:
+  origin: maestro
+  default_recipients:
+    - Trilok Soni <tsoni@quicinc.com>
+    - Shiraz Hashim <shashim@qti.qualcomm.com>
+    - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
+    - Yijie Yang <yijie.yang@oss.qualcomm.com>
+    - Yushan Li <yushan.li@oss.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs8300_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs8300_hardware.yaml
@@ -1,0 +1,8 @@
+qcs8300-ride:
+  origin: maestro
+  default_recipients:
+    - Trilok Soni <tsoni@quicinc.com>
+    - Shiraz Hashim <shashim@qti.qualcomm.com>
+    - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
+    - Yijie Yang <yijie.yang@oss.qualcomm.com>
+    - Yushan Li <yushan.li@oss.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs9100_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs9100_hardware.yaml
@@ -1,0 +1,8 @@
+qcs9100-ride:
+  origin: maestro
+  default_recipients:
+    - Trilok Soni <tsoni@quicinc.com>
+    - Shiraz Hashim <shashim@qti.qualcomm.com>
+    - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
+    - Yijie Yang <yijie.yang@oss.qualcomm.com>
+    - Yushan Li <yushan.li@oss.qualcomm.com>

--- a/backend/data/notifications/subscriptions/x1e80100_hardware.yaml
+++ b/backend/data/notifications/subscriptions/x1e80100_hardware.yaml
@@ -1,0 +1,8 @@
+x1e80100:
+  origin: maestro
+  default_recipients:
+    - Trilok Soni <tsoni@quicinc.com>
+    - Shiraz Hashim <shashim@qti.qualcomm.com>
+    - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
+    - Yijie Yang <yijie.yang@oss.qualcomm.com>
+    - Yushan Li <yushan.li@oss.qualcomm.com>

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -169,6 +169,16 @@ else:
                 "--summary-origins=maestro",
             ],
         ),
+        (
+            "33 3 * * 1",
+            "django.core.management.call_command",
+            [
+                "notifications",
+                "--action=hardware_summary",
+                "--send",
+                "--yes",
+            ],
+        ),
     ]
 
 # Email settings for SMTP backend

--- a/backend/kernelCI_app/helpers/hardwares.py
+++ b/backend/kernelCI_app/helpers/hardwares.py
@@ -1,0 +1,50 @@
+from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.hardwareListing import HardwareItem
+
+
+def sanitize_hardware(
+    hardware: dict,
+) -> HardwareItem:
+    """Sanitizes a HardwareItem that was returned by a 'hardwarelisting-like' query
+
+    Returns a HardwareItem object"""
+    hardware_name = hardware["hardware"]
+    platform = hardware["platform"]
+
+    build_status_summary = StatusCount(
+        PASS=hardware["pass_builds"],
+        FAIL=hardware["fail_builds"],
+        NULL=hardware["null_builds"],
+        ERROR=hardware["error_builds"],
+        MISS=hardware["miss_builds"],
+        DONE=hardware["done_builds"],
+        SKIP=hardware["skip_builds"],
+    )
+
+    test_status_summary = StatusCount(
+        PASS=hardware["pass_tests"],
+        FAIL=hardware["fail_tests"],
+        NULL=hardware["null_tests"],
+        ERROR=hardware["error_tests"],
+        MISS=hardware["miss_tests"],
+        DONE=hardware["done_tests"],
+        SKIP=hardware["skip_tests"],
+    )
+
+    boot_status_summary = StatusCount(
+        PASS=hardware["pass_boots"],
+        FAIL=hardware["fail_boots"],
+        NULL=hardware["null_boots"],
+        ERROR=hardware["error_boots"],
+        MISS=hardware["miss_boots"],
+        DONE=hardware["done_boots"],
+        SKIP=hardware["skip_boots"],
+    )
+
+    return HardwareItem(
+        hardware=hardware_name,
+        platform=platform,
+        test_status_summary=test_status_summary,
+        boot_status_summary=boot_status_summary,
+        build_status_summary=build_status_summary,
+    )

--- a/backend/kernelCI_app/management/commands/templates/hardware_report.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/hardware_report.txt.j2
@@ -1,0 +1,32 @@
+{% extends "base.txt" %}
+{% block header %}{% endblock %}
+{% block content %}
+Hello,
+
+Status summary for {{ hardware_id }}
+
+Builds:{{ "\t" }}{{ "{:>5}".format(build_status_group["success"]) }} ✅
+{{- "{:>5}".format(build_status_group["failed"]) }} ❌
+{{- "{:>5}".format(build_status_group["inconclusive"]) }} ⚠️
+Boots: {{ "\t" }}{{ "{:>5}".format(boot_status_group["success"]) }} ✅
+{{- "{:>5}".format(boot_status_group["failed"]) }} ❌
+{{- "{:>5}".format(boot_status_group["inconclusive"]) }} ⚠️
+Tests: {{ "\t" }}{{ "{:>5}".format(test_status_group["success"]) }} ✅
+{{- "{:>5}".format(test_status_group["failed"]) }} ❌
+{{- "{:>5}".format(test_status_group["inconclusive"]) }} ⚠️
+-------------
+{% for data in hardware_data %}
+#kernelci test {{ data["id"] }}
+- Path: {{ data["path"] }}
+- Status: {{ data["status"] }}
+- Comment: {{ data["comment"] }}
+- Starttime: {{ data["start_time"] }}
+- Tree: {{ data["tree_name"] }}/{{ data["git_repository_branch"] }}
+- Origin: {{ data["test_origin"] }}
+- Test_lab: {{ data["runtime"] }}
+- Lava_job_id: {{ data["job_id"] }}
+- Commit: {{ data["git_commit_hash"] }}
+- Dashboard: https://dashboard.kernelci.org/test/{{ data["id"] }}
+-------------
+{% endfor %}
+{%- endblock -%}

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -26,6 +26,8 @@ The command supports four primary actions:
         * Report for all pending issues
 1. `summary`
     * Runs a checkout summary report for trees listed in the [subscriptions folder](../backend/data/notifications/subscriptions/).
+1. `hardware_summary`
+    * Generate weekly hardware reports for hardware listed in the [subscriptions folder](../backend/data/notifications/subscriptions/). Emails are sent only for hardware with failed tests.
 1.  `fake_report`
     * Generates a fake report (for  testing email send).
 
@@ -54,6 +56,7 @@ These options are available for all actions and are always optional:
 | `--summary-signup-folder` | `summary` | Optional | Alternative signup folder under `/backend/data` |
 | `--summary-origins` | `summary` | Optional | Comma-separated list to limit to specific origins |
 | `--skip-sent-reports` | `summary` | Optional | Skip reports that have already been sent |
+| `--hardware-origins` | `hardware_summary` | Optional | Comma-separated list to limit to specific origins |
 | `--tree` | `fake_report` | Optional | Add recipients for the given tree name |
 
 


### PR DESCRIPTION
### Description
Add a new hardware_summary action to the notifications management command. 
This action generates hardware reports based on the hardware subscription files.
### Changes
- Add a new `hardware_summary` action to the notifications command with CLI argument.
- Add functions to parse hardware subscription files, query hardware data, and normalize hardware results.
- Add Jinja template for email reports.
- Add example and Qualcomm hardware subscription files.
### How to Test
Run the following command to generate the hardware summary report:
```bash
poetry run python manage.py notifications --action hardware_summary 
```
### Related Issue
Closes #1081 