### PR TITLE
backend: notifications: move kernelci Reported-by tag up

### DIFF
--- a/backend/kernelCI_app/management/commands/templates/issue_boot.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/issue_boot.txt.j2
@@ -25,6 +25,10 @@ Log excerpt:
 =====================================================
 {% endif %}
 
+Include the KernelCI tag when submitting fixes:
+
+Reported-by: kernelci.org bot <bot@kernelci.org>
+
 # Hardware platforms affected:
 {% for boot in boots %}
 ## {{boot["platform"]}}
@@ -44,7 +48,5 @@ Log excerpt:
 {% endfor %}
 
 #kernelci issue {{ issue["id"] }}
-
-Reported-by: kernelci.org bot <bot@kernelci.org>
 
 {%- endblock -%}

--- a/backend/kernelCI_app/management/commands/templates/issue_build.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/issue_build.txt.j2
@@ -24,6 +24,10 @@ Log excerpt:
 =====================================================
 {% endif %}
 
+Include the KernelCI tag when submitting fixes:
+
+Reported-by: kernelci.org bot <bot@kernelci.org>
+
 # Builds where the incident occurred:
 {% for build in builds %}
 ## {{ build["config_name"] }} on ({{ build["architecture"] }}):
@@ -33,7 +37,5 @@ Log excerpt:
 {% endfor %}
 
 #kernelci issue {{ issue["id"] }}
-
-Reported-by: kernelci.org bot <bot@kernelci.org>
 
 {%- endblock -%}


### PR DESCRIPTION
Our tag was at the end of the report, which makes some people miss it when looking at the report.

That results in fixes being sent upstream without our Reported-by tag being added.