### PR TITLE
Remove old grafana references

### DIFF
--- a/backend/docs/database-logic.md
+++ b/backend/docs/database-logic.md
@@ -5,7 +5,6 @@ that we should know
 
 
 There are some resources that can be used as reference:
-- [Grafana Dashboard](https://kcidb.kernelci.org/d/home/)
 - [Submitter guide](https://docs.kernelci.org/kcidb/submitter_guide/)
 - [kcidb json schema](https://github.com/kernelci/kcidb-io/blob/main/kcidb_io/schema/v05_03.py)
 

--- a/backend/kernelCI_app/management/commands/templates/issues.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/issues.txt.j2
@@ -14,7 +14,6 @@ Build regressions:
 - Commit HEAD: {{ issue["git_commit_hash"] }}
 - Incidents Count: {{issue["incident_count"]}}
 - Dashboard: https://d.kernelci.org/issue/{{ issue["id"] }}
-- Grafana: https://grafana.kernelci.org/d/issue/issue?var-id={{ issue["id"] }}
 ---
 {% endfor %}
 {% endif %}
@@ -30,7 +29,6 @@ Boot regressions:
 - Commit HEAD: {{ issue["git_commit_hash"] }}
 - Incidents Count: {{issue["incident_count"]}}
 - Dashboard: https://d.kernelci.org/issue/{{ issue["id"] }}
-- Grafana: https://grafana.kernelci.org/d/issue/issue?var-id={{ issue["id"] }}
 ---
 {% endfor %}
 {% endif %}

--- a/dashboard/src/components/SideMenu/SideMenu.tsx
+++ b/dashboard/src/components/SideMenu/SideMenu.tsx
@@ -68,10 +68,6 @@ const dashboardItems: LinkStringItems[] = [
     url: 'https://netdev.bots.linux.dev/contest.html',
     label: 'netdev-CI',
   },
-  {
-    url: 'https://grafana.kernelci.org/d/home',
-    label: 'Grafana',
-  },
 ];
 
 type SideMenuItemProps = {


### PR DESCRIPTION
As described in the linked issue, the old grafana dashboards (including https://grafana.kernelci.org/d/home/home?orgId=1 and https://kcidb.kernelci.org/d/home/home) have been turned off with the removal of Google infra.

## Changes
- Edits issue notifications, sideMenu link, and a backend doc


## Visual References and Examples
<table>
  <tr>
    <th> Before </th>
    <th> After </th>
  </tr>
  <tr>
    <td>
      <img alt="image" src="https://github.com/user-attachments/assets/3cdc96b1-5133-4e5b-8084-f70870a1f0c8" />
    </td>
    <td>
      <img alt="image" src="https://github.com/user-attachments/assets/a5824c58-90dd-43b2-84d0-3167826dae9f" />
    </td>
  </tr>
</table>

Issue notifications before:
```
...
#kernelci issue maestro:72940b40f28b010e55f79c1d33319eb611d93d3c
- Comment:  error: cannot open arch/riscv/kernel/vdso/vdso-dummy.o: No such file or directory in arch/riscv/kernel/vdso/vdso-syms.o (arch/riscv/kernel/vdso/Makefile:49) [logspec:kbuild,kbuild.compiler.linker_error]
- Timestamp: 2025-10-17 22:51:35.105180+00:00
- Tree: android/android11-5.4
- Origin: maestro
- Commit HEAD: 59683ca0a0d60673dbe6da6fe8286a4a96814f09
- Incidents Count: 3
- Dashboard: https://d.kernelci.org/issue/maestro:72940b40f28b010e55f79c1d33319eb611d93d3c
- Grafana: https://grafana.kernelci.org/d/issue/issue?var-id=maestro:72940b40f28b010e55f79c1d33319eb611d93d3c
---
...
```

Issue notifications after:
```
...
#kernelci issue maestro:72940b40f28b010e55f79c1d33319eb611d93d3c
- Comment:  error: cannot open arch/riscv/kernel/vdso/vdso-dummy.o: No such file or directory in arch/riscv/kernel/vdso/vdso-syms.o (arch/riscv/kernel/vdso/Makefile:49) [logspec:kbuild,kbuild.compiler.linker_error]
- Timestamp: 2025-10-17 22:51:35.105180+00:00
- Tree: android/android11-5.4
- Origin: maestro
- Commit HEAD: 59683ca0a0d60673dbe6da6fe8286a4a96814f09
- Incidents Count: 3
- Dashboard: https://d.kernelci.org/issue/maestro:72940b40f28b010e55f79c1d33319eb611d93d3c
---
...
```



Closes #1620