### PR TITLE
chore: bump kcidb-io version

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -885,7 +885,7 @@ dev = ["flake8", "pylint", "pytest"]
 type = "git"
 url = "https://github.com/kernelci/kcidb-io.git"
 reference = "HEAD"
-resolved_reference = "de0b71bef26ccaf2fbcd01a5828af8e0aefb1c4e"
+resolved_reference = "6cff0df92a282caf6a3e44eb0d2a8d2808676f2d"
 
 [[package]]
 name = "markupsafe"


### PR DESCRIPTION
## Objective
Update the kcidb-io dependency to the latest version from the upstream repository.

## Key Changes
- Updated kcidb-io resolved reference from `de0b71b` to `6cff0df` in poetry.lock