### PR TITLE
chore: bump django version from 5.1.14 to 5.2.8

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -380,18 +380,18 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "django"
-version = "5.1.14"
+version = "5.2.8"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "django-5.1.14-py3-none-any.whl", hash = "sha256:2a4b9c20404fd1bf50aaaa5542a19d860594cba1354f688f642feb271b91df27"},
-    {file = "django-5.1.14.tar.gz", hash = "sha256:b98409fb31fdd6e8c3a6ba2eef3415cc5c0020057b43b21ba7af6eff5f014831"},
+    {file = "django-5.2.8-py3-none-any.whl", hash = "sha256:37e687f7bd73ddf043e2b6b97cfe02fcbb11f2dbb3adccc6a2b18c6daa054d7f"},
+    {file = "django-5.2.8.tar.gz", hash = "sha256:23254866a5bb9a2cfa6004e8b809ec6246eba4b58a7589bc2772f1bcc8456c7f"},
 ]
 
 [package.dependencies]
-asgiref = ">=3.8.1,<4"
+asgiref = ">=3.8.1"
 sqlparse = ">=0.3.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 


### PR DESCRIPTION
Upgrade Django from version 5.1.14 to 5.2.8 to leverage new features and improvements in the latest stable release.

## Problem Solved
The current Django version (5.1.x) lacks support for modern database features that will improve our data modeling capabilities, particularly composite primary keys which are essential for optimizing our database schema.

## Impact
This upgrade enables the use of composite primary keys feature, allowing us to define multi-column primary keys directly in our models. This will reduce redundant indexes and provide better support for complex relationships in our data models. Additionally, we gain access to other Django 5.2 improvements including enhanced query optimization and security updates.