### PR TITLE
Fix(ui): make cards group to the right

### DIFF
--- a/dashboard/src/components/Tabs/TabGrid.tsx
+++ b/dashboard/src/components/Tabs/TabGrid.tsx
@@ -18,13 +18,13 @@ const ResponsiveDetailsGrid = ({
   const leftTopCards = topCards.slice(0, midIndex);
   const rightTopCards = topCards.slice(midIndex);
 
-  const midBodyIndex = Math.ceil(bodyCards.length / 2);
+  const midBodyIndex = Math.floor(bodyCards.length / 2);
   const leftBodyCards = bodyCards.slice(0, midBodyIndex);
   const rightBodyCards = bodyCards.slice(midBodyIndex);
 
   return (
     <>
-      <div className="hidden grid-cols-2 gap-4 min-2xl:grid">
+      <div className="hidden grid-cols-2 gap-4 2xl:grid">
         <div>
           {leftTopCards}
           {leftBodyCards}
@@ -35,7 +35,7 @@ const ResponsiveDetailsGrid = ({
         </div>
         <div className="col-span-2">{footerCards}</div>
       </div>
-      <div className="min-2xl:hidden">
+      <div className="2xl:hidden">
         {topCards}
         <div className="grid grid-cols-1 lg:grid-cols-2 lg:gap-x-8">
           <div>{leftBodyCards}</div>


### PR DESCRIPTION
When the origin card is not visible, there would be 3 cards to the left and 1 to the right

## Visual reference

Before:
<img width="1437" height="908" alt="image" src="https://github.com/user-attachments/assets/3ebebe3e-42da-49f5-8b45-44f653fba5a6" />

After:
<img width="1437" height="908" alt="image" src="https://github.com/user-attachments/assets/a7a59eb4-efb5-4848-aad9-aa0b6a6f9bb8" />

Before:
<img width="1697" height="1016" alt="image" src="https://github.com/user-attachments/assets/c916b1c2-7434-456d-9892-966a8f99c2a6" />

After:
<img width="1697" height="1016" alt="image" src="https://github.com/user-attachments/assets/63ab0dd5-3d04-4582-8a09-7cec1a301897" />
