### PR TITLE
fix: show hardware/tree table even when no data is available

### DIFF
--- a/dashboard/src/components/IssueTable/IssueTable.tsx
+++ b/dashboard/src/components/IssueTable/IssueTable.tsx
@@ -20,6 +20,7 @@ import type { LinkProps } from '@tanstack/react-router';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
 import { useCallback, useMemo, useState } from 'react';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -45,6 +46,9 @@ import { valueOrEmpty } from '@/lib/string';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 import { shouldShowRelativeDate } from '@/lib/date';
 import { RedirectFrom } from '@/types/general';
+
+import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
+import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 const getLinkProps = (
   row: Row<IssueListingTableItem>,
@@ -178,9 +182,19 @@ const columns: ColumnDef<IssueListingTableItem>[] = [
 
 interface IIssueTable {
   issueListing?: IssueListingResponse;
+  status?: UseQueryResult['status'];
+  queryData?: unknown;
+  error?: Error | null;
+  isLoading?: boolean;
 }
 
-export const IssueTable = ({ issueListing }: IIssueTable): JSX.Element => {
+export const IssueTable = ({
+  issueListing,
+  status,
+  queryData,
+  error,
+  isLoading,
+}: IIssueTable): JSX.Element => {
   const { listingSize } = useSearch({ from: '/_main/issues' });
   const navigate = useNavigate({ from: '/issues' });
 
@@ -261,7 +275,7 @@ export const IssueTable = ({ issueListing }: IIssueTable): JSX.Element => {
     ) : (
       <TableRow>
         <TableCell colSpan={columns.length} className="h-24 text-center">
-          <FormattedMessage id="global.noResults" />
+          <FormattedMessage id="issueListing.notFound" />
         </TableCell>
       </TableRow>
     );
@@ -279,9 +293,22 @@ export const IssueTable = ({ issueListing }: IIssueTable): JSX.Element => {
 
   return (
     <>
-      <BaseTable headerComponents={tableHeaders}>
-        <TableBody>{tableBody}</TableBody>
-      </BaseTable>
+      <QuerySwitcher
+        status={status}
+        data={queryData}
+        error={error}
+        customError={
+          <MemoizedSectionError
+            isLoading={isLoading}
+            errorMessage={error?.message}
+            emptyLabel="issueListing.notFound"
+          />
+        }
+      >
+        <BaseTable headerComponents={tableHeaders}>
+          <TableBody>{tableBody}</TableBody>
+        </BaseTable>
+      </QuerySwitcher>
       <PaginationInfo
         table={table}
         intlLabel="global.issues"

--- a/dashboard/src/components/QuerySwitcher/QuerySwitcher.tsx
+++ b/dashboard/src/components/QuerySwitcher/QuerySwitcher.tsx
@@ -3,6 +3,8 @@ import { Fragment, type ReactNode, type JSX } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
+import { HttpStatusCode } from 'axios';
+
 import { cn } from '@/lib/utils';
 
 import { Skeleton } from '@/components/ui/skeleton';
@@ -17,6 +19,7 @@ type QuerySwitcherProps = {
   data?: unknown;
   customError?: ReactNode;
   customEmptyDataComponent?: JSX.Element;
+  error?: Error | null;
 };
 
 const QuerySwitcher = ({
@@ -26,6 +29,7 @@ const QuerySwitcher = ({
   data,
   customError,
   customEmptyDataComponent,
+  error,
 }: QuerySwitcherProps): JSX.Element => {
   if (!status) {
     return customEmptyDataComponent ?? <Fragment />;
@@ -40,7 +44,20 @@ const QuerySwitcher = ({
           <FormattedMessage id="global.loading" />
         </Skeleton>
       );
-    case 'error':
+    case 'error': {
+      let errorStatusCode: number | undefined;
+      const errorMessage = error?.message;
+      if (errorMessage) {
+        const splittedError = errorMessage.split(':');
+        if (splittedError.length > 1) {
+          errorStatusCode = parseInt(splittedError[0]);
+        }
+      }
+
+      if (errorStatusCode === HttpStatusCode.Ok) {
+        return <>{children}</>;
+      }
+
       return (
         <>
           {customError ?? (
@@ -50,6 +67,7 @@ const QuerySwitcher = ({
           )}
         </>
       );
+    }
   }
 
   if (!data) {

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -348,6 +348,8 @@ export const messages = {
     'treeDetails.validBuilds': 'Success builds',
     'treeListing.description': 'List of trees for kernel builds and tests',
     'treeListing.notFound': 'No tree information available',
+    'treeListing.statusUnavailable':
+      'Error: Unable to load tree status information. Displaying basic information only.',
     'treeListing.title': 'Tree Listing ― KCI Dashboard',
   },
 };

--- a/dashboard/src/pages/Hardware/HardwareListingPage.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPage.tsx
@@ -3,8 +3,6 @@ import { roundToNearestMinutes } from 'date-fns';
 
 import { useSearch } from '@tanstack/react-router';
 
-import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
-
 import { Toaster } from '@/components/ui/toaster';
 
 import type { HardwareItem } from '@/types/hardware';
@@ -12,8 +10,6 @@ import type { HardwareItem } from '@/types/hardware';
 import { useHardwareListing } from '@/api/hardware';
 
 import { dateObjectToTimestampInSeconds, daysToSeconds } from '@/utils/date';
-
-import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import type { RequiredStatusCount, StatusCount } from '@/types/general';
 
@@ -144,27 +140,21 @@ const HardwareListingPage = ({
   );
 
   return (
-    <QuerySwitcher
-      status={status}
-      data={data}
-      customError={
-        <MemoizedSectionError
-          isLoading={isLoading}
-          errorMessage={error?.message}
-          emptyLabel="hardwareListing.notFound"
-        />
-      }
-    >
+    <>
       <Toaster />
       <div className="flex flex-col gap-6">
         <HardwareTable
           treeTableRows={listItems}
           endTimestampInSeconds={endTimestampInSeconds}
           startTimestampInSeconds={startTimestampInSeconds}
+          status={status}
+          queryData={data}
+          error={error}
+          isLoading={isLoading}
         />
       </div>
       {kcidevComponent}
-    </QuerySwitcher>
+    </>
   );
 };
 

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -15,6 +15,7 @@ import {
 } from '@tanstack/react-table';
 
 import { useCallback, useMemo, useState, type JSX } from 'react';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -53,11 +54,18 @@ import { REDUCED_TIME_SEARCH } from '@/utils/constants/general';
 import { EMPTY_VALUE } from '@/lib/string';
 import { Badge } from '@/components/ui/badge';
 
+import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
+import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+
 // TODO Extract and reuse the table
 interface IHardwareTable {
   treeTableRows: HardwareItem[];
   startTimestampInSeconds: number;
   endTimestampInSeconds: number;
+  status?: UseQueryResult['status'];
+  queryData?: unknown;
+  error?: Error | null;
+  isLoading?: boolean;
 }
 
 const getLinkProps = (
@@ -345,6 +353,10 @@ export function HardwareTable({
   treeTableRows,
   startTimestampInSeconds,
   endTimestampInSeconds,
+  status,
+  queryData,
+  error,
+  isLoading,
 }: IHardwareTable): JSX.Element {
   const { listingSize } = useSearch({ strict: false });
   const navigate = useNavigate({ from: '/hardware' });
@@ -429,7 +441,7 @@ export function HardwareTable({
     ) : (
       <TableRow>
         <TableCell colSpan={columns.length} className="h-24 text-center">
-          <FormattedMessage id="global.noResults" />
+          <FormattedMessage id="hardwareListing.notFound" />
         </TableCell>
       </TableRow>
     );
@@ -475,9 +487,22 @@ export function HardwareTable({
           <PaginationButtons table={table} className="pl-4" />
         </div>
       </div>
-      <BaseTable headerComponents={tableHeaders}>
-        <TableBody>{tableBody}</TableBody>
-      </BaseTable>
+      <QuerySwitcher
+        status={status}
+        data={queryData}
+        error={error}
+        customError={
+          <MemoizedSectionError
+            isLoading={isLoading}
+            errorMessage={error?.message}
+            emptyLabel="hardwareListing.notFound"
+          />
+        }
+      >
+        <BaseTable headerComponents={tableHeaders}>
+          <TableBody>{tableBody}</TableBody>
+        </BaseTable>
+      </QuerySwitcher>
       <PaginationInfo
         table={table}
         intlLabel="global.hardware"

--- a/dashboard/src/pages/IssueListing/IssueListingPage.tsx
+++ b/dashboard/src/pages/IssueListing/IssueListingPage.tsx
@@ -4,11 +4,7 @@ import { useSearch } from '@tanstack/react-router';
 
 import { FormattedMessage } from 'react-intl';
 
-import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
-
 import { Toaster } from '@/components/ui/toaster';
-
-import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
 import { useIssueListing } from '@/api/issue';
 import { IssueTable } from '@/components/IssueTable/IssueTable';
@@ -69,17 +65,7 @@ export const IssueListingPage = ({
   }, [data, inputFilter]);
 
   return (
-    <QuerySwitcher
-      status={status}
-      data={data}
-      customError={
-        <MemoizedSectionError
-          isLoading={isLoading}
-          errorMessage={error?.message}
-          emptyLabel="issueListing.notFound"
-        />
-      }
-    >
+    <>
       <Toaster />
       <div className="flex flex-col gap-6 pb-4">
         <div className="flex items-center justify-between gap-4 max-[650px]:flex-wrap">
@@ -97,9 +83,15 @@ export const IssueListingPage = ({
             <IssueListingFilter paramFilter={diffFilter} data={data?.filters} />
           </div>
         </div>
-        <IssueTable issueListing={filteredData} />
+        <IssueTable
+          issueListing={filteredData}
+          status={status}
+          queryData={data}
+          error={error}
+          isLoading={isLoading}
+        />
         <MemoizedKcidevFooter commandGroup="issue" />
       </div>
-    </QuerySwitcher>
+    </>
   );
 };


### PR DESCRIPTION
Display tables even when the API returns a "not found" error (HTTP 200 with an error message), showing an empty table instead of an error component

## Problem Solved

A "Not Found" response from the backend caused the UI to hide the whole table, blocking users from changing the date range and other filters

## Impact

Improves UX by showing empty tables for "Not Found" cases while preserving error handling for real failures. The table remains visible and filterable even when no results are found

## Visual Reference

Before:

<img width="1320" height="612" alt="image" src="https://github.com/user-attachments/assets/bb43fe0a-0645-478d-bbfc-02c3c7f11221" />


After:

<img width="1320" height="612" alt="image" src="https://github.com/user-attachments/assets/171230ef-5b21-40ba-9fb7-719fba353c86" />


Closes #1636, closes #57