### PR TITLE
Fix(tests): fix test classes discovery warnings

### DIFF
--- a/backend/kernelCI_app/models.py
+++ b/backend/kernelCI_app/models.py
@@ -137,6 +137,9 @@ class Builds(models.Model):
 
 
 class Tests(models.Model):
+    # Disables automatic pytest test discovery for this class
+    __test__ = False
+
     class UnitPrefix(models.TextChoices):
         METRIC = "metric"
         BINARY = "binary"

--- a/backend/kernelCI_app/tests/factories/test_factory.py
+++ b/backend/kernelCI_app/tests/factories/test_factory.py
@@ -13,6 +13,9 @@ from .mocks import Test, Checkout
 class TestFactory(DjangoModelFactory):
     """Factory for creating Test instances with realistic test data."""
 
+    # Disables automatic pytest test discovery for this class
+    __test__ = False
+
     class Meta:
         model = Tests
 

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -28,6 +28,9 @@ from kernelCI_app.typeModels.databases import (
 
 
 class TestArchSummaryItem(BaseModel):
+    # Disables automatic pytest test discovery for this class
+    __test__ = False
+
     arch: str
     compiler: str
     status: StatusCount
@@ -91,6 +94,9 @@ class BuildHistoryItem(BaseModel):
 
 
 class TestSummary(BaseModel):
+    # Disables automatic pytest test discovery for this class
+    __test__ = False
+
     status: StatusCount
     origins: dict[str, StatusCount]
     architectures: list[TestArchSummaryItem]

--- a/backend/kernelCI_app/typeModels/testDetails.py
+++ b/backend/kernelCI_app/typeModels/testDetails.py
@@ -83,6 +83,9 @@ class TestStatusHistoryResponse(BaseModel):
 
 
 class TestStatusHistoryRequest(BaseModel):
+    # Disables automatic pytest test discovery for this class
+    __test__ = False
+
     path: Annotated[str, Field(description=DocStrings.STATUS_HISTORY_PATH_DESCRIPTION)]
     origin: Annotated[
         str,

--- a/backend/kernelCI_app/typeModels/treeListing.py
+++ b/backend/kernelCI_app/typeModels/treeListing.py
@@ -18,6 +18,9 @@ from pydantic import BaseModel, Field, RootModel
 
 
 class TestStatusCount(BaseModel):
+    # Disables automatic pytest test discovery for this class
+    __test__ = False
+
     pass_count: int = Field(alias="pass")
     error_count: int = Field(alias="error")
     fail_count: int = Field(alias="fail")


### PR DESCRIPTION
Pytest checks all classes starting with 'Test' for unit/integration/all tests, but some classes start with Test but are not meant for pytest (such as the `Tests` model or the class `TestSummary` used in some endpoints). Leaving 'Test' as the default classname for discovery is still needed though, since almost all unit tests are organized that way.

## Changes
- Added `__test__ = False` to classes used in unit/integration tests and that start with `Test` but that don't contain test cases themselves.

## How to test
Run pytest and check that the warnings lowered from 10 to 2 (multiplied by the number of workers, which is 4 by default)

Check https://docs.pytest.org/en/8.3.x/example/pythoncollection.html