### PR TITLE
feat(notifications): improve hardware summary code

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -27,7 +27,7 @@ The command supports four primary actions:
 1. `summary`
     * Runs a checkout summary report for trees listed in the [subscriptions folder](../backend/data/notifications/subscriptions/).
 1. `hardware_summary`
-    * Generate weekly hardware reports for hardware listed in the [subscriptions folder](../backend/data/notifications/subscriptions/). Emails are sent only for hardware with failed tests.
+    * Generate weekly hardware reports for hardware listed in the [subscriptions folder](../backend/data/notifications/subscriptions/).
 1.  `fake_report`
     * Generates a fake report (for  testing email send).
 


### PR DESCRIPTION
### Description
Currently, Hardware summary emails are only sent when tests fail and notifications run both in staging and production environments.

### Changes

- Send weekly hardware summary emails regardless of failures

- Restrict notifications to production or dev environments

### How to Test
Run the following command to generate the hardware summary report:
```
poetry run python manage.py notifications --action hardware_summary
```
### Related Issue
Closes #1644 