### PR TITLE
Fix: move filter button down for small screens

### DIFF
--- a/dashboard/src/components/Tabs/FilterList.tsx
+++ b/dashboard/src/components/Tabs/FilterList.tsx
@@ -1,16 +1,17 @@
-import { useCallback, useMemo, type JSX } from 'react';
+import { useCallback, type JSX } from 'react';
 
 import FilterList from '@/components/FilterList/FilterList';
 import type { TFilter } from '@/types/general';
 
 interface IDetailsFilterList {
   filter: TFilter;
+  flatFilter: string[];
   navigate: (filter: TFilter) => void;
   cleanFilters: () => void;
   isLoading: boolean;
 }
 
-const createFlatFilter = (filter: TFilter): string[] => {
+export const createFlatFilter = (filter: TFilter): string[] => {
   const flatFilter: string[] = [];
 
   Object.entries(filter).forEach(([field, fieldValue]) => {
@@ -29,12 +30,11 @@ const createFlatFilter = (filter: TFilter): string[] => {
 
 const DetailsFilterList = ({
   filter,
+  flatFilter,
   navigate,
   cleanFilters,
   isLoading = false,
 }: IDetailsFilterList): JSX.Element => {
-  const flatFilter = useMemo(() => createFlatFilter(filter), [filter]);
-
   const onClickItem = useCallback(
     (flatValue: string, _: number) => {
       const [field, ...rest] = flatValue.split(':');

--- a/dashboard/src/components/Tabs/Tabs.tsx
+++ b/dashboard/src/components/Tabs/Tabs.tsx
@@ -26,6 +26,7 @@ export interface ITabsComponent {
   filterListElement?: JSX.Element;
   onValueChange?: TabsProp['onValueChange'];
   value?: TabsProp['value'];
+  headerExtra?: ReactElement;
 }
 
 const TabsComponent = ({
@@ -34,6 +35,7 @@ const TabsComponent = ({
   filterListElement,
   onValueChange,
   value,
+  headerExtra,
 }: ITabsComponent): JSX.Element => {
   const tabsTrigger = useMemo(
     () =>
@@ -68,11 +70,14 @@ const TabsComponent = ({
       defaultValue={defaultTab}
       className="w-full"
     >
-      <div className="bg-light-gray sticky top-16 z-5 rounded-md pt-12 pb-6">
-        <TabsList className="border-dark-gray w-full justify-start rounded-none border-b bg-transparent">
-          {tabsTrigger}
-        </TabsList>
-        {filterListElement && <div className="pt-6">{filterListElement}</div>}
+      <div className="bg-light-gray sticky top-18 z-5 flex flex-col gap-6 rounded-md pt-6 pb-6">
+        <div className="flex w-full flex-wrap justify-between gap-6">
+          <TabsList className="border-dark-gray flex-1 items-baseline justify-start rounded-none border-b bg-transparent">
+            {tabsTrigger}
+          </TabsList>
+          {headerExtra}
+        </div>
+        {filterListElement}
       </div>
 
       {tabsContent}

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -23,6 +23,7 @@ export interface ITreeDetailsTab {
   filterListElement?: JSX.Element;
   countElements: TabRightElementRecord;
   urlFrom: TreeDetailsRouteFrom;
+  headerExtra?: React.JSX.Element;
 }
 
 const TreeDetailsTab = ({
@@ -30,6 +31,7 @@ const TreeDetailsTab = ({
   countElements,
   treeDetailsLazyLoaded,
   urlFrom,
+  headerExtra,
 }: ITreeDetailsTab): JSX.Element => {
   const params = useParams({
     from: urlFrom,
@@ -101,6 +103,7 @@ const TreeDetailsTab = ({
       filterListElement={filterListElement}
       value={currentPageTab}
       onValueChange={onValueChange}
+      headerExtra={headerExtra}
     />
   );
 };

--- a/dashboard/src/pages/TreeDetails/TreeDetails.tsx
+++ b/dashboard/src/pages/TreeDetails/TreeDetails.tsx
@@ -36,7 +36,9 @@ import type { TFilter } from '@/types/general';
 
 import { mapFilterToReq } from '@/components/Tabs/Filters';
 
-import DetailsFilterList from '@/components/Tabs/FilterList';
+import DetailsFilterList, {
+  createFlatFilter,
+} from '@/components/Tabs/FilterList';
 
 import { truncateUrl } from '@/lib/string';
 
@@ -257,22 +259,27 @@ const TreeDetails = ({
     });
   }, [navigate, params]);
 
-  const filterListElement = useMemo(
-    () => (
+  const filterListElement = useMemo(() => {
+    const flatFilter = createFlatFilter(diffFilter);
+    if (flatFilter.length === 0) {
+      return undefined;
+    }
+
+    return (
       <DetailsFilterList
         filter={diffFilter}
+        flatFilter={flatFilter}
         cleanFilters={cleanAll}
         navigate={onFilterChange}
         isLoading={treeDetailsLazyLoaded.summary.isPlaceholderData}
       />
-    ),
-    [
-      cleanAll,
-      diffFilter,
-      onFilterChange,
-      treeDetailsLazyLoaded.summary.isPlaceholderData,
-    ],
-  );
+    );
+  }, [
+    cleanAll,
+    diffFilter,
+    onFilterChange,
+    treeDetailsLazyLoaded.summary.isPlaceholderData,
+  ]);
 
   const [buildStatusCount, bootStatusCount, testStatusCount]: [
     GroupedStatus,
@@ -350,6 +357,25 @@ const TreeDetails = ({
     },
   );
 
+  const filterButtonHeaderExtra = useMemo(() => {
+    if (!data) {
+      if (isLoading) {
+        return <LoadingCircle className="mr-8" />;
+      } else {
+        return undefined;
+      }
+    }
+
+    return (
+      <TreeDetailsFilter
+        paramFilter={diffFilter}
+        treeUrl={data.common.tree_url}
+        data={data}
+        urlFrom={urlFrom}
+      />
+    );
+  }, [data, diffFilter, isLoading, urlFrom]);
+
   return (
     <PageWithTitle title={treeDetailsTitle}>
       <MemoizedTreeHardwareDetailsOGTags
@@ -395,25 +421,12 @@ const TreeDetails = ({
           />
         </div>
         <div className="flex flex-col pb-2">
-          <div className="sticky top-[4.5rem] z-10">
-            <div className="absolute top-2 right-0 py-4">
-              {data ? (
-                <TreeDetailsFilter
-                  paramFilter={diffFilter}
-                  treeUrl={data.common.tree_url}
-                  data={data}
-                  urlFrom={urlFrom}
-                />
-              ) : (
-                isLoading && <LoadingCircle className="mt-6 mr-8" />
-              )}
-            </div>
-          </div>
           <TreeDetailsTab
             treeDetailsLazyLoaded={treeDetailsLazyLoaded}
             filterListElement={filterListElement}
             countElements={tabsCounts}
             urlFrom={urlFrom}
+            headerExtra={filterButtonHeaderExtra}
           />
         </div>
       </div>

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 
 import { FormattedMessage } from 'react-intl';
 
-import type { JSX } from 'react';
+import type { JSX, ReactElement } from 'react';
 import { useCallback, useMemo } from 'react';
 
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -28,6 +28,7 @@ export interface IHardwareDetailsTab {
   fullDataResult?: UseQueryResult<THardwareDetails>;
   summaryData: HardwareDetailsSummary;
   hasSelectedTrees: boolean;
+  headerExtra?: ReactElement;
 }
 
 const HardwareDetailsTabs = ({
@@ -37,6 +38,7 @@ const HardwareDetailsTabs = ({
   fullDataResult,
   summaryData,
   hasSelectedTrees,
+  headerExtra,
 }: IHardwareDetailsTab): JSX.Element => {
   const { currentPageTab } = useSearch({
     from: '/_main/hardware/$hardwareId',
@@ -134,6 +136,7 @@ const HardwareDetailsTabs = ({
       value={currentPageTab}
       onValueChange={onTabChange}
       filterListElement={filterListElement}
+      headerExtra={headerExtra}
     />
   );
 };


### PR DESCRIPTION
## Changes
- Refactored how the filter cards are calculated, returning `null` if there are no filters present
- Added a `headerExtra` parameter to the tabs so that the filters button can be organized together with the tabs
- Changed tailwind classes so that the button automatically wraps with the tabs selector, independently of the screen size
- Changed some paddings around

## How to test
Go to treeDetails pages and hardwareDetails pages to check the new placement, other tables should be normal

Closes #1423 

## Visual reference

New designs:
<table>
  <thead>
    <th>Small with filters</th>
    <th>Small without filters</th>
  </thead>
  <tbody>
    <tr>
      <td className="w-1/2">
<img width="656" height="830" alt="image" src="https://github.com/user-attachments/assets/ceca9460-c2cc-43de-abd8-b67a91d1f7fb" />
</td>
      <td className="w-1/2">
<img width="656" height="830" alt="image" src="https://github.com/user-attachments/assets/b200fcf1-82bf-43bf-a627-2463386b0ee7" />
</td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <th>Medium with filters</th>
    <th>Medium without filters</th>
  </thead>
  <tbody>
    <tr>
      <td>
<img width="848" height="806" alt="image" src="https://github.com/user-attachments/assets/5d1304cf-6399-4f33-8d14-baf09a180f31" />

</td>
      <td>
<img width="848" height="806" alt="image" src="https://github.com/user-attachments/assets/376d9960-44e6-425e-ba3b-9d4f56a6171f" />

</td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <th>Large with/without filters</th>
  </thead>
  <tbody>
    <tr>
      <td>
<img width="1811" height="801" alt="image" src="https://github.com/user-attachments/assets/50a15e87-5667-4eb1-9c1c-2463500fd634" />


</td>
</tr>
<tr>
      <td>
<img width="1811" height="801" alt="image" src="https://github.com/user-attachments/assets/646ada92-719c-4601-95ee-dd821118b0e8" />


</td>
    </tr>
  </tbody>
</table>