### PR TITLE
feat: add prometheus metrics aggregation to ingester

### DIFF
--- a/backend/kernelCI_app/constants/ingester.py
+++ b/backend/kernelCI_app/constants/ingester.py
@@ -29,6 +29,13 @@ CACHE_LOGS_SIZE_LIMIT = int(os.environ.get("CACHE_LOGS_SIZE_LIMIT", 100000))
 
 TREES_FILE = "/app/trees.yaml"
 
+INGESTER_GRAFANA_LABEL = "django"
+
+try:
+    INGESTER_METRICS_PORT = int(os.environ.get("INGESTER_METRICS_PORT", 8002))
+except (ValueError, TypeError):
+    logger.warning("Invalid INGESTER_METRICS_PORT, using default 8002")
+    INGESTER_METRICS_PORT = 8002
 
 # Batching and backpressure controls
 try:

--- a/backend/kernelCI_app/management/commands/monitor_submissions.py
+++ b/backend/kernelCI_app/management/commands/monitor_submissions.py
@@ -6,6 +6,7 @@ import os
 from kernelCI_app.management.commands.helpers.kcidbng_ingester import (
     ingest_submissions_parallel,
 )
+from kernelCI_app.constants.ingester import INGESTER_METRICS_PORT
 from kernelCI_app.management.commands.helpers.file_utils import (
     load_tree_names,
     verify_spool_dirs,
@@ -13,6 +14,7 @@ from kernelCI_app.management.commands.helpers.file_utils import (
 from kernelCI_app.management.commands.helpers.log_excerpt_utils import (
     cache_logs_maintenance,
 )
+from prometheus_client import start_http_server
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +65,7 @@ class Command(BaseCommand):
         trees_file: str,
         **options,
     ):
+        start_http_server(INGESTER_METRICS_PORT)
         archive_dir = os.path.join(spool_dir, "archive")
         failed_dir = os.path.join(spool_dir, "failed")
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/process_submissions_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/process_submissions_test.py
@@ -2,6 +2,9 @@ from unittest.mock import patch, MagicMock
 from django.db import IntegrityError
 from django.test import SimpleTestCase
 from django.utils import timezone
+from kernelCI_app.management.commands.helpers.kcidbng_ingester import (
+    MAP_TABLENAMES_TO_COUNTER,
+)
 from pydantic import ValidationError
 
 from kernelCI_app.management.commands.helpers.process_submissions import (
@@ -329,7 +332,9 @@ class TestBuildInstancesFromSubmission(SimpleTestCase):
             ],
         }
 
-        result = build_instances_from_submission(submission_data)
+        result = build_instances_from_submission(
+            submission_data, MAP_TABLENAMES_TO_COUNTER
+        )
 
         expected = {
             "issues": [mock_make_issue.return_value],
@@ -347,7 +352,7 @@ class TestBuildInstancesFromSubmission(SimpleTestCase):
         mock_make_incident.assert_called_once()
 
     def test_build_instances_from_submission_with_empty_data(self):
-        result = build_instances_from_submission({})
+        result = build_instances_from_submission({}, MAP_TABLENAMES_TO_COUNTER)
 
         expected = {
             "issues": [],
@@ -370,7 +375,9 @@ class TestBuildInstancesFromSubmission(SimpleTestCase):
             "TestModel", []
         )
 
-        result = build_instances_from_submission(submission_data)
+        result = build_instances_from_submission(
+            submission_data, MAP_TABLENAMES_TO_COUNTER
+        )
 
         self.assertEqual(len(result["issues"]), 0)
         mock_logger.error.assert_called_once()
@@ -390,7 +397,9 @@ class TestBuildInstancesFromSubmission(SimpleTestCase):
             ]
         }
 
-        result = build_instances_from_submission(submission_data)
+        result = build_instances_from_submission(
+            submission_data, MAP_TABLENAMES_TO_COUNTER
+        )
 
         self.assertEqual(len(result["issues"]), 2)
         self.assertEqual(mock_make_issue.call_count, 2)
@@ -415,7 +424,9 @@ class TestBuildInstancesFromSubmission(SimpleTestCase):
             mock_issue_3,
         ]
 
-        result = build_instances_from_submission(submission_data)
+        result = build_instances_from_submission(
+            submission_data, MAP_TABLENAMES_TO_COUNTER
+        )
 
         self.assertEqual(len(result["issues"]), 2)
         self.assertEqual(result["issues"][0], mock_issue_1)

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1884,4 +1884,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "e91b0d1cd67eb864f83e9ba993ca029aede40d15b82343b1e69889c76704beea"
+content-hash = "b789548973c061f2665b4b0029a0b49c72b49a5f5e693ebafa3cd6b2b613333d"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ django-crontab = "^0.7.1"
 django-prometheus = "^2.3.1"
 redis = {extras = ["hiredis"], version = "^5.2.1"}
 kcidb_io = {git = "https://github.com/kernelci/kcidb-io.git"}
+prometheus-client = "^0.23.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/monitoring/ingester.json
+++ b/monitoring/ingester.json
@@ -1,0 +1,304 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "ef6i3x5negsu8f"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": ["django"],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": true,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-17142428006",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ef1wywwokay9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(kcidb_ingestions_total[$__rate_interval])",
+          "legendFormat": "{{ingester}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ingestions per second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-17142428006",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(kcidb_checkouts_total[$__rate_interval])",
+          "legendFormat": "Checkouts - {{origin}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(kcidb_tests_total[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Tests - {{origin}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ef1wywwokay9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(kcidb_issues_total[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Issues - {{origin}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ef1wywwokay9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(kcidb_builds_total[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Builds - {{origin}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "ef1wywwokay9sb"
+          },
+          "editorMode": "code",
+          "expr": "rate(kcidb_incidents_total[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Incidents - {{origin}}",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Items processed per origin",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "auto",
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Ingester Performance",
+  "uid": "4247e4df-2ce2-4024-aed2-db89a663e663",
+  "version": 1
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -13,3 +13,8 @@ scrape_configs:
       - targets: ['host.docker.internal:8001']
     metrics_path: '/metrics/'
     scrape_interval: 10s
+  - job_name: 'kernelci-ingester'
+    static_configs:
+      - targets: ['host.docker.internal:8002']
+    metrics_path: '/metrics/'
+    scrape_interval: 1s


### PR DESCRIPTION
This PR adds metrics aggregations using prometheus_client to the ingester, including total submissions ingested and items processed (tests, builds, checkouts, etc.)

## Changes

- Added `prometheus_client` to the project
- Set up a http server within ingester to aggregate the metrics
- Added a JSON with a Grafana dashboard showing submissions processed per second and total items per origin

## Visual reference

<img width="1612" height="404" alt="image" src="https://github.com/user-attachments/assets/46205ab9-3499-4913-8971-14520a6ab1ac" />

## How to test

1. Run Grafana + Prometheus using the docker compose file `docker-compose.monitoring.yml`
2. Access Grafana at localhost:3000
3. Add Prometheus as a datasource to Grafana
4. Import the dashboard file in [ingester.json](https://github.com/gustavobtflores/kernelci-dashboard/blob/f873ef9ba98e5bd3ed1fd8fa912cf6d0ad5914c5/monitoring/ingester.json) to Grafana
5. Get some submissions and add to a folder with the subfolders `archive` and `failed`
6. Run the monitor_submissions command `poetry run python manage.py monitor_submissions --spool-dir ./submissions --trees-file ./trees-name.yaml`
7. Check if the metrics are being counted in the Grafana dashboard

Closes #1658 