### PR TITLE
refactor: modify ingester to use processes in a 'fan-out' pattern

### DIFF
--- a/backend/kernelCI_app/constants/ingester.py
+++ b/backend/kernelCI_app/constants/ingester.py
@@ -38,6 +38,9 @@ PROMETHEUS_MULTIPROC_DIR must be set for Prometheus multiprocess metrics to be c
 See https://prometheus.github.io/client_python/multiprocess/ for more details.
 """
 
+INGEST_FILES_BATCH_SIZE = int(os.environ.get("INGEST_FILES_BATCH_SIZE", 100))
+"""Size of the batch of files to be queued. Default: 100"""
+
 try:
     INGESTER_METRICS_PORT = int(os.environ.get("INGESTER_METRICS_PORT", 8002))
 except (ValueError, TypeError):

--- a/backend/kernelCI_app/typeModels/modelTypes.py
+++ b/backend/kernelCI_app/typeModels/modelTypes.py
@@ -1,10 +1,13 @@
-from typing import Literal
+from typing import Literal, Type
 from kernelCI_app.models import Builds, Checkouts, Incidents, Issues, Tests
 
 type TableNames = Literal["issues", "checkouts", "builds", "tests", "incidents"]
 type TableModels = Issues | Checkouts | Builds | Tests | Incidents
+type TableModelsClass = Type[Issues] | Type[Checkouts] | Type[Builds] | Type[
+    Tests
+] | Type[Incidents]
 
-MODEL_MAP: dict[TableNames, TableModels] = {
+MODEL_MAP: dict[TableNames, TableModelsClass] = {
     "issues": Issues,
     "checkouts": Checkouts,
     "builds": Builds,


### PR DESCRIPTION
This PR reviews the ingester architecture to use processes both for file processing and database insertion, allowing faster processing using multiple database connections doing batch inserts at the same time.

## How to test

1. Get some submissions files and a trees.yaml file
2. Run the monitor_submissions command `poetry run python manage.py monitor_submissions [...options]`
3. Check if the submissions are being moved to the correct directory and data inserted correctly in the database

## Performance

Before: 
```
[2026-01-07 22:16:28] Ingest cycle: 48000 files (ok=48000, fail=0) in 664.84s | 72.20 files/s | 9002.68 MB processed (13.54 MB/s)
```

After:
```
[2026-01-08 13:33:54] Ingest cycle: 48000 files (ok=48000, fail=0) in 411.70s | 116.59 files/s | 9002.68 MB processed (21.87 MB/s)
```

Closes #1673