### PR TITLE
Fix: correct metrics notification recipient

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -192,7 +192,8 @@ else:
             [
                 "notifications",
                 "--action=metrics_summary",
-                "--add-mailing-lists",
+                "--to=kernelci@lists.linux.dev",
+                "--cc=kernelci-results@groups.io",
                 "--send",
                 "--yes",
             ],


### PR DESCRIPTION
Changes the recipient of the metrics notification from the default (kernelci-results@groups.io) to kernelci@lists.linux.dev