### PR TITLE
feat(ci): add e2e tests to staging deployment workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,12 +173,12 @@ jobs:
         with:
           name: coverage-data-integration
           path: backend/coverage-integration.sqlite
-      
+       
       - name: Clean containers
         run: |
           docker compose -f docker-compose.test.yml down --volumes --remove-orphans
           docker system prune -af
-  
+   
   update-coverage-badge:
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
@@ -214,33 +214,14 @@ jobs:
           poetry run coverage combine
           poetry run coverage json -o ${{ github.workspace }}/coverage.json
         working-directory: ./backend
-      
+       
       - name: Update Coverage Badge
         uses: we-cli/coverage-badge-action@main
 
-  deploy-staging:
+  # Call job in a a split file
+  call-deploy-staging:
+    needs: [lint-js, build-front, lint-and-unit-test-django, integration-test-django]
+    # This 'if' ensures it only runs on pushes to main (the production requirement)
     if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-    runs-on: ubuntu-latest
-    needs:
-      - lint-js
-      - build-front
-      - lint-and-unit-test-django
-      - integration-test-django
-    steps:
-      - name: Configure staging host authenticity
-        run: |
-          mkdir -p ~/.ssh/ && chmod 700 ~/.ssh/
-          touch ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
-          echo "$SSH_HOSTKEY" > ~/.ssh/known_hosts
-        env:
-          SSH_HOSTKEY: ${{ secrets.STAGING_HOSTKEY }}
-
-      - name: Deploy to staging
-        run: |
-          eval $(ssh-agent -s)
-          echo "$SSH_KEY" | ssh-add - >/dev/null
-          ssh "${SSH_USER}@${SSH_HOST}" "deploy ${GITHUB_SHA}"
-        env:
-          SSH_USER: ${{ secrets.STAGING_USER }}
-          SSH_HOST: ${{ secrets.STAGING_HOST }}
-          SSH_KEY: ${{ secrets.STAGING_KEY }}
+    uses: ./.github/workflows/deploy-staging.yaml
+    secrets: inherit

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,0 +1,62 @@
+name: Deploy Staging and E2E
+
+on:
+  workflow_call:
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure staging host authenticity
+        run: |
+          mkdir -p ~/.ssh/ && chmod 700 ~/.ssh/
+          touch ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+          echo "$SSH_HOSTKEY" > ~/.ssh/known_hosts
+        env:
+          SSH_HOSTKEY: ${{ secrets.STAGING_HOSTKEY }}
+
+      - name: Deploy to staging
+        run: |
+          eval $(ssh-agent -s)
+          echo "$SSH_KEY" | ssh-add - >/dev/null
+          ssh "${SSH_USER}@${SSH_HOST}" "deploy ${GITHUB_SHA}"
+        env:
+          SSH_USER: ${{ secrets.STAGING_USER }}
+          SSH_HOST: ${{ secrets.STAGING_HOST }}
+          SSH_KEY: ${{ secrets.STAGING_KEY }}
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: deploy-staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch node_modules
+        uses: actions/cache@v4
+        id: fetch-node_modules
+        with:
+          key: node_modules-${{ runner.os }}-${{ hashFiles('./dashboard/pnpm-lock.yaml') }}
+          path: ./dashboard/node_modules
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: './dashboard/.nvmrc'
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+        working-directory: ./dashboard
+
+      - name: Wait for staging deployment to be ready
+        run: sleep 180
+
+      - name: Run e2e tests against staging
+        run: pnpm e2e
+        working-directory: ./dashboard
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: https://staging.dashboard.kernelci.org:9000


### PR DESCRIPTION
# Summary
Adds end-to-end (e2e) tests to the CI workflow that run automatically after staging deployment. This ensures staging is tested before considering it safe, while keeping production deployments non-blocking.


## Changes
- Added e2e-tests job to .github/workflows/ci.yaml that depends on deploy-staging
- Job waits 3 minutes for staging readiness, then runs Playwright tests against https://staging.dashboard.kernelci.org:9000
- Tests are non-blocking for production (manual deploys can proceed regardless of e2e results)

## Testing
1. Automatic: Push to main to trigger full CI + staging deploy + e2e tests

## Disclaimer: There is a commit just to test the CI that remove guardrails, this will be removed before merge

Closes https://github.com/kernelci/dashboard/issues/1684
