### PR TITLE
fix: modify width of main content to avoid overflowing

### DIFF
--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -514,14 +514,14 @@ export function TreeTable({
 
   return (
     <div className="flex flex-col gap-6 pb-4">
-      <div className="grid grid-cols-1 items-center gap-4 min-[850px]:grid-cols-2 lg:grid-cols-[1fr_auto_auto] lg:gap-8">
-        <span className="text-dim-gray w-full justify-start text-left text-sm min-[850px]:col-span-2 lg:col-span-1">
+      <div className="flex flex-wrap items-center justify-end gap-4">
+        <span className="text-dim-gray flex-1 justify-start text-left text-sm">
           <FormattedMessage
             id="global.projectUnderDevelopment"
             values={formattedBreakLineValue}
           />
         </span>
-        <div className="flex w-full justify-end gap-y-2 max-[700px]:flex-wrap min-[850px]:justify-start">
+        <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
           <MemoizedInputTime navigateFrom="/tree" />
           <ItemsPerPageSelector
             table={table}
@@ -529,7 +529,7 @@ export function TreeTable({
             className="pl-4"
           />
         </div>
-        <div className="flex w-full justify-end gap-y-2 max-[700px]:flex-wrap">
+        <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
           <ListingCount table={table} intlLabel="global.trees" />
           <PaginationButtons table={table} className="pl-4" />
         </div>

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -464,14 +464,14 @@ export function HardwareTable({
 
   return (
     <div className="flex flex-col gap-6 pb-4">
-      <div className="grid grid-cols-1 items-center gap-4 min-[850px]:grid-cols-2 lg:grid-cols-[1fr_auto_auto] lg:gap-8">
-        <span className="text-dim-gray w-full justify-start text-left text-sm min-[850px]:col-span-2 lg:col-span-1">
+      <div className="flex flex-wrap items-center justify-end gap-4">
+        <span className="text-dim-gray flex-1 justify-start text-left text-sm">
           <FormattedMessage
             id="global.projectUnderDevelopment"
             values={formattedBreakLineValue}
           />
         </span>
-        <div className="flex w-full justify-end gap-y-2 max-[700px]:flex-wrap min-[850px]:justify-start">
+        <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
           <MemoizedInputTime
             navigateFrom="/hardware"
             defaultInterval={REDUCED_TIME_SEARCH}
@@ -482,7 +482,7 @@ export function HardwareTable({
             className="pl-4"
           />
         </div>
-        <div className="flex w-full justify-end gap-y-2 max-[700px]:flex-wrap">
+        <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
           <ListingCount table={table} intlLabel="global.hardware" />
           <PaginationButtons table={table} className="pl-4" />
         </div>

--- a/dashboard/src/pages/HardwareNew/HardwareTable.tsx
+++ b/dashboard/src/pages/HardwareNew/HardwareTable.tsx
@@ -466,14 +466,14 @@ export function HardwareTable({
 
   return (
     <div className="flex flex-col gap-6 pb-4">
-      <div className="grid grid-cols-1 items-center gap-4 min-[850px]:grid-cols-2 lg:grid-cols-[1fr_auto_auto] lg:gap-8">
-        <span className="text-dim-gray w-full justify-start text-left text-sm min-[850px]:col-span-2 lg:col-span-1">
+      <div className="flex flex-wrap items-center justify-end gap-4">
+        <span className="text-dim-gray flex-1 justify-start text-left text-sm">
           <FormattedMessage
             id="global.projectUnderDevelopment"
             values={formattedBreakLineValue}
           />
         </span>
-        <div className="flex w-full justify-end gap-y-2 max-[700px]:flex-wrap min-[850px]:justify-start">
+        <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
           <MemoizedInputTime
             navigateFrom="/hardware-new"
             defaultInterval={REDUCED_TIME_SEARCH}
@@ -484,7 +484,7 @@ export function HardwareTable({
             className="pl-4"
           />
         </div>
-        <div className="flex w-full justify-end gap-y-2 max-[700px]:flex-wrap">
+        <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
           <ListingCount table={table} intlLabel="global.hardware" />
           <PaginationButtons table={table} className="pl-4" />
         </div>

--- a/dashboard/src/pages/IssueListing/IssueListingPage.tsx
+++ b/dashboard/src/pages/IssueListing/IssueListingPage.tsx
@@ -68,7 +68,7 @@ export const IssueListingPage = ({
     <>
       <Toaster />
       <div className="flex flex-col gap-6 pb-4">
-        <div className="flex items-center justify-between gap-4 max-[650px]:flex-wrap">
+        <div className="flex flex-wrap items-center justify-between gap-4">
           <span className="text-dim-gray text-left text-sm">
             <FormattedMessage
               id="global.projectUnderDevelopment"

--- a/dashboard/src/routes/_main/route.tsx
+++ b/dashboard/src/routes/_main/route.tsx
@@ -20,7 +20,7 @@ const RouteComponent = (): JSX.Element => {
       <div className="h-full w-full">
         <div className="flex w-full flex-row">
           <SideMenu />
-          <main className="flex w-full flex-col">
+          <main className="flex min-w-0 flex-1 flex-col">
             <TopBar />
             <div className="bg-light-gray h-full w-full px-16 pt-24">
               <Outlet />


### PR DESCRIPTION
## Description

The main content of the pages in the dashboard weren't considering the size of the sidenav menu, what caused the main content to overflow on smaller screens, this PR modifies the size of the main content to consider the sidenav menu width avoiding overflow

## Visual reference

References below in ~800px screensize

### Before

<img width="791" height="927" alt="Screenshot from 2026-01-13 17-13-11" src="https://github.com/user-attachments/assets/11dd99fa-f66b-4e7f-992e-b4576901ab00" />

### After

<img width="791" height="927" alt="Screenshot from 2026-01-13 17-11-51" src="https://github.com/user-attachments/assets/72b163ff-2cd3-45c8-b285-1fd4a48a07e7" />

Closes #1700