### PR TITLE
fix: changes on queryIncosistencyValidator in HardwareDetails to avoid refetch loop

### DIFF
--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -128,6 +128,22 @@ function HardwareDetails(): JSX.Element {
 
   const reqFilter = mapFilterToReq(diffFilter);
 
+  const inconsistencyNavigateParams = useMemo(
+    () => ({ hardwareId }),
+    [hardwareId],
+  );
+
+  const inconsistencyInvalidatorEnabled = useMemo(() => {
+    // Only compare against listing-provided router state when the page is in its
+    // "default" state. When tree selection / commit selection is active, count
+    // mismatches are expected and should not trigger global invalidations.
+    return (
+      isEmptyObject(reqFilter) &&
+      treeIndexes === null &&
+      isEmptyObject(treeCommits)
+    );
+  }, [reqFilter, treeCommits, treeIndexes]);
+
   const updateTreeFilters = useCallback((selectedIndexes: number[] | null) => {
     navigate({
       search: previousSearch => ({
@@ -209,8 +225,8 @@ function HardwareDetails(): JSX.Element {
     referenceData: hardwareStatusHistoryState,
     comparedData: hardwareDataPreparedForInconsistencyValidation,
     navigate: navigate,
-    enabled: isEmptyObject(reqFilter),
-    navigateParams: { hardwareId: hardwareId },
+    enabled: inconsistencyInvalidatorEnabled,
+    navigateParams: inconsistencyNavigateParams,
   });
 
   const hardwareTableForCommitHistory = useMemo(() => {


### PR DESCRIPTION
### Description

This PR changes useQueryInconsistencyInvalidator in HardwareDetails that could re-trigger continuously due to unstable navigateParams and expected count mismatches during tree/commit filtering, causing repeated invalidations/requests.

Closes #1710 