### PR TITLE
Feat: use new tree listing

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,5 +1,9 @@
 # Use port 8000 to go directly to the backend/gunicorn.
 # Use port 80 to go through Nginx (proxy service on Docker)
 VITE_API_BASE_URL=http://localhost:8000
+
+# Feature Flags
 VITE_FEATURE_FLAG_SHOW_DEV=false
+VITE_FEATURE_FLAG_TREE_LISTING_VERSION=v1
+
 PLAYWRIGHT_TEST_BASE_URL=https://staging.dashboard.kernelci.org:9000

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -70,5 +70,8 @@ Also, we are using file based routing in the tanstack router, only files that st
 # Feature Flags
 
 They are used when we want to hide a feature for some users, without having to do branch manipulation.
-Right now the only feature flag is for Dev only and it is controlled by the env
-`FEATURE_FLAG_SHOW_DEV=false` it is a boolean.
+
+Available feature flags:
+
+- `VITE_FEATURE_FLAG_SHOW_DEV` - Controls visibility of dev-only features (boolean, default: `false`)
+- `VITE_FEATURE_FLAG_TREE_LISTING_VERSION` - Controls which tree listing version to display. Set to `"v1"` for the old version or `"v2"` for the new version (string, default: `"v1"`)

--- a/dashboard/src/api/tree.ts
+++ b/dashboard/src/api/tree.ts
@@ -11,6 +11,8 @@ import type {
 } from '@/types/tree/Tree';
 import { DEFAULT_ORIGIN } from '@/types/general';
 
+import type { TreeListingRoutesMap } from '@/utils/constants/treeListing';
+
 import { RequestData } from './commonRequest';
 
 const fetchTreeCheckoutData = async (
@@ -30,11 +32,12 @@ const fetchTreeCheckoutData = async (
 
 export const useTreeTable = ({
   enabled,
+  searchFrom,
 }: {
   enabled: boolean;
+  searchFrom: TreeListingRoutesMap['v1']['search'];
 }): UseQueryResult<Tree[]> => {
-  const { origin, intervalInDays } = useSearch({ from: '/_main/tree/v1' });
-
+  const { origin, intervalInDays } = useSearch({ from: searchFrom });
   const queryKey = ['treeTable', origin, intervalInDays];
 
   return useQuery({
@@ -47,7 +50,7 @@ export const useTreeTable = ({
 
 const fetchTreeFastCheckoutData = async (
   origin: string,
-  intervalInDays?: number,
+  intervalInDays: number,
 ): Promise<TreeFastPathResponse> => {
   const params = {
     origin: origin,
@@ -60,8 +63,12 @@ const fetchTreeFastCheckoutData = async (
   return data;
 };
 
-export const useTreeTableFast = (): UseQueryResult<TreeFastPathResponse> => {
-  const { origin, intervalInDays } = useSearch({ from: '/_main/tree/v1' });
+export const useTreeTableFast = ({
+  searchFrom,
+}: {
+  searchFrom: TreeListingRoutesMap['v1']['search'];
+}): UseQueryResult<TreeFastPathResponse> => {
+  const { origin, intervalInDays } = useSearch({ from: searchFrom });
 
   const queryKey = ['treeTableFast', origin, intervalInDays];
 
@@ -104,7 +111,7 @@ export const useTreeLatest = (
 
 const fetchTreeListingV2 = async (
   origin: string,
-  intervalInDays?: number,
+  intervalInDays: number,
 ): Promise<TreeV2[]> => {
   const params = {
     origin: origin,
@@ -117,9 +124,12 @@ const fetchTreeListingV2 = async (
   return data;
 };
 
-export const useTreeListingV2 = (): UseQueryResult<TreeV2[]> => {
-  const { origin, intervalInDays } = useSearch({ from: '/_main/tree' });
-
+export const useTreeListingV2 = ({
+  searchFrom,
+}: {
+  searchFrom: TreeListingRoutesMap['v2']['search'];
+}): UseQueryResult<TreeV2[]> => {
+  const { origin, intervalInDays } = useSearch({ from: searchFrom });
   const queryKey = ['treeTableV2', origin, intervalInDays];
 
   return useQuery({

--- a/dashboard/src/api/tree.ts
+++ b/dashboard/src/api/tree.ts
@@ -7,6 +7,7 @@ import type {
   Tree,
   TreeFastPathResponse,
   TreeLatestResponse,
+  TreeV2,
 } from '@/types/tree/Tree';
 import { DEFAULT_ORIGIN } from '@/types/general';
 
@@ -32,7 +33,7 @@ export const useTreeTable = ({
 }: {
   enabled: boolean;
 }): UseQueryResult<Tree[]> => {
-  const { origin, intervalInDays } = useSearch({ from: '/_main/tree' });
+  const { origin, intervalInDays } = useSearch({ from: '/_main/tree/v1' });
 
   const queryKey = ['treeTable', origin, intervalInDays];
 
@@ -60,7 +61,7 @@ const fetchTreeFastCheckoutData = async (
 };
 
 export const useTreeTableFast = (): UseQueryResult<TreeFastPathResponse> => {
-  const { origin, intervalInDays } = useSearch({ from: '/_main/tree' });
+  const { origin, intervalInDays } = useSearch({ from: '/_main/tree/v1' });
 
   const queryKey = ['treeTableFast', origin, intervalInDays];
 
@@ -97,6 +98,33 @@ export const useTreeLatest = (
   return useQuery({
     queryKey: ['treeLatest', treeName, branch, origin, gitCommitHash],
     queryFn: () => fetchTreeLatest(treeName, branch, origin, gitCommitHash),
+    refetchOnWindowFocus: false,
+  });
+};
+
+const fetchTreeListingV2 = async (
+  origin: string,
+  intervalInDays?: number,
+): Promise<TreeV2[]> => {
+  const params = {
+    origin: origin,
+    interval_in_days: intervalInDays,
+  };
+
+  const data = await RequestData.get<TreeV2[]>('/api/tree-v2/', {
+    params,
+  });
+  return data;
+};
+
+export const useTreeListingV2 = (): UseQueryResult<TreeV2[]> => {
+  const { origin, intervalInDays } = useSearch({ from: '/_main/tree' });
+
+  const queryKey = ['treeTableV2', origin, intervalInDays];
+
+  return useQuery({
+    queryKey,
+    queryFn: () => fetchTreeListingV2(origin, intervalInDays),
     refetchOnWindowFocus: false,
   });
 };

--- a/dashboard/src/components/Banner/BaseBanner.tsx
+++ b/dashboard/src/components/Banner/BaseBanner.tsx
@@ -1,0 +1,33 @@
+import type { VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
+import type { JSX } from 'react';
+
+import { cn } from '@/lib/utils';
+
+const bannerVariants = cva('rounded-md p-3 text-sm', {
+  variants: {
+    variant: {
+      default:
+        'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300',
+      green:
+        'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export const BaseBanner = ({
+  children,
+  variant,
+  className,
+}: {
+  children: JSX.Element;
+  variant?: VariantProps<typeof bannerVariants>['variant'];
+  className?: string;
+}): JSX.Element => {
+  return (
+    <div className={cn(bannerVariants({ variant }), className)}>{children}</div>
+  );
+};

--- a/dashboard/src/components/Banner/PageBanner.tsx
+++ b/dashboard/src/components/Banner/PageBanner.tsx
@@ -1,0 +1,86 @@
+import type { LinkProps } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
+import type { JSX } from 'react';
+import type { MessageDescriptor } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { BaseBanner } from '@/components/Banner/BaseBanner';
+
+const GITHUB_ISSUES_URL = 'https://github.com/kernelci/dashboard/issues';
+
+interface IPageBanner {
+  pageNameId: MessageDescriptor['id'];
+  pageRoute: LinkProps['to'];
+}
+
+/**
+ * This is the banner that goes in the older page
+ */
+export const OldPageBanner = ({
+  pageNameId,
+  pageRoute: newerPageRoute,
+}: IPageBanner): JSX.Element => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <BaseBanner>
+      <FormattedMessage
+        id="messages.olderPageVersion"
+        values={{
+          page: formatMessage({ id: pageNameId }),
+          gitHubLink: (
+            <a
+              href={GITHUB_ISSUES_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              {formatMessage({ id: 'global.gitHubIssue' })}
+            </a>
+          ),
+          newPageLink: (
+            <Link to={newerPageRoute} className="underline">
+              {formatMessage({ id: 'global.here' })}
+            </Link>
+          ),
+        }}
+      />
+    </BaseBanner>
+  );
+};
+
+/**
+ * This is the banner that goes in the newer page
+ */
+export const NewPageBanner = ({
+  pageNameId,
+  pageRoute: olderPageRoute,
+}: IPageBanner): JSX.Element => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <BaseBanner variant="green">
+      <FormattedMessage
+        id="messages.newerPageVersion"
+        values={{
+          page: formatMessage({ id: pageNameId }),
+          gitHubLink: (
+            <a
+              href={GITHUB_ISSUES_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              {formatMessage({ id: 'global.gitHubIssue' })}
+            </a>
+          ),
+          oldVersionLink: (
+            <Link to={olderPageRoute} className="underline">
+              {formatMessage({ id: 'global.here' })}
+            </Link>
+          ),
+        }}
+      />
+    </BaseBanner>
+  );
+};

--- a/dashboard/src/components/OpenGraphTags/ListingOGTags.tsx
+++ b/dashboard/src/components/OpenGraphTags/ListingOGTags.tsx
@@ -3,7 +3,7 @@ import { memo, useMemo } from 'react';
 
 import { useIntl } from 'react-intl';
 
-import type { PossibleMonitorPath } from '@/types/general';
+import type { ListingPaths } from '@/types/general';
 import type { MessagesKey } from '@/locales/messages';
 
 import { OpenGraphTags } from './OpenGraphTags';
@@ -12,7 +12,7 @@ const ListingOGTags = ({
   monitor,
   search,
 }: {
-  monitor: PossibleMonitorPath;
+  monitor: ListingPaths;
   search: string;
 }): JSX.Element => {
   const { formatMessage } = useIntl();
@@ -29,9 +29,6 @@ const ListingOGTags = ({
         break;
       case '/issues':
         descriptionId = 'issueListing.description';
-        break;
-      case '/hardware-new':
-        descriptionId = 'hardwareListing.description';
         break;
     }
     return (
@@ -50,8 +47,6 @@ const ListingOGTags = ({
         return formatMessage({ id: 'hardwareListing.title' });
       case '/issues':
         return formatMessage({ id: 'issueListing.title' });
-      case '/hardware-new':
-        return formatMessage({ id: 'hardwareListing.title' });
     }
   }, [formatMessage, monitor]);
 

--- a/dashboard/src/components/Status/Status.tsx
+++ b/dashboard/src/components/Status/Status.tsx
@@ -6,6 +6,8 @@ import ColoredCircle from '@/components/ColoredCircle/ColoredCircle';
 import type { GroupedStatus } from '@/utils/status';
 import { groupStatus } from '@/utils/status';
 
+// TODO: replace the preCalculatedGroupedStatus with a type-safe approach,
+// currently everything is optional
 interface ITestStatus {
   pass?: number;
   error?: number;
@@ -64,11 +66,58 @@ export const GroupedTestStatus = ({
   );
 };
 
-interface ITestStatusWithLink extends ITestStatus {
+interface IStatusLinkProps {
   passLinkProps?: LinkProps;
   failLinkProps?: LinkProps;
   inconclusiveLinkProps?: LinkProps;
 }
+
+interface IBaseGroupedStatusWithLink extends IStatusLinkProps {
+  groupedStatus: GroupedStatus;
+  hideInconclusive?: boolean;
+}
+
+export const BaseGroupedStatusWithLink = ({
+  groupedStatus,
+  passLinkProps,
+  failLinkProps,
+  inconclusiveLinkProps,
+  hideInconclusive = false,
+}: IBaseGroupedStatusWithLink): JSX.Element => {
+  return (
+    <div className="flex flex-row gap-1">
+      {
+        <Link {...passLinkProps}>
+          <ColoredCircle
+            quantity={groupedStatus.successCount}
+            tooltipText="global.success"
+            backgroundClassName="bg-light-green"
+          />
+        </Link>
+      }
+      {
+        <Link {...failLinkProps}>
+          <ColoredCircle
+            quantity={groupedStatus.failedCount}
+            tooltipText="global.failed"
+            backgroundClassName="bg-light-red"
+          />
+        </Link>
+      }
+      {!hideInconclusive && (
+        <Link {...inconclusiveLinkProps}>
+          <ColoredCircle
+            quantity={groupedStatus.inconclusiveCount}
+            tooltipText="global.inconclusive"
+            backgroundClassName="bg-medium-gray"
+          />
+        </Link>
+      )}
+    </div>
+  );
+};
+
+interface ITestStatusWithLink extends ITestStatus, IStatusLinkProps {}
 
 export const GroupedTestStatusWithLink = ({
   pass,
@@ -83,7 +132,7 @@ export const GroupedTestStatusWithLink = ({
   failLinkProps,
   inconclusiveLinkProps,
 }: ITestStatusWithLink): JSX.Element => {
-  const { successCount, inconclusiveCount, failedCount } = groupStatus({
+  const groupedStatus = groupStatus({
     doneCount: done,
     errorCount: error,
     failCount: fail,
@@ -92,36 +141,15 @@ export const GroupedTestStatusWithLink = ({
     skipCount: skip,
     nullCount: nullStatus,
   });
+
   return (
-    <div className="flex flex-row gap-1">
-      {
-        <Link {...passLinkProps}>
-          <ColoredCircle
-            quantity={successCount ?? 0}
-            tooltipText="global.success"
-            backgroundClassName="bg-light-green"
-          />
-        </Link>
-      }
-      {
-        <Link {...failLinkProps}>
-          <ColoredCircle
-            quantity={failedCount}
-            tooltipText="global.failed"
-            backgroundClassName="bg-light-red"
-          />
-        </Link>
-      }
-      {!hideInconclusive && (
-        <Link {...inconclusiveLinkProps}>
-          <ColoredCircle
-            quantity={inconclusiveCount ?? 0}
-            tooltipText="global.inconclusive"
-            backgroundClassName="bg-medium-gray"
-          />
-        </Link>
-      )}
-    </div>
+    <BaseGroupedStatusWithLink
+      groupedStatus={groupedStatus}
+      passLinkProps={passLinkProps}
+      failLinkProps={failLinkProps}
+      inconclusiveLinkProps={inconclusiveLinkProps}
+      hideInconclusive={hideInconclusive}
+    />
   );
 };
 

--- a/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
@@ -14,11 +14,9 @@ import { matchesRegexOrIncludes } from '@/lib/string';
 
 import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
 
-import { TreeTable } from './TreeTable';
+import type { TreeListingRoutesMap } from '@/utils/constants/treeListing';
 
-interface ITreeListingPage {
-  inputFilter: string;
-}
+import { TreeTable } from './TreeTable';
 
 function isCompleteTree(
   data: Tree | TreeFastPathResponse[number],
@@ -26,16 +24,23 @@ function isCompleteTree(
   return 'build_status' in data;
 }
 
-const TreeListingPage = ({ inputFilter }: ITreeListingPage): JSX.Element => {
+const TreeListingPage = ({
+  inputFilter,
+  urlFromMap,
+}: {
+  inputFilter: string;
+  urlFromMap: TreeListingRoutesMap['v1'];
+}): JSX.Element => {
   //TODO: Combine these 2 hooks inside a single hook
   const {
     data: fastData,
     status: fastStatus,
     error: fastError,
     isLoading: isFastLoading,
-  } = useTreeTableFast();
+  } = useTreeTableFast({ searchFrom: urlFromMap.search });
   const { data, error, status, isLoading } = useTreeTable({
     enabled: fastStatus === 'success' && !!fastData,
+    searchFrom: urlFromMap.search,
   });
 
   const listItems: TreeTableBody[] = useMemo(() => {
@@ -124,6 +129,7 @@ const TreeListingPage = ({ inputFilter }: ITreeListingPage): JSX.Element => {
           error={actualError}
           isLoading={isFastLoading}
           showStatusUnavailable={hasPartialFailure}
+          urlFromMap={urlFromMap}
         />
       </div>
       {kcidevComponent}

--- a/dashboard/src/components/TreeListingPage/TreeListingV2.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeListingV2.tsx
@@ -1,0 +1,86 @@
+import { useMemo, type JSX } from 'react';
+
+import type { TreeV2 } from '@/types/tree/Tree';
+
+import { useTreeListingV2 } from '@/api/tree';
+
+import { Toaster } from '@/components/ui/toaster';
+
+import { matchesRegexOrIncludes } from '@/lib/string';
+
+import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
+
+import { TreeTableV2 } from './TreeTableV2';
+
+const TreeListingPage = ({
+  inputFilter,
+}: {
+  inputFilter: string;
+}): JSX.Element => {
+  const { data, error, status, isLoading } = useTreeListingV2();
+
+  const listItems: TreeV2[] = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+
+    return data
+      .filter(tree => {
+        return (
+          matchesRegexOrIncludes(tree.git_commit_hash, inputFilter) ||
+          matchesRegexOrIncludes(tree.git_repository_branch, inputFilter) ||
+          matchesRegexOrIncludes(tree.git_repository_url, inputFilter) ||
+          matchesRegexOrIncludes(tree.tree_name, inputFilter)
+        );
+      })
+      .sort((a, b) => {
+        const currentATreeName = a.tree_name ?? '';
+        const currentBTreeName = b.tree_name ?? '';
+        const treeNameComparison =
+          currentATreeName.localeCompare(currentBTreeName);
+
+        if (treeNameComparison !== 0) {
+          return treeNameComparison;
+        }
+
+        const currentABranch = a.git_repository_branch ?? '';
+        const currentBBranch = b.git_repository_branch ?? '';
+        const branchComparison = currentABranch.localeCompare(currentBBranch);
+        if (branchComparison !== 0) {
+          return branchComparison;
+        }
+
+        if (a.start_time === undefined || b.start_time === undefined) {
+          return 0;
+        }
+        return (
+          new Date(b.start_time).getTime() - new Date(a.start_time).getTime()
+        );
+      });
+  }, [data, inputFilter]);
+
+  const kcidevComponent = useMemo(
+    () => (
+      <MemoizedKcidevFooter commandGroup="trees" args={{ cmdName: 'trees' }} />
+    ),
+    [],
+  );
+
+  return (
+    <>
+      <Toaster />
+      <div className="flex flex-col gap-6">
+        <TreeTableV2
+          treeTableRows={listItems}
+          status={status}
+          queryData={data}
+          error={error}
+          isLoading={isLoading}
+        />
+      </div>
+      {kcidevComponent}
+    </>
+  );
+};
+
+export default TreeListingPage;

--- a/dashboard/src/components/TreeListingPage/TreeListingV2.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeListingV2.tsx
@@ -10,14 +10,20 @@ import { matchesRegexOrIncludes } from '@/lib/string';
 
 import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
 
+import type { TreeListingRoutesMap } from '@/utils/constants/treeListing';
+
 import { TreeTableV2 } from './TreeTableV2';
 
-const TreeListingPage = ({
+const TreeListingV2 = ({
   inputFilter,
+  urlFromMap,
 }: {
   inputFilter: string;
+  urlFromMap: TreeListingRoutesMap['v2'];
 }): JSX.Element => {
-  const { data, error, status, isLoading } = useTreeListingV2();
+  const { data, error, status, isLoading } = useTreeListingV2({
+    searchFrom: urlFromMap.search,
+  });
 
   const listItems: TreeV2[] = useMemo(() => {
     if (!data) {
@@ -76,6 +82,7 @@ const TreeListingPage = ({
           queryData={data}
           error={error}
           isLoading={isLoading}
+          urlFromMap={urlFromMap}
         />
       </div>
       {kcidevComponent}
@@ -83,4 +90,4 @@ const TreeListingPage = ({
   );
 };
 
-export default TreeListingPage;
+export default TreeListingV2;

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -533,7 +533,7 @@ export function TreeTable({
           />
         </span>
         <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
-          <MemoizedInputTime navigateFrom="/tree" />
+          <MemoizedInputTime navigateFrom={urlFromMap.navigate} />
           <ItemsPerPageSelector
             table={table}
             onPaginationChange={navigateWithPageSize}

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -24,7 +24,7 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 import { TooltipDateTime } from '@/components/TooltipDateTime';
 
 import type { TreeTableBody, TreeV2 } from '@/types/tree/Tree';
-import { DEFAULT_ORIGIN, RedirectFrom } from '@/types/general';
+import { RedirectFrom } from '@/types/general';
 import type { TFilter } from '@/types/general';
 
 import { formattedBreakLineValue } from '@/locales/messages';
@@ -63,6 +63,7 @@ import { makeTreeIdentifierKey } from '@/utils/trees';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+import type { TreeListingRoutesMap } from '@/utils/constants/treeListing';
 
 const getLinkProps = (
   row: Row<TreeTableBody>,
@@ -410,15 +411,6 @@ export const sortTreesWithPinnedFirst = <T extends TreeTableBody | TreeV2>(
   });
 };
 
-interface ITreeTable {
-  treeTableRows: TreeTableBody[];
-  status?: UseQueryResult['status'];
-  queryData?: unknown;
-  error?: Error | null;
-  isLoading?: boolean;
-  showStatusUnavailable?: boolean;
-}
-
 export function TreeTable({
   treeTableRows,
   status,
@@ -426,10 +418,18 @@ export function TreeTable({
   error,
   isLoading,
   showStatusUnavailable,
-}: ITreeTable): JSX.Element {
-  const { origin: unsafeOrigin, listingSize } = useSearch({ strict: false });
-  const origin = unsafeOrigin ?? DEFAULT_ORIGIN;
-  const navigate = useNavigate({ from: '/tree' });
+  urlFromMap,
+}: {
+  treeTableRows: TreeTableBody[];
+  status?: UseQueryResult['status'];
+  queryData?: unknown;
+  error?: Error | null;
+  isLoading?: boolean;
+  showStatusUnavailable?: boolean;
+  urlFromMap: TreeListingRoutesMap['v1'];
+}): JSX.Element {
+  const { origin, listingSize } = useSearch({ from: urlFromMap.search });
+  const navigate = useNavigate({ from: urlFromMap.navigate });
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);

--- a/dashboard/src/components/TreeListingPage/TreeTableV2.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTableV2.tsx
@@ -368,7 +368,7 @@ export function TreeTableV2({
           />
         </span>
         <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
-          <MemoizedInputTime navigateFrom="/tree" />
+          <MemoizedInputTime navigateFrom={urlFromMap.navigate} />
           <ItemsPerPageSelector
             table={table}
             onPaginationChange={navigateWithPageSize}

--- a/dashboard/src/components/TreeListingPage/TreeTableV2.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTableV2.tsx
@@ -22,7 +22,7 @@ import type { LinkProps } from '@tanstack/react-router';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
 import type { TreeV2 } from '@/types/tree/Tree';
-import { DEFAULT_ORIGIN, RedirectFrom } from '@/types/general';
+import { RedirectFrom } from '@/types/general';
 import type { TFilter } from '@/types/general';
 
 import { formattedBreakLineValue } from '@/locales/messages';
@@ -50,6 +50,8 @@ import { MemoizedInputTime } from '@/components/InputTime';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
+
+import type { TreeListingRoutesMap } from '@/utils/constants/treeListing';
 
 import { commonTreeTableColumns, sortTreesWithPinnedFirst } from './TreeTable';
 
@@ -247,25 +249,26 @@ const getColumns = (origin: string): ColumnDef<TreeV2>[] => {
   ];
 };
 
-interface ITreeTableV2 {
-  treeTableRows: TreeV2[];
-  status?: UseQueryResult['status'];
-  queryData?: unknown;
-  error?: Error | null;
-  isLoading?: boolean;
-  showStatusUnavailable?: boolean;
-}
-
 export function TreeTableV2({
   treeTableRows,
   status,
   queryData,
   error,
   isLoading,
-}: ITreeTableV2): JSX.Element {
-  const { origin: unsafeOrigin, listingSize } = useSearch({ strict: false });
-  const origin = unsafeOrigin ?? DEFAULT_ORIGIN;
-  const navigate = useNavigate({ from: '/tree' });
+  urlFromMap,
+}: {
+  treeTableRows: TreeV2[];
+  status?: UseQueryResult['status'];
+  queryData?: unknown;
+  error?: Error | null;
+  isLoading?: boolean;
+  showStatusUnavailable?: boolean;
+  urlFromMap: TreeListingRoutesMap['v2'];
+}): JSX.Element {
+  const { origin, listingSize } = useSearch({
+    from: urlFromMap.search,
+  });
+  const navigate = useNavigate({ from: urlFromMap.navigate });
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);

--- a/dashboard/src/components/TreeListingPage/TreeTableV2.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTableV2.tsx
@@ -21,9 +21,7 @@ import { FormattedMessage } from 'react-intl';
 import type { LinkProps } from '@tanstack/react-router';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
-import { TooltipDateTime } from '@/components/TooltipDateTime';
-
-import type { TreeTableBody, TreeV2 } from '@/types/tree/Tree';
+import type { TreeV2 } from '@/types/tree/Tree';
 import { DEFAULT_ORIGIN, RedirectFrom } from '@/types/general';
 import type { TFilter } from '@/types/general';
 
@@ -37,11 +35,7 @@ import BaseTable, { TableHead } from '@/components/Table/BaseTable';
 import { TableBody, TableCell, TableRow } from '@/components/ui/table';
 import { ConditionalTableCell } from '@/components/Table/ConditionalTableCell';
 
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/Tooltip';
-
-import { sanitizeTableValue } from '@/components/Table/tableUtils';
-
-import { GroupedTestStatusWithLink } from '@/components/Status/Status';
+import { BaseGroupedStatusWithLink } from '@/components/Status/Status';
 import { TableHeader } from '@/components/Table/TableHeader';
 import {
   ItemsPerPageSelector,
@@ -49,23 +43,18 @@ import {
   PaginationButtons,
   PaginationInfo,
 } from '@/components/Table/PaginationInfo';
-import { CommitTagTooltip } from '@/components/Tooltip/CommitTagTooltip';
 
 import type { ListingTableColumnMeta } from '@/types/table';
 
-import { statusCountToRequiredStatusCount } from '@/utils/status';
-
 import { MemoizedInputTime } from '@/components/InputTime';
-import { shouldShowRelativeDate } from '@/lib/date';
-import { valueOrEmpty } from '@/lib/string';
-import { PinnedTrees } from '@/utils/constants/tables';
-import { makeTreeIdentifierKey } from '@/utils/trees';
 
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
+import { commonTreeTableColumns, sortTreesWithPinnedFirst } from './TreeTable';
+
 const getLinkProps = (
-  row: Row<TreeTableBody>,
+  row: Row<TreeV2>,
   origin: string,
   tabTarget?: string,
   diffFilter?: TFilter,
@@ -125,118 +114,13 @@ const getLinkProps = (
       ...s,
       ...stateParams,
       from: RedirectFrom.Tree,
-      treeStatusCount: {
-        builds: statusCountToRequiredStatusCount({
-          PASS: row.original.build_status?.PASS,
-          FAIL: row.original.build_status?.FAIL,
-          NULL: row.original.build_status?.NULL,
-          DONE: row.original.build_status?.DONE,
-          ERROR: row.original.build_status?.ERROR,
-          MISS: row.original.build_status?.MISS,
-          SKIP: row.original.build_status?.SKIP,
-        }),
-        tests: statusCountToRequiredStatusCount({
-          PASS: row.original.test_status?.pass,
-          FAIL: row.original.test_status?.fail,
-          NULL: row.original.test_status?.null,
-          DONE: row.original.test_status?.done,
-          ERROR: row.original.test_status?.error,
-          MISS: row.original.test_status?.miss,
-          SKIP: row.original.test_status?.skip,
-        }),
-        boots: statusCountToRequiredStatusCount({
-          PASS: row.original.boot_status?.pass,
-          FAIL: row.original.boot_status?.fail,
-          NULL: row.original.boot_status?.null,
-          DONE: row.original.boot_status?.done,
-          ERROR: row.original.boot_status?.error,
-          MISS: row.original.boot_status?.miss,
-          SKIP: row.original.boot_status?.skip,
-        }),
-      },
     }),
   };
 };
 
-export const commonTreeTableColumns: ColumnDef<TreeTableBody | TreeV2>[] = [
-  {
-    accessorKey: 'tree_name',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.tree" />
-    ),
-    cell: ({ row }): JSX.Element => {
-      return (
-        <Tooltip>
-          <TooltipTrigger>
-            {sanitizeTableValue(row.getValue('tree_name') ?? '', false)}
-          </TooltipTrigger>
-          <TooltipContent>
-            <a
-              href={row.original.git_repository_url}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {sanitizeTableValue(row.original.git_repository_url, false)}
-            </a>
-          </TooltipContent>
-        </Tooltip>
-      );
-    },
-    meta: {
-      tabTarget: 'global.builds',
-    },
-  },
-  {
-    accessorKey: 'git_repository_branch',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.branch" />
-    ),
-    cell: ({ row }) => valueOrEmpty(row.getValue('git_repository_branch')),
-    meta: {
-      tabTarget: 'global.builds',
-    },
-  },
-  {
-    id: 'git_commit_tags',
-    accessorKey: 'git_commit_tags',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="globalTable.commitTag" />
-    ),
-    cell: ({ row }): JSX.Element => (
-      <CommitTagTooltip
-        commitName={row.original.git_commit_name}
-        commitHash={row.original.git_commit_hash}
-        commitTags={row.original.git_commit_tags}
-      />
-    ),
-    meta: {
-      tabTarget: 'global.builds',
-    },
-  },
-  {
-    accessorKey: 'start_time',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="global.date" />
-    ),
-    cell: ({ row }): JSX.Element => (
-      <TooltipDateTime
-        dateTime={row.getValue('start_time')}
-        lineBreak={true}
-        showRelative={shouldShowRelativeDate(row.getValue('start_time'))}
-      />
-    ),
-    meta: {
-      tabTarget: 'global.builds',
-    },
-  },
-];
-
-const getColumns = (
-  origin: string,
-  showStatusUnavailable?: boolean,
-): ColumnDef<TreeTableBody>[] => {
+const getColumns = (origin: string): ColumnDef<TreeV2>[] => {
   return [
-    ...(commonTreeTableColumns as ColumnDef<TreeTableBody>[]),
+    ...(commonTreeTableColumns as ColumnDef<TreeV2>[]),
     {
       accessorKey: 'build_status.PASS',
       header: ({ column }): JSX.Element => (
@@ -249,15 +133,13 @@ const getColumns = (
       cell: ({ column, row }): JSX.Element => {
         const tabTarget = (column.columnDef.meta as ListingTableColumnMeta)
           .tabTarget;
-        return row.original.build_status ? (
-          <GroupedTestStatusWithLink
-            pass={row.original.build_status.PASS}
-            skip={row.original.build_status.SKIP}
-            fail={row.original.build_status.FAIL}
-            miss={row.original.build_status.MISS}
-            done={row.original.build_status.DONE}
-            error={row.original.build_status.ERROR}
-            nullStatus={row.original.build_status.NULL}
+        return (
+          <BaseGroupedStatusWithLink
+            groupedStatus={{
+              successCount: row.original.build_status.PASS,
+              failedCount: row.original.build_status.FAIL,
+              inconclusiveCount: row.original.build_status.INCONCLUSIVE,
+            }}
             passLinkProps={getLinkProps(row, origin, tabTarget, {
               buildStatus: { PASS: true },
             })}
@@ -274,10 +156,6 @@ const getColumns = (
               },
             })}
           />
-        ) : showStatusUnavailable ? (
-          <span>-</span>
-        ) : (
-          <FormattedMessage id="global.loading" defaultMessage="Loading..." />
         );
       },
       meta: {
@@ -296,15 +174,13 @@ const getColumns = (
       cell: ({ column, row }): JSX.Element => {
         const tabTarget = (column.columnDef.meta as ListingTableColumnMeta)
           .tabTarget;
-        return row.original.boot_status ? (
-          <GroupedTestStatusWithLink
-            pass={row.original.boot_status.pass}
-            skip={row.original.boot_status.skip}
-            fail={row.original.boot_status.fail}
-            miss={row.original.boot_status.miss}
-            done={row.original.boot_status.done}
-            error={row.original.boot_status.error}
-            nullStatus={row.original.boot_status.null}
+        return (
+          <BaseGroupedStatusWithLink
+            groupedStatus={{
+              successCount: row.original.boot_status.PASS,
+              failedCount: row.original.boot_status.FAIL,
+              inconclusiveCount: row.original.boot_status.INCONCLUSIVE,
+            }}
             passLinkProps={getLinkProps(row, origin, tabTarget, {
               bootStatus: { PASS: true },
             })}
@@ -321,10 +197,6 @@ const getColumns = (
               },
             })}
           />
-        ) : showStatusUnavailable ? (
-          <span>-</span>
-        ) : (
-          <FormattedMessage id="global.loading" defaultMessage="Loading..." />
         );
       },
       meta: {
@@ -343,15 +215,13 @@ const getColumns = (
       cell: ({ column, row }): JSX.Element => {
         const tabTarget = (column.columnDef.meta as ListingTableColumnMeta)
           .tabTarget;
-        return row.original.test_status ? (
-          <GroupedTestStatusWithLink
-            pass={row.original.test_status.pass}
-            skip={row.original.test_status.skip}
-            fail={row.original.test_status.fail}
-            miss={row.original.test_status.miss}
-            done={row.original.test_status.done}
-            error={row.original.test_status.error}
-            nullStatus={row.original.test_status.null}
+        return (
+          <BaseGroupedStatusWithLink
+            groupedStatus={{
+              successCount: row.original.test_status.PASS,
+              failedCount: row.original.test_status.FAIL,
+              inconclusiveCount: row.original.test_status.INCONCLUSIVE,
+            }}
             passLinkProps={getLinkProps(row, origin, tabTarget, {
               testStatus: { PASS: true },
             })}
@@ -368,10 +238,6 @@ const getColumns = (
               },
             })}
           />
-        ) : showStatusUnavailable ? (
-          <span>-</span>
-        ) : (
-          <FormattedMessage id="global.loading" defaultMessage="Loading..." />
         );
       },
       meta: {
@@ -381,37 +247,8 @@ const getColumns = (
   ];
 };
 
-export const sortTreesWithPinnedFirst = <T extends TreeTableBody | TreeV2>(
-  treeTableRows: T[],
-): T[] => {
-  return treeTableRows.sort((a, b) => {
-    const aKey = makeTreeIdentifierKey({
-      treeName: valueOrEmpty(a.tree_name),
-      gitRepositoryBranch: valueOrEmpty(a.git_repository_branch),
-      separator: '/',
-    });
-    const bKey = makeTreeIdentifierKey({
-      treeName: valueOrEmpty(b.tree_name),
-      gitRepositoryBranch: valueOrEmpty(b.git_repository_branch),
-      separator: '/',
-    });
-
-    const aIsPinned = PinnedTrees.some(regex => regex.test(aKey));
-    const bIsPinned = PinnedTrees.some(regex => regex.test(bKey));
-
-    if (aIsPinned && !bIsPinned) {
-      return -1;
-    }
-    if (!aIsPinned && bIsPinned) {
-      return 1;
-    }
-
-    return aKey.localeCompare(bKey);
-  });
-};
-
-interface ITreeTable {
-  treeTableRows: TreeTableBody[];
+interface ITreeTableV2 {
+  treeTableRows: TreeV2[];
   status?: UseQueryResult['status'];
   queryData?: unknown;
   error?: Error | null;
@@ -419,14 +256,13 @@ interface ITreeTable {
   showStatusUnavailable?: boolean;
 }
 
-export function TreeTable({
+export function TreeTableV2({
   treeTableRows,
   status,
   queryData,
   error,
   isLoading,
-  showStatusUnavailable,
-}: ITreeTable): JSX.Element {
+}: ITreeTableV2): JSX.Element {
   const { origin: unsafeOrigin, listingSize } = useSearch({ strict: false });
   const origin = unsafeOrigin ?? DEFAULT_ORIGIN;
   const navigate = useNavigate({ from: '/tree' });
@@ -438,15 +274,11 @@ export function TreeTable({
     listingSize,
   );
 
-  const orderedData = useMemo(
-    () => sortTreesWithPinnedFirst(treeTableRows),
-    [treeTableRows],
-  );
+  const orderedData = useMemo(() => {
+    return sortTreesWithPinnedFirst(treeTableRows);
+  }, [treeTableRows]);
 
-  const columns = useMemo(
-    () => getColumns(origin, showStatusUnavailable),
-    [origin, showStatusUnavailable],
-  );
+  const columns = useMemo(() => getColumns(origin), [origin]);
 
   const table = useReactTable({
     data: orderedData,
@@ -545,13 +377,6 @@ export function TreeTable({
           <PaginationButtons table={table} className="pl-4" />
         </div>
       </div>
-      {showStatusUnavailable && (
-        <div className="rounded-md border border-red-500 bg-red-50 p-4 text-red-800">
-          <p className="text-sm">
-            <FormattedMessage id="treeListing.statusUnavailable" />
-          </p>
-        </div>
-      )}
       <QuerySwitcher
         status={status}
         data={queryData}

--- a/dashboard/src/hooks/useFeatureFlag.ts
+++ b/dashboard/src/hooks/useFeatureFlag.ts
@@ -1,9 +1,12 @@
 type FeatureFlags = {
   showDev: boolean;
+  treeListingVersion: string;
 };
 
 export const useFeatureFlag = (): FeatureFlags => {
   return {
     showDev: import.meta.env.VITE_FEATURE_FLAG_SHOW_DEV ?? false,
+    treeListingVersion:
+      import.meta.env.VITE_FEATURE_FLAG_TREE_LISTING_VERSION ?? 'v1',
   };
 };

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -138,7 +138,9 @@ export const messages = {
     'global.filter': 'Filter',
     'global.filters': 'Filters',
     'global.fullLogs': 'Full logs',
+    'global.gitHubIssue': 'GitHub Issue',
     'global.hardware': 'Hardware',
+    'global.here': 'here',
     'global.id': 'Id',
     'global.inconclusive': 'Inconclusive',
     'global.inconclusiveCount': 'Inconclusive: {count}',
@@ -258,6 +260,10 @@ export const messages = {
     'logViewer.viewFullLog': 'View full log for {fileName}',
     'logspec.info':
       "This is the same logspec data that's in the misc data section",
+    'messages.newerPageVersion':
+      'This is the new, optimized version of the {page}. If you find any bugs, please file a {gitHubLink} and you can still access the old version {oldVersionLink}. Please note that some historical data might be missing, but it should be updated with recent data.',
+    'messages.olderPageVersion':
+      'This is the legacy version of the {page}, please refer to the new, optimized version {newPageLink}. If you find any bugs or divergences, please report to {gitHubLink}.',
     'routes.buildDetails': 'Build',
     'routes.hardwareMonitor': 'Hardware',
     'routes.hardwareNewMonitor': 'Hardware New',
@@ -352,6 +358,7 @@ export const messages = {
     'treeListing.statusUnavailable':
       'Error: Unable to load tree status information. Displaying basic information only.',
     'treeListing.title': 'Tree Listing ― KCI Dashboard',
+    'treeListing.treeListing': 'Tree Listing',
   },
 };
 

--- a/dashboard/src/pages/HardwareNew/Hardware.tsx
+++ b/dashboard/src/pages/HardwareNew/Hardware.tsx
@@ -35,7 +35,7 @@ const Hardware = (): JSX.Element => {
 
   return (
     <>
-      <MemoizedListingOGTags monitor="/hardware-new" search={hardwareSearch} />
+      <MemoizedListingOGTags monitor="/hardware" search={hardwareSearch} />
       <div className="fixed top-0 z-10 mx-[380px] flex w-full pt-5 pr-12 pl-6">
         <div className="flex w-2/3 items-center px-6">
           <DebounceInput

--- a/dashboard/src/pages/TreeListing/Trees.tsx
+++ b/dashboard/src/pages/TreeListing/Trees.tsx
@@ -11,6 +11,7 @@ import TreeListingPage from '@/components/TreeListingPage/TreeListingPage';
 
 import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
+import { OldPageBanner } from '@/components/Banner/PageBanner';
 
 const Trees = (): JSX.Element => {
   const { treeSearch: unsafeTreeSearch } = useSearch({
@@ -49,7 +50,8 @@ const Trees = (): JSX.Element => {
           />
         </div>
       </div>
-      <div className="bg-light-gray w-full py-10">
+      <OldPageBanner pageNameId="treeListing.treeListing" pageRoute="/tree" />
+      <div className="bg-light-gray w-full py-4">
         <TreeListingPage inputFilter={treeSearch} />
       </div>
     </>

--- a/dashboard/src/pages/TreeListing/Trees.tsx
+++ b/dashboard/src/pages/TreeListing/Trees.tsx
@@ -5,22 +5,25 @@ import { useIntl } from 'react-intl';
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
-import { z } from 'zod';
-
 import TreeListingPage from '@/components/TreeListingPage/TreeListingPage';
 
 import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
 import { OldPageBanner } from '@/components/Banner/PageBanner';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import type { TreeListingRoutesMap } from '@/utils/constants/treeListing';
 
-const Trees = (): JSX.Element => {
-  const { treeSearch: unsafeTreeSearch } = useSearch({
-    strict: false,
+const Trees = ({
+  urlFromMap,
+}: {
+  urlFromMap: TreeListingRoutesMap['v1'];
+}): JSX.Element => {
+  const { treeListingVersion } = useFeatureFlag();
+  const { treeSearch } = useSearch({
+    from: urlFromMap.search,
   });
 
-  const treeSearch = z.string().catch('').parse(unsafeTreeSearch);
-
-  const navigate = useNavigate({ from: '/tree/v1' });
+  const navigate = useNavigate({ from: urlFromMap.navigate });
 
   const onInputSearchTextChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -50,9 +53,11 @@ const Trees = (): JSX.Element => {
           />
         </div>
       </div>
-      <OldPageBanner pageNameId="treeListing.treeListing" pageRoute="/tree" />
+      {treeListingVersion !== 'v1' && (
+        <OldPageBanner pageNameId="treeListing.treeListing" pageRoute="/tree" />
+      )}
       <div className="bg-light-gray w-full py-4">
-        <TreeListingPage inputFilter={treeSearch} />
+        <TreeListingPage inputFilter={treeSearch} urlFromMap={urlFromMap} />
       </div>
     </>
   );

--- a/dashboard/src/pages/TreeListing/Trees.tsx
+++ b/dashboard/src/pages/TreeListing/Trees.tsx
@@ -1,0 +1,59 @@
+import type { ChangeEvent, JSX } from 'react';
+import { useCallback } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { useNavigate, useSearch } from '@tanstack/react-router';
+
+import { z } from 'zod';
+
+import TreeListingPage from '@/components/TreeListingPage/TreeListingPage';
+
+import DebounceInput from '@/components/DebounceInput/DebounceInput';
+import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
+
+const Trees = (): JSX.Element => {
+  const { treeSearch: unsafeTreeSearch } = useSearch({
+    strict: false,
+  });
+
+  const treeSearch = z.string().catch('').parse(unsafeTreeSearch);
+
+  const navigate = useNavigate({ from: '/tree/v1' });
+
+  const onInputSearchTextChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      navigate({
+        search: previousSearch => ({
+          ...previousSearch,
+          treeSearch: e.target.value,
+        }),
+      });
+    },
+    [navigate],
+  );
+
+  const { formatMessage } = useIntl();
+
+  return (
+    <>
+      <MemoizedListingOGTags monitor="/tree" search={treeSearch} />
+      <div className="fixed top-0 z-10 mx-[380px] flex w-full pt-5 pr-12 pl-6">
+        <div className="flex w-2/3 items-center px-6">
+          <DebounceInput
+            debouncedSideEffect={onInputSearchTextChange}
+            className="w-2/3"
+            type="text"
+            startingValue={treeSearch}
+            placeholder={formatMessage({ id: 'tree.searchPlaceholder' })}
+          />
+        </div>
+      </div>
+      <div className="bg-light-gray w-full py-10">
+        <TreeListingPage inputFilter={treeSearch} />
+      </div>
+    </>
+  );
+};
+
+export default Trees;

--- a/dashboard/src/pages/TreeListing/TreesV2.tsx
+++ b/dashboard/src/pages/TreeListing/TreesV2.tsx
@@ -5,21 +5,24 @@ import { useIntl } from 'react-intl';
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
 
-import { z } from 'zod';
-
 import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
 import TreeListingV2 from '@/components/TreeListingPage/TreeListingV2';
 import { NewPageBanner } from '@/components/Banner/PageBanner';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import type { TreeListingRoutesMap } from '@/utils/constants/treeListing';
 
-const TreeListingNew = (): JSX.Element => {
-  const { treeSearch: unsafeTreeSearch } = useSearch({
-    strict: false,
+const TreeListingPageV2 = ({
+  urlFromMap,
+}: {
+  urlFromMap: TreeListingRoutesMap['v2'];
+}): JSX.Element => {
+  const { treeListingVersion } = useFeatureFlag();
+  const { treeSearch } = useSearch({
+    from: urlFromMap.search,
   });
 
-  const treeSearch = z.string().catch('').parse(unsafeTreeSearch);
-
-  const navigate = useNavigate({ from: '/' });
+  const navigate = useNavigate({ from: urlFromMap.navigate });
 
   const onInputSearchTextChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -49,15 +52,17 @@ const TreeListingNew = (): JSX.Element => {
           />
         </div>
       </div>
-      <NewPageBanner
-        pageNameId="treeListing.treeListing"
-        pageRoute="/tree/v1"
-      />
+      {treeListingVersion !== 'v2' && (
+        <NewPageBanner
+          pageNameId="treeListing.treeListing"
+          pageRoute="/tree/v1"
+        />
+      )}
       <div className="bg-light-gray w-full py-4">
-        <TreeListingV2 inputFilter={treeSearch} />
+        <TreeListingV2 inputFilter={treeSearch} urlFromMap={urlFromMap} />
       </div>
     </>
   );
 };
 
-export default TreeListingNew;
+export default TreeListingPageV2;

--- a/dashboard/src/pages/TreeListing/TreesV2.tsx
+++ b/dashboard/src/pages/TreeListing/TreesV2.tsx
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
 import TreeListingV2 from '@/components/TreeListingPage/TreeListingV2';
+import { NewPageBanner } from '@/components/Banner/PageBanner';
 
 const TreeListingNew = (): JSX.Element => {
   const { treeSearch: unsafeTreeSearch } = useSearch({
@@ -48,7 +49,11 @@ const TreeListingNew = (): JSX.Element => {
           />
         </div>
       </div>
-      <div className="bg-light-gray w-full py-10">
+      <NewPageBanner
+        pageNameId="treeListing.treeListing"
+        pageRoute="/tree/v1"
+      />
+      <div className="bg-light-gray w-full py-4">
         <TreeListingV2 inputFilter={treeSearch} />
       </div>
     </>

--- a/dashboard/src/pages/TreeListing/TreesV2.tsx
+++ b/dashboard/src/pages/TreeListing/TreesV2.tsx
@@ -7,12 +7,11 @@ import { useNavigate, useSearch } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
-import TreeListingPage from '@/components/TreeListingPage/TreeListingPage';
-
 import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
+import TreeListingV2 from '@/components/TreeListingPage/TreeListingV2';
 
-const Trees = (): JSX.Element => {
+const TreeListingNew = (): JSX.Element => {
   const { treeSearch: unsafeTreeSearch } = useSearch({
     strict: false,
   });
@@ -50,10 +49,10 @@ const Trees = (): JSX.Element => {
         </div>
       </div>
       <div className="bg-light-gray w-full py-10">
-        <TreeListingPage inputFilter={treeSearch} />
+        <TreeListingV2 inputFilter={treeSearch} />
       </div>
     </>
   );
 };
 
-export default Trees;
+export default TreeListingNew;

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -20,12 +20,14 @@ import { Route as MainTreeIndexRouteImport } from './routes/_main/tree/index'
 import { Route as MainIssuesIndexRouteImport } from './routes/_main/issues/index'
 import { Route as MainHardwareIndexRouteImport } from './routes/_main/hardware/index'
 import { Route as MainHardwareNewIndexRouteImport } from './routes/_main/hardware-new/index'
+import { Route as MainTreeV2RouteRouteImport } from './routes/_main/tree/v2/route'
 import { Route as MainTreeV1RouteRouteImport } from './routes/_main/tree/v1/route'
 import { Route as MainTreeTreeIdRouteRouteImport } from './routes/_main/tree/$treeId/route'
 import { Route as MainTestTestIdRouteRouteImport } from './routes/_main/test/$testId/route'
 import { Route as MainIssueIssueIdRouteRouteImport } from './routes/_main/issue/$issueId/route'
 import { Route as MainHardwareHardwareIdRouteRouteImport } from './routes/_main/hardware/$hardwareId/route'
 import { Route as MainBuildBuildIdRouteRouteImport } from './routes/_main/build/$buildId/route'
+import { Route as MainTreeV2IndexRouteImport } from './routes/_main/tree/v2/index'
 import { Route as MainTreeV1IndexRouteImport } from './routes/_main/tree/v1/index'
 import { Route as MainTreeTreeIdIndexRouteImport } from './routes/_main/tree/$treeId/index'
 import { Route as MainTestTestIdIndexRouteImport } from './routes/_main/test/$testId/index'
@@ -109,6 +111,11 @@ const MainHardwareNewIndexRoute = MainHardwareNewIndexRouteImport.update({
   path: '/',
   getParentRoute: () => MainHardwareNewRouteRoute,
 } as any)
+const MainTreeV2RouteRoute = MainTreeV2RouteRouteImport.update({
+  id: '/v2',
+  path: '/v2',
+  getParentRoute: () => MainTreeRouteRoute,
+} as any)
 const MainTreeV1RouteRoute = MainTreeV1RouteRouteImport.update({
   id: '/v1',
   path: '/v1',
@@ -139,6 +146,11 @@ const MainBuildBuildIdRouteRoute = MainBuildBuildIdRouteRouteImport.update({
   id: '/build/$buildId',
   path: '/build/$buildId',
   getParentRoute: () => MainRouteRoute,
+} as any)
+const MainTreeV2IndexRoute = MainTreeV2IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => MainTreeV2RouteRoute,
 } as any)
 const MainTreeV1IndexRoute = MainTreeV1IndexRouteImport.update({
   id: '/',
@@ -316,6 +328,7 @@ export interface FileRoutesByFullPath {
   '/test/$testId': typeof MainTestTestIdRouteRouteWithChildren
   '/tree/$treeId': typeof MainTreeTreeIdRouteRouteWithChildren
   '/tree/v1': typeof MainTreeV1RouteRouteWithChildren
+  '/tree/v2': typeof MainTreeV2RouteRouteWithChildren
   '/hardware-new/': typeof MainHardwareNewIndexRoute
   '/hardware/': typeof MainHardwareIndexRoute
   '/issues/': typeof MainIssuesIndexRoute
@@ -330,6 +343,7 @@ export interface FileRoutesByFullPath {
   '/test/$testId/': typeof MainTestTestIdIndexRoute
   '/tree/$treeId/': typeof MainTreeTreeIdIndexRoute
   '/tree/v1/': typeof MainTreeV1IndexRoute
+  '/tree/v2/': typeof MainTreeV2IndexRoute
   '/tree/$treeName/$branch/$hash': typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   '/b/$buildId/': typeof MainalternativesBBuildIdIndexRoute
   '/i/$issueId/': typeof MainalternativesIIssueIdIndexRoute
@@ -363,6 +377,7 @@ export interface FileRoutesByTo {
   '/test/$testId': typeof MainTestTestIdIndexRoute
   '/tree/$treeId': typeof MainTreeTreeIdIndexRoute
   '/tree/v1': typeof MainTreeV1IndexRoute
+  '/tree/v2': typeof MainTreeV2IndexRoute
   '/b/$buildId': typeof MainalternativesBBuildIdIndexRoute
   '/i/$issueId': typeof MainalternativesIIssueIdIndexRoute
   '/t/$testId': typeof MainalternativesTTestIdIndexRoute
@@ -396,6 +411,7 @@ export interface FileRoutesById {
   '/_main/test/$testId': typeof MainTestTestIdRouteRouteWithChildren
   '/_main/tree/$treeId': typeof MainTreeTreeIdRouteRouteWithChildren
   '/_main/tree/v1': typeof MainTreeV1RouteRouteWithChildren
+  '/_main/tree/v2': typeof MainTreeV2RouteRouteWithChildren
   '/_main/hardware-new/': typeof MainHardwareNewIndexRoute
   '/_main/hardware/': typeof MainHardwareIndexRoute
   '/_main/issues/': typeof MainIssuesIndexRoute
@@ -410,6 +426,7 @@ export interface FileRoutesById {
   '/_main/test/$testId/': typeof MainTestTestIdIndexRoute
   '/_main/tree/$treeId/': typeof MainTreeTreeIdIndexRoute
   '/_main/tree/v1/': typeof MainTreeV1IndexRoute
+  '/_main/tree/v2/': typeof MainTreeV2IndexRoute
   '/_main/tree/$treeName/$branch/$hash': typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   '/_main/(alternatives)/b/$buildId/': typeof MainalternativesBBuildIdIndexRoute
   '/_main/(alternatives)/i/$issueId/': typeof MainalternativesIIssueIdIndexRoute
@@ -444,6 +461,7 @@ export interface FileRouteTypes {
     | '/test/$testId'
     | '/tree/$treeId'
     | '/tree/v1'
+    | '/tree/v2'
     | '/hardware-new/'
     | '/hardware/'
     | '/issues/'
@@ -458,6 +476,7 @@ export interface FileRouteTypes {
     | '/test/$testId/'
     | '/tree/$treeId/'
     | '/tree/v1/'
+    | '/tree/v2/'
     | '/tree/$treeName/$branch/$hash'
     | '/b/$buildId/'
     | '/i/$issueId/'
@@ -491,6 +510,7 @@ export interface FileRouteTypes {
     | '/test/$testId'
     | '/tree/$treeId'
     | '/tree/v1'
+    | '/tree/v2'
     | '/b/$buildId'
     | '/i/$issueId'
     | '/t/$testId'
@@ -523,6 +543,7 @@ export interface FileRouteTypes {
     | '/_main/test/$testId'
     | '/_main/tree/$treeId'
     | '/_main/tree/v1'
+    | '/_main/tree/v2'
     | '/_main/hardware-new/'
     | '/_main/hardware/'
     | '/_main/issues/'
@@ -537,6 +558,7 @@ export interface FileRouteTypes {
     | '/_main/test/$testId/'
     | '/_main/tree/$treeId/'
     | '/_main/tree/v1/'
+    | '/_main/tree/v2/'
     | '/_main/tree/$treeName/$branch/$hash'
     | '/_main/(alternatives)/b/$buildId/'
     | '/_main/(alternatives)/i/$issueId/'
@@ -641,6 +663,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MainHardwareNewIndexRouteImport
       parentRoute: typeof MainHardwareNewRouteRoute
     }
+    '/_main/tree/v2': {
+      id: '/_main/tree/v2'
+      path: '/v2'
+      fullPath: '/tree/v2'
+      preLoaderRoute: typeof MainTreeV2RouteRouteImport
+      parentRoute: typeof MainTreeRouteRoute
+    }
     '/_main/tree/v1': {
       id: '/_main/tree/v1'
       path: '/v1'
@@ -682,6 +711,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/build/$buildId'
       preLoaderRoute: typeof MainBuildBuildIdRouteRouteImport
       parentRoute: typeof MainRouteRoute
+    }
+    '/_main/tree/v2/': {
+      id: '/_main/tree/v2/'
+      path: '/'
+      fullPath: '/tree/v2/'
+      preLoaderRoute: typeof MainTreeV2IndexRouteImport
+      parentRoute: typeof MainTreeV2RouteRoute
     }
     '/_main/tree/v1/': {
       id: '/_main/tree/v1/'
@@ -976,6 +1012,18 @@ const MainTreeV1RouteRouteWithChildren = MainTreeV1RouteRoute._addFileChildren(
   MainTreeV1RouteRouteChildren,
 )
 
+interface MainTreeV2RouteRouteChildren {
+  MainTreeV2IndexRoute: typeof MainTreeV2IndexRoute
+}
+
+const MainTreeV2RouteRouteChildren: MainTreeV2RouteRouteChildren = {
+  MainTreeV2IndexRoute: MainTreeV2IndexRoute,
+}
+
+const MainTreeV2RouteRouteWithChildren = MainTreeV2RouteRoute._addFileChildren(
+  MainTreeV2RouteRouteChildren,
+)
+
 interface MainTreeTreeNameBranchHashRouteRouteChildren {
   MainTreeTreeNameBranchHashIndexRoute: typeof MainTreeTreeNameBranchHashIndexRoute
 }
@@ -993,6 +1041,7 @@ const MainTreeTreeNameBranchHashRouteRouteWithChildren =
 interface MainTreeRouteRouteChildren {
   MainTreeTreeIdRouteRoute: typeof MainTreeTreeIdRouteRouteWithChildren
   MainTreeV1RouteRoute: typeof MainTreeV1RouteRouteWithChildren
+  MainTreeV2RouteRoute: typeof MainTreeV2RouteRouteWithChildren
   MainTreeIndexRoute: typeof MainTreeIndexRoute
   MainTreeTreeNameBranchHashRouteRoute: typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   MainTreeTreeNameBranchIndexRoute: typeof MainTreeTreeNameBranchIndexRoute
@@ -1001,6 +1050,7 @@ interface MainTreeRouteRouteChildren {
 const MainTreeRouteRouteChildren: MainTreeRouteRouteChildren = {
   MainTreeTreeIdRouteRoute: MainTreeTreeIdRouteRouteWithChildren,
   MainTreeV1RouteRoute: MainTreeV1RouteRouteWithChildren,
+  MainTreeV2RouteRoute: MainTreeV2RouteRouteWithChildren,
   MainTreeIndexRoute: MainTreeIndexRoute,
   MainTreeTreeNameBranchHashRouteRoute:
     MainTreeTreeNameBranchHashRouteRouteWithChildren,

--- a/dashboard/src/routeTree.gen.ts
+++ b/dashboard/src/routeTree.gen.ts
@@ -20,11 +20,13 @@ import { Route as MainTreeIndexRouteImport } from './routes/_main/tree/index'
 import { Route as MainIssuesIndexRouteImport } from './routes/_main/issues/index'
 import { Route as MainHardwareIndexRouteImport } from './routes/_main/hardware/index'
 import { Route as MainHardwareNewIndexRouteImport } from './routes/_main/hardware-new/index'
+import { Route as MainTreeV1RouteRouteImport } from './routes/_main/tree/v1/route'
 import { Route as MainTreeTreeIdRouteRouteImport } from './routes/_main/tree/$treeId/route'
 import { Route as MainTestTestIdRouteRouteImport } from './routes/_main/test/$testId/route'
 import { Route as MainIssueIssueIdRouteRouteImport } from './routes/_main/issue/$issueId/route'
 import { Route as MainHardwareHardwareIdRouteRouteImport } from './routes/_main/hardware/$hardwareId/route'
 import { Route as MainBuildBuildIdRouteRouteImport } from './routes/_main/build/$buildId/route'
+import { Route as MainTreeV1IndexRouteImport } from './routes/_main/tree/v1/index'
 import { Route as MainTreeTreeIdIndexRouteImport } from './routes/_main/tree/$treeId/index'
 import { Route as MainTestTestIdIndexRouteImport } from './routes/_main/test/$testId/index'
 import { Route as MainIssueIssueIdIndexRouteImport } from './routes/_main/issue/$issueId/index'
@@ -107,6 +109,11 @@ const MainHardwareNewIndexRoute = MainHardwareNewIndexRouteImport.update({
   path: '/',
   getParentRoute: () => MainHardwareNewRouteRoute,
 } as any)
+const MainTreeV1RouteRoute = MainTreeV1RouteRouteImport.update({
+  id: '/v1',
+  path: '/v1',
+  getParentRoute: () => MainTreeRouteRoute,
+} as any)
 const MainTreeTreeIdRouteRoute = MainTreeTreeIdRouteRouteImport.update({
   id: '/$treeId',
   path: '/$treeId',
@@ -132,6 +139,11 @@ const MainBuildBuildIdRouteRoute = MainBuildBuildIdRouteRouteImport.update({
   id: '/build/$buildId',
   path: '/build/$buildId',
   getParentRoute: () => MainRouteRoute,
+} as any)
+const MainTreeV1IndexRoute = MainTreeV1IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => MainTreeV1RouteRoute,
 } as any)
 const MainTreeTreeIdIndexRoute = MainTreeTreeIdIndexRouteImport.update({
   id: '/',
@@ -303,6 +315,7 @@ export interface FileRoutesByFullPath {
   '/issue/$issueId': typeof MainIssueIssueIdRouteRouteWithChildren
   '/test/$testId': typeof MainTestTestIdRouteRouteWithChildren
   '/tree/$treeId': typeof MainTreeTreeIdRouteRouteWithChildren
+  '/tree/v1': typeof MainTreeV1RouteRouteWithChildren
   '/hardware-new/': typeof MainHardwareNewIndexRoute
   '/hardware/': typeof MainHardwareIndexRoute
   '/issues/': typeof MainIssuesIndexRoute
@@ -316,6 +329,7 @@ export interface FileRoutesByFullPath {
   '/issue/$issueId/': typeof MainIssueIssueIdIndexRoute
   '/test/$testId/': typeof MainTestTestIdIndexRoute
   '/tree/$treeId/': typeof MainTreeTreeIdIndexRoute
+  '/tree/v1/': typeof MainTreeV1IndexRoute
   '/tree/$treeName/$branch/$hash': typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   '/b/$buildId/': typeof MainalternativesBBuildIdIndexRoute
   '/i/$issueId/': typeof MainalternativesIIssueIdIndexRoute
@@ -348,6 +362,7 @@ export interface FileRoutesByTo {
   '/issue/$issueId': typeof MainIssueIssueIdIndexRoute
   '/test/$testId': typeof MainTestTestIdIndexRoute
   '/tree/$treeId': typeof MainTreeTreeIdIndexRoute
+  '/tree/v1': typeof MainTreeV1IndexRoute
   '/b/$buildId': typeof MainalternativesBBuildIdIndexRoute
   '/i/$issueId': typeof MainalternativesIIssueIdIndexRoute
   '/t/$testId': typeof MainalternativesTTestIdIndexRoute
@@ -380,6 +395,7 @@ export interface FileRoutesById {
   '/_main/issue/$issueId': typeof MainIssueIssueIdRouteRouteWithChildren
   '/_main/test/$testId': typeof MainTestTestIdRouteRouteWithChildren
   '/_main/tree/$treeId': typeof MainTreeTreeIdRouteRouteWithChildren
+  '/_main/tree/v1': typeof MainTreeV1RouteRouteWithChildren
   '/_main/hardware-new/': typeof MainHardwareNewIndexRoute
   '/_main/hardware/': typeof MainHardwareIndexRoute
   '/_main/issues/': typeof MainIssuesIndexRoute
@@ -393,6 +409,7 @@ export interface FileRoutesById {
   '/_main/issue/$issueId/': typeof MainIssueIssueIdIndexRoute
   '/_main/test/$testId/': typeof MainTestTestIdIndexRoute
   '/_main/tree/$treeId/': typeof MainTreeTreeIdIndexRoute
+  '/_main/tree/v1/': typeof MainTreeV1IndexRoute
   '/_main/tree/$treeName/$branch/$hash': typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   '/_main/(alternatives)/b/$buildId/': typeof MainalternativesBBuildIdIndexRoute
   '/_main/(alternatives)/i/$issueId/': typeof MainalternativesIIssueIdIndexRoute
@@ -426,6 +443,7 @@ export interface FileRouteTypes {
     | '/issue/$issueId'
     | '/test/$testId'
     | '/tree/$treeId'
+    | '/tree/v1'
     | '/hardware-new/'
     | '/hardware/'
     | '/issues/'
@@ -439,6 +457,7 @@ export interface FileRouteTypes {
     | '/issue/$issueId/'
     | '/test/$testId/'
     | '/tree/$treeId/'
+    | '/tree/v1/'
     | '/tree/$treeName/$branch/$hash'
     | '/b/$buildId/'
     | '/i/$issueId/'
@@ -471,6 +490,7 @@ export interface FileRouteTypes {
     | '/issue/$issueId'
     | '/test/$testId'
     | '/tree/$treeId'
+    | '/tree/v1'
     | '/b/$buildId'
     | '/i/$issueId'
     | '/t/$testId'
@@ -502,6 +522,7 @@ export interface FileRouteTypes {
     | '/_main/issue/$issueId'
     | '/_main/test/$testId'
     | '/_main/tree/$treeId'
+    | '/_main/tree/v1'
     | '/_main/hardware-new/'
     | '/_main/hardware/'
     | '/_main/issues/'
@@ -515,6 +536,7 @@ export interface FileRouteTypes {
     | '/_main/issue/$issueId/'
     | '/_main/test/$testId/'
     | '/_main/tree/$treeId/'
+    | '/_main/tree/v1/'
     | '/_main/tree/$treeName/$branch/$hash'
     | '/_main/(alternatives)/b/$buildId/'
     | '/_main/(alternatives)/i/$issueId/'
@@ -619,6 +641,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MainHardwareNewIndexRouteImport
       parentRoute: typeof MainHardwareNewRouteRoute
     }
+    '/_main/tree/v1': {
+      id: '/_main/tree/v1'
+      path: '/v1'
+      fullPath: '/tree/v1'
+      preLoaderRoute: typeof MainTreeV1RouteRouteImport
+      parentRoute: typeof MainTreeRouteRoute
+    }
     '/_main/tree/$treeId': {
       id: '/_main/tree/$treeId'
       path: '/$treeId'
@@ -653,6 +682,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/build/$buildId'
       preLoaderRoute: typeof MainBuildBuildIdRouteRouteImport
       parentRoute: typeof MainRouteRoute
+    }
+    '/_main/tree/v1/': {
+      id: '/_main/tree/v1/'
+      path: '/'
+      fullPath: '/tree/v1/'
+      preLoaderRoute: typeof MainTreeV1IndexRouteImport
+      parentRoute: typeof MainTreeV1RouteRoute
     }
     '/_main/tree/$treeId/': {
       id: '/_main/tree/$treeId/'
@@ -928,6 +964,18 @@ const MainTreeTreeIdRouteRouteChildren: MainTreeTreeIdRouteRouteChildren = {
 const MainTreeTreeIdRouteRouteWithChildren =
   MainTreeTreeIdRouteRoute._addFileChildren(MainTreeTreeIdRouteRouteChildren)
 
+interface MainTreeV1RouteRouteChildren {
+  MainTreeV1IndexRoute: typeof MainTreeV1IndexRoute
+}
+
+const MainTreeV1RouteRouteChildren: MainTreeV1RouteRouteChildren = {
+  MainTreeV1IndexRoute: MainTreeV1IndexRoute,
+}
+
+const MainTreeV1RouteRouteWithChildren = MainTreeV1RouteRoute._addFileChildren(
+  MainTreeV1RouteRouteChildren,
+)
+
 interface MainTreeTreeNameBranchHashRouteRouteChildren {
   MainTreeTreeNameBranchHashIndexRoute: typeof MainTreeTreeNameBranchHashIndexRoute
 }
@@ -944,6 +992,7 @@ const MainTreeTreeNameBranchHashRouteRouteWithChildren =
 
 interface MainTreeRouteRouteChildren {
   MainTreeTreeIdRouteRoute: typeof MainTreeTreeIdRouteRouteWithChildren
+  MainTreeV1RouteRoute: typeof MainTreeV1RouteRouteWithChildren
   MainTreeIndexRoute: typeof MainTreeIndexRoute
   MainTreeTreeNameBranchHashRouteRoute: typeof MainTreeTreeNameBranchHashRouteRouteWithChildren
   MainTreeTreeNameBranchIndexRoute: typeof MainTreeTreeNameBranchIndexRoute
@@ -951,6 +1000,7 @@ interface MainTreeRouteRouteChildren {
 
 const MainTreeRouteRouteChildren: MainTreeRouteRouteChildren = {
   MainTreeTreeIdRouteRoute: MainTreeTreeIdRouteRouteWithChildren,
+  MainTreeV1RouteRoute: MainTreeV1RouteRouteWithChildren,
   MainTreeIndexRoute: MainTreeIndexRoute,
   MainTreeTreeNameBranchHashRouteRoute:
     MainTreeTreeNameBranchHashRouteRouteWithChildren,

--- a/dashboard/src/routes/_main/tree/index.tsx
+++ b/dashboard/src/routes/_main/tree/index.tsx
@@ -2,12 +2,25 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
-import TreeListing from '@/pages/TreeListing/TreesV2';
+import type { JSX } from 'react';
+
+import TreeListingV2 from '@/pages/TreeListing/TreesV2';
+import TreeListingV1 from '@/pages/TreeListing/Trees';
+import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 
 export const TreeSearchSchema = z.object({
   treeSearch: z.string().catch(''),
 });
 
+const TreeListingComponent = (): JSX.Element => {
+  const { treeListingVersion } = useFeatureFlag();
+  return treeListingVersion === 'v2' ? (
+    <TreeListingV2 urlFromMap={{ search: '/_main/tree', navigate: '/tree' }} />
+  ) : (
+    <TreeListingV1 urlFromMap={{ search: '/_main/tree', navigate: '/tree' }} />
+  );
+};
+
 export const Route = createFileRoute('/_main/tree/')({
-  component: TreeListing,
+  component: TreeListingComponent,
 });

--- a/dashboard/src/routes/_main/tree/v1/index.tsx
+++ b/dashboard/src/routes/_main/tree/v1/index.tsx
@@ -9,5 +9,7 @@ export const TreeSearchSchema = z.object({
 });
 
 export const Route = createFileRoute('/_main/tree/v1/')({
-  component: Trees,
+  component: () => (
+    <Trees urlFromMap={{ search: '/_main/tree/v1', navigate: '/tree/v1' }} />
+  ),
 });

--- a/dashboard/src/routes/_main/tree/v1/index.tsx
+++ b/dashboard/src/routes/_main/tree/v1/index.tsx
@@ -2,12 +2,12 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { z } from 'zod';
 
-import TreeListing from '@/pages/TreeListing/TreesV2';
+import Trees from '@/pages/TreeListing/Trees';
 
 export const TreeSearchSchema = z.object({
   treeSearch: z.string().catch(''),
 });
 
-export const Route = createFileRoute('/_main/tree/')({
-  component: TreeListing,
+export const Route = createFileRoute('/_main/tree/v1/')({
+  component: Trees,
 });

--- a/dashboard/src/routes/_main/tree/v1/route.tsx
+++ b/dashboard/src/routes/_main/tree/v1/route.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
+
+import { z } from 'zod';
+
+import {
+  makeZIntervalInDays,
+  zListingSize,
+  type SearchSchema,
+} from '@/types/general';
+import {
+  DEFAULT_LISTING_ITEMS,
+  DEFAULT_TIME_SEARCH,
+} from '@/utils/constants/general';
+
+const defaultValues = {
+  intervalInDays: DEFAULT_TIME_SEARCH,
+  treeSearch: '',
+  listingSize: DEFAULT_LISTING_ITEMS,
+};
+
+export const RootSearchSchema = z.object({
+  intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+  treeSearch: z.string().catch(''),
+  listingSize: zListingSize,
+} satisfies SearchSchema);
+
+export const Route = createFileRoute('/_main/tree/v1')({
+  validateSearch: RootSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
+});

--- a/dashboard/src/routes/_main/tree/v2/index.tsx
+++ b/dashboard/src/routes/_main/tree/v2/index.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { z } from 'zod';
+
+import TreeListingNew from '@/pages/TreeListing/TreesV2';
+
+export const TreeSearchSchema = z.object({
+  treeSearch: z.string().catch(''),
+});
+
+export const Route = createFileRoute('/_main/tree/v2/')({
+  component: () => (
+    <TreeListingNew
+      urlFromMap={{ search: '/_main/tree/v2', navigate: '/tree/v2' }}
+    />
+  ),
+});

--- a/dashboard/src/routes/_main/tree/v2/route.tsx
+++ b/dashboard/src/routes/_main/tree/v2/route.tsx
@@ -1,0 +1,30 @@
+import { createFileRoute, stripSearchParams } from '@tanstack/react-router';
+
+import { z } from 'zod';
+
+import {
+  makeZIntervalInDays,
+  zListingSize,
+  type SearchSchema,
+} from '@/types/general';
+import {
+  DEFAULT_LISTING_ITEMS,
+  DEFAULT_TIME_SEARCH,
+} from '@/utils/constants/general';
+
+const defaultValues = {
+  intervalInDays: DEFAULT_TIME_SEARCH,
+  treeSearch: '',
+  listingSize: DEFAULT_LISTING_ITEMS,
+};
+
+export const RootSearchSchema = z.object({
+  intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+  treeSearch: z.string().catch(''),
+  listingSize: zListingSize,
+} satisfies SearchSchema);
+
+export const Route = createFileRoute('/_main/tree/v2')({
+  validateSearch: RootSearchSchema,
+  search: { middlewares: [stripSearchParams(defaultValues)] },
+});

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -98,6 +98,12 @@ export type StatusCount = {
   DONE?: number;
 };
 
+export type ShortStatusCount = {
+  PASS: number;
+  FAIL: number;
+  INCONCLUSIVE: number;
+};
+
 export type StatusCountV2 = StatusCount & {
   INCONCLUSIVE?: number;
 };

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -395,8 +395,10 @@ export enum RedirectFrom {
   Issues = 'issues',
 }
 
+export type ListingPaths = '/tree' | '/hardware' | '/issues';
+
 export type PossibleMonitorPath =
-  | '/tree'
-  | '/hardware'
-  | '/issues'
-  | '/hardware-new';
+  | ListingPaths
+  | '/hardware-new'
+  | '/tree/v1'
+  | '/tree/v2';

--- a/dashboard/src/types/tree/Tree.tsx
+++ b/dashboard/src/types/tree/Tree.tsx
@@ -1,4 +1,4 @@
-import type { RequiredStatusCount } from '@/types/general';
+import type { RequiredStatusCount, ShortStatusCount } from '@/types/general';
 
 export type TreeFastPathResponse = Array<{
   id: string;
@@ -42,6 +42,12 @@ type AllTabCounts = {
 export type TreeTableBody = BaseTree & AllTabCounts;
 
 export type Tree = BaseTree & Required<AllTabCounts>;
+
+export type TreeV2 = BaseTree & {
+  build_status: ShortStatusCount;
+  test_status: ShortStatusCount;
+  boot_status: ShortStatusCount;
+};
 
 export type TreeLatestResponse = {
   tree_name: string;

--- a/dashboard/src/utils/constants/treeListing.ts
+++ b/dashboard/src/utils/constants/treeListing.ts
@@ -1,0 +1,15 @@
+import type { FileRoutesById, FileRoutesByTo } from '@/routeTree.gen';
+
+type ValidTreeNavigates<T extends keyof FileRoutesByTo> = T;
+type ValidTreeFroms<T extends keyof FileRoutesById> = T;
+
+export type TreeListingRoutesMap = {
+  v1: {
+    navigate: ValidTreeNavigates<'/tree' | '/tree/v1'>;
+    search: ValidTreeFroms<'/_main/tree' | '/_main/tree/v1'>;
+  };
+  v2: {
+    navigate: ValidTreeNavigates<'/tree' | '/tree/v2'>;
+    search: ValidTreeFroms<'/_main/tree' | '/_main/tree/v2'>;
+  };
+};


### PR DESCRIPTION
## Changes

- Adds a new page for the treeListing using the new endpoint
- Updates the status type to conform with the 3-status format
- Reorganizes routes and files
- Refactors some component parts to be reusable between treeListings
- Adds a banner to switch between treeListing versions
- Adds a feature flag to switch the main treeListing version
  - Also refactors a lot of components since they now will be able to appear on multiple routes

Logic for the naming of the components/pages/routes:

- we shouldn't have to rename a whole file every time a version changes (such as "treeListing" -> "treeListingV0")
- there shouldn't be a new route for a different version of a page, only a new subroute (note that this is not the same for the backend, where a new version should equate to a new api endpoint for discoverability)
- the latest version of the route shouldn't need to explicit the version
- we should avoid calling things "old" or "new" as these words are relative and may change meaning over time

## How to test
Start of with data in the new treeListing table, instructions on how to populate it can be found in #1706 
Check the new treeListing page and the old version. Check if the redirects are working as intended

Closes #1559 