### PR TITLE
Feat: move automatic labs to another field

### DIFF
--- a/backend/kernelCI_app/constants/ingester.py
+++ b/backend/kernelCI_app/constants/ingester.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import re
 from utils.validation import is_boolean_or_string_true
 
 logger = logging.getLogger("ingester")
@@ -65,3 +66,8 @@ try:
 except (ValueError, TypeError):
     logger.warning("Invalid INGEST_QUEUE_MAXSIZE, using default 5000")
     INGEST_QUEUE_MAXSIZE = 5000
+
+AUTOMATIC_LABS = re.compile(r"^(shell|k8s.*)$")
+"""Regex pattern to find labs that were named automatically and should not be in the real lab/runtime field"""
+AUTOMATIC_LAB_FIELD = "automatic_lab"
+"""Field name where automatic lab names will be moved to"""

--- a/dashboard/src/components/BuildsTable/DefaultBuildsColumns.tsx
+++ b/dashboard/src/components/BuildsTable/DefaultBuildsColumns.tsx
@@ -15,7 +15,6 @@ import {
   MoreDetailsTableHeader,
 } from '@/components/Table/DetailsColumn';
 import { getBuildStatusGroup } from '@/utils/status';
-import { UNKNOWN_STRING } from '@/utils/constants/backend';
 
 export const defaultBuildColumns: ColumnDef<AccordionItemBuilds>[] = [
   {
@@ -39,16 +38,6 @@ export const defaultBuildColumns: ColumnDef<AccordionItemBuilds>[] = [
     header: ({ column }): JSX.Element => (
       <TableHeader column={column} intlKey="global.compiler" />
     ),
-  },
-  {
-    id: 'lab',
-    accessorKey: 'lab',
-    header: ({ column }): JSX.Element => (
-      <TableHeader column={column} intlKey="global.lab" />
-    ),
-    cell: ({ row }): string => {
-      return row.getValue('lab') || UNKNOWN_STRING;
-    },
   },
   {
     accessorKey: 'date',


### PR DESCRIPTION
As discussed in the linked issue, some labs are generated automatically and should not be in the actual "lab" field (or "runtime" for tests)

## Changes
- Adds another step for the submission file processing that moves specific labs to a new field, and removes the lab/runtime field from the misc column
- Removes "lab" from build columns since currently all build labs are "k8s-all", meaning that after this change all of them would turn into "Unknown"

## How to test
In order to actually test this feature you should run the ingester on a couple of submissions that have the automatic labs. Then check their build/test page and their item on the treeDetails/hardwareDetails page.

How to start the ingester:
- Open the database (docker compose up -d dashboard_db --build),
- Make sure to have all migrations applied (poetry run python3 manage.py migrate),
- Retrieve the submissions and place them in a folder for consumption (example submissions [here](https://drive.google.com/file/d/1ekpdc6rZt3QeEEe_MQVJ_nA9KcigPkHo/view?usp=sharing)),
- Also have the trees_name file ([here](https://drive.google.com/file/d/1JpWJ2zoo5wDgDBCtLKC_EEOn-EEzkp2V/view?usp=sharing)) and place it in backend/volume_data/trees-name.yaml,
- Consume the submissions (poetry run python3 manage.py monitor_submissions --spool-dir folder/containing/the/submissions --trees-file volume_data/trees-name.yaml)

Closes #1647