### PR TITLE
feat(notifications): adjust hardware summary template with 3-level la…

### DIFF
--- a/backend/data/notifications/example-hardware-subscription.yaml
+++ b/backend/data/notifications/example-hardware-subscription.yaml
@@ -4,6 +4,8 @@
 
 qcs9100-ride: # The hardware platform name
   origin: maestro
+  labs:
+    lava-kci-qualcomm: https://lava-oss.qualcomm.com
   default_recipients:
     - Recipient One <Recipient1@example.com>
     - Recipient Two <Recipient2@example.com>

--- a/backend/data/notifications/subscriptions/qcs615_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs615_hardware.yaml
@@ -1,5 +1,7 @@
 qcs615-ride:
   origin: maestro
+  labs:
+    lava-kci-qualcomm: https://lava-oss.qualcomm.com
   default_recipients:
     - Trilok Soni <tsoni@quicinc.com>
     - Shiraz Hashim <shashim@qti.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs6490_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs6490_hardware.yaml
@@ -1,5 +1,7 @@
 qcs6490-rb3gen2:
   origin: maestro
+  labs:
+    lava-kci-qualcomm: https://lava-oss.qualcomm.com
   default_recipients:
     - Trilok Soni <tsoni@quicinc.com>
     - Shiraz Hashim <shashim@qti.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs8300_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs8300_hardware.yaml
@@ -1,5 +1,7 @@
 qcs8300-ride:
   origin: maestro
+  labs:
+    lava-kci-qualcomm: https://lava-oss.qualcomm.com
   default_recipients:
     - Trilok Soni <tsoni@quicinc.com>
     - Shiraz Hashim <shashim@qti.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs9100_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs9100_hardware.yaml
@@ -1,5 +1,7 @@
 qcs9100-ride:
   origin: maestro
+  labs:
+    lava-kci-qualcomm: https://lava-oss.qualcomm.com
   default_recipients:
     - Trilok Soni <tsoni@quicinc.com>
     - Shiraz Hashim <shashim@qti.qualcomm.com>

--- a/backend/data/notifications/subscriptions/x1e80100_hardware.yaml
+++ b/backend/data/notifications/subscriptions/x1e80100_hardware.yaml
@@ -1,5 +1,7 @@
 x1e80100:
   origin: maestro
+  labs:
+    lava-kci-qualcomm: https://lava-oss.qualcomm.com
   default_recipients:
     - Trilok Soni <tsoni@quicinc.com>
     - Shiraz Hashim <shashim@qti.qualcomm.com>

--- a/backend/kernelCI_app/management/commands/helpers/summary.py
+++ b/backend/kernelCI_app/management/commands/helpers/summary.py
@@ -176,7 +176,7 @@ def process_hardware_submissions_files(
 ) -> tuple[set[HardwareKey], dict[HardwareKey, dict[str, Any]]]:
     """
     Processes all hardware submission files and returns the set of HardwareKey
-    and the dict linking each hardware to its default recipients
+    and the dict linking each hardware to its default recipients and labs
     """
     (base_dir, signup_folder) = _assign_default_folders(
         base_dir=base_dir, signup_folder=signup_folder
@@ -189,7 +189,10 @@ def process_hardware_submissions_files(
         "default_recipients": [
             "Recipient One <Recipient1@example.com>",
             "Recipient Two <Recipient2@example.com>"
-        ]
+        ],
+        "labs": {
+            "lava-collabora": "https://lava.collabora.dev",
+        },
     }
     """
 
@@ -200,6 +203,8 @@ def process_hardware_submissions_files(
 
         imx6q-sabrelite:
         origin: maestro
+        labs:
+            lava-collabora: https://lava.collabora.dev
         default_recipients:
             - Recipient One <Recipient1@example.com>
             - Recipient Two <Recipient2@example.com>
@@ -212,11 +217,13 @@ def process_hardware_submissions_files(
                 if hardware_origins is not None and origin not in hardware_origins:
                     continue
                 default_recipients = hardware_values.get("default_recipients", [])
+                labs = hardware_values.get("labs")
 
                 hardware_key = (hardware_name, origin)
                 hardware_key_set.add(hardware_key)
                 hardware_prop_map[hardware_key] = {
-                    "default_recipients": default_recipients
+                    "default_recipients": default_recipients,
+                    "labs": labs,
                 }
         else:
             log_message(

--- a/backend/kernelCI_app/management/commands/templates/hardware_report.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/hardware_report.txt.j2
@@ -1,32 +1,42 @@
 {% extends "base.txt" %}
+{% set IND = ' ' %}
 {% block header %}{% endblock %}
 {% block content %}
 Hello,
 
 Status summary for {{ hardware_id }}
+Builds:{{ "\t" }}{{ "{:>5}".format(build_status_group_all["success"]) }} ✅
+{{- "{:>5}".format(build_status_group_all["failed"]) }} ❌
+{{- "{:>5}".format(build_status_group_all["inconclusive"]) }} ⚠️
+Boots: {{ "\t" }}{{ "{:>5}".format(boot_status_group_all["success"]) }} ✅
+{{- "{:>5}".format(boot_status_group_all["failed"]) }} ❌
+{{- "{:>5}".format(boot_status_group_all["inconclusive"]) }} ⚠️
+Tests: {{ "\t" }}{{ "{:>5}".format(test_status_group_all["success"]) }} ✅
+{{- "{:>5}".format(test_status_group_all["failed"]) }} ❌
+{{- "{:>5}".format(test_status_group_all["inconclusive"]) }} ⚠️
+================================================================
+{% for suite_name, trees in hardware_data.items() %}
+>{{ IND }}TEST SUITE: {{ suite_name }}
+------------------------------------------------------------------------------------------------------------
+{%- for tree_name, branches in trees.items() %}
+{%- for branch_name, commits in branches.items() %}
+{{ IND * 4 }}>>{{ IND }}TREE: {{ tree_name }}{{ IND }}|{{ IND }}BRANCH: {{ branch_name }}
 
-Builds:{{ "\t" }}{{ "{:>5}".format(build_status_group["success"]) }} ✅
-{{- "{:>5}".format(build_status_group["failed"]) }} ❌
-{{- "{:>5}".format(build_status_group["inconclusive"]) }} ⚠️
-Boots: {{ "\t" }}{{ "{:>5}".format(boot_status_group["success"]) }} ✅
-{{- "{:>5}".format(boot_status_group["failed"]) }} ❌
-{{- "{:>5}".format(boot_status_group["inconclusive"]) }} ⚠️
-Tests: {{ "\t" }}{{ "{:>5}".format(test_status_group["success"]) }} ✅
-{{- "{:>5}".format(test_status_group["failed"]) }} ❌
-{{- "{:>5}".format(test_status_group["inconclusive"]) }} ⚠️
--------------
-{% for data in hardware_data %}
-#kernelci test {{ data["id"] }}
-- Path: {{ data["path"] }}
-- Status: {{ data["status"] }}
-- Comment: {{ data["comment"] }}
-- Starttime: {{ data["start_time"] }}
-- Tree: {{ data["tree_name"] }}/{{ data["git_repository_branch"] }}
-- Origin: {{ data["test_origin"] }}
-- Test_lab: {{ data["runtime"] }}
-- Lava_job_id: {{ data["job_id"] }}
-- Commit: {{ data["git_commit_hash"] }}
-- Dashboard: https://dashboard.kernelci.org/test/{{ data["id"] }}
--------------
+{%- for commit_hash, commit_data in commits.items() %}
+{{ IND * 8 }}>>>{{ IND }}COMMIT: {{ commit_hash }}
+
+{%- for data in commit_data | sort(attribute='path') %}
+{{ IND * 12 }}- Path: {{ data["path"] }}
+{{ IND * 12 }}- Status: {{ data["status"] }}
+{{ IND * 12 }}- Origin: {{ data["test_origin"] }}
+{{ IND * 12 }}- Starttime: {{ data["start_time"] }}
+{{ IND * 12 }}- Test_lab: {{ data["runtime"] }}
+{{ IND * 12 }}- Lava_job: {{ labs_for_key[data["runtime"]]}}/scheduler/job/{{ data["job_id"] }}
+{{ IND * 12 }}- Dashboard: https://dashboard.kernelci.org/test/{{ data["id"] }}
+{{ IND * 12 }}------------------------------------------------------------
+{% endfor %}
+{%- endfor -%}
+{%- endfor -%}
+{%- endfor -%}
 {% endfor %}
 {%- endblock -%}


### PR DESCRIPTION
### Description
Currently,  the hardware summary email is displayed in a flat structure, making the report unclear and unable to filter results by lab.

### Changes
- Adjust the hardware summary report to a three-layer layout (Test Suite -> Tree/Branch -> Commit) to improve readability.

- Add a lab-filter feature so users can configure which lab results they want to display.

### How to Test
Run the following command to generate the hardware summary report:
```
poetry run python manage.py notifications --action hardware_summary
```
### Example
```
Hello,

Status summary for mt8395-genio-1200-evk
Builds:    2 ✅    0 ❌    0 ⚠️
Boots:      2 ✅    2 ❌   2 ⚠️
Tests:    2 ✅  2 ❌ 2 ⚠️
================================================================

> TEST SUITE: kselftest
------------------------------------------------------------------------------------------------------------
    >> TREE: next | BRANCH: master

        >>> COMMIT: f817b6dd2b62d921a6cdc0a3ac599cd1851f343c

            - Path: kselftest.device_error_logs
            - Status: FAIL
            - Test_lab: lava-collabora
            - Lava_job: https://lava.collabora.dev/scheduler/job/19042179
            - Dashboard: https://dashboard.kernelci.org/test/maestro:6859031e5c2cf25042d06f60
            ------------------------------------------------------------
```

### Related Issue
Closes #1725 