### PR TITLE
Feat: add responsivity to searchbar

### DIFF
--- a/dashboard/src/components/Dialog/CustomDialog.tsx
+++ b/dashboard/src/components/Dialog/CustomDialog.tsx
@@ -36,8 +36,12 @@ export type ActionLink = ActionLinkWithIntl | ActionLinkWithLabel;
 
 export interface CustomDialogProps {
   trigger: ReactNode;
-  titleIntlId: MessagesKey;
-  descriptionIntlId: MessagesKey;
+  titleIntlId?: MessagesKey;
+  descriptionIntlId?: MessagesKey;
+  content?: ReactNode;
+  contentClassName?: string;
+  showOverlay?: boolean;
+  showCloseButton?: boolean;
   footerClassName?: string;
   actionLinks?: ActionLink[];
   showCancel?: boolean;
@@ -47,47 +51,67 @@ export const CustomDialog = ({
   trigger,
   titleIntlId,
   descriptionIntlId,
+  content,
+  contentClassName,
+  showOverlay = true,
+  showCloseButton = true,
   footerClassName,
   actionLinks = [],
   showCancel = true,
 }: CustomDialogProps): JSX.Element => {
+  const hasHeader = Boolean(titleIntlId || descriptionIntlId);
+  const hasFooter = actionLinks.length > 0 || showCancel;
+
   return (
     <Dialog>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle className="leading-normal tracking-normal">
-            <FormattedMessage id={titleIntlId} />
-          </DialogTitle>
-          <DialogDescription>
-            <FormattedMessage id={descriptionIntlId} />
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter className={footerClassName}>
-          {actionLinks.map((actionLink, index) => (
-            <Button key={index} asChild>
-              <a
-                href={actionLink.href}
-                target={actionLink.target ?? '_blank'}
-                rel={actionLink.rel ?? 'noreferrer'}
-              >
-                {actionLink.intlId ? (
-                  <FormattedMessage id={actionLink.intlId} />
-                ) : (
-                  actionLink.label
-                )}
-                {actionLink.icon}
-              </a>
-            </Button>
-          ))}
-          {showCancel && (
-            <DialogClose asChild>
-              <Button variant={'outline'}>
-                <FormattedMessage id="global.cancel" />
+      <DialogContent
+        className={contentClassName}
+        showOverlay={showOverlay}
+        showCloseButton={showCloseButton}
+      >
+        {hasHeader && (
+          <DialogHeader>
+            {titleIntlId && (
+              <DialogTitle className="leading-normal tracking-normal">
+                <FormattedMessage id={titleIntlId} />
+              </DialogTitle>
+            )}
+            {descriptionIntlId && (
+              <DialogDescription>
+                <FormattedMessage id={descriptionIntlId} />
+              </DialogDescription>
+            )}
+          </DialogHeader>
+        )}
+        {content}
+        {hasFooter && (
+          <DialogFooter className={footerClassName}>
+            {actionLinks.map((actionLink, index) => (
+              <Button key={index} asChild>
+                <a
+                  href={actionLink.href}
+                  target={actionLink.target ?? '_blank'}
+                  rel={actionLink.rel ?? 'noreferrer'}
+                >
+                  {actionLink.intlId ? (
+                    <FormattedMessage id={actionLink.intlId} />
+                  ) : (
+                    actionLink.label
+                  )}
+                  {actionLink.icon}
+                </a>
               </Button>
-            </DialogClose>
-          )}
-        </DialogFooter>
+            ))}
+            {showCancel && (
+              <DialogClose asChild>
+                <Button variant={'outline'}>
+                  <FormattedMessage id="global.cancel" />
+                </Button>
+              </DialogClose>
+            )}
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/dashboard/src/components/SearchBoxNavigate/SearchBoxNavigate.tsx
+++ b/dashboard/src/components/SearchBoxNavigate/SearchBoxNavigate.tsx
@@ -1,0 +1,143 @@
+import { useMatches, useNavigate, useSearch } from '@tanstack/react-router';
+import type { ChangeEvent, JSX } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useIntl } from 'react-intl';
+import { HiSearch } from 'react-icons/hi';
+
+import DebounceInput from '@/components/DebounceInput/DebounceInput';
+import { CustomDialog } from '@/components/Dialog/CustomDialog';
+
+// Relates the type of listing to the corresponding search key
+const forwardFields: Record<string, string> = {
+  tree: 'treeSearch',
+  hardware: 'hardwareSearch',
+  issue: 'issueSearch',
+};
+
+interface ISearchData {
+  currentSearch?: string;
+  searchPlaceholder: string;
+  navigateTarget: string;
+}
+
+export const SearchBoxNavigate = (): JSX.Element => {
+  const matches = useMatches();
+  const routeInfo = useMemo(() => {
+    const lastMatch = matches[matches.length - 1];
+    const cleanFullPath = lastMatch?.fullPath.replace(/\//g, '') ?? '';
+
+    if (['tree', 'treev1', 'treev2'].includes(cleanFullPath)) {
+      return 'tree';
+    }
+
+    if (['hardware', 'hardwarev1'].includes(cleanFullPath)) {
+      return 'hardware';
+    }
+
+    if (cleanFullPath === 'issues') {
+      return 'issue';
+    }
+
+    return 'unknown';
+  }, [matches]);
+  const { formatMessage } = useIntl();
+
+  const { treeSearch, hardwareSearch, issueSearch } = useSearch({
+    strict: false,
+  });
+  const searchData = useMemo((): ISearchData => {
+    switch (routeInfo) {
+      case 'tree':
+        return {
+          currentSearch: treeSearch,
+          searchPlaceholder: formatMessage({ id: 'tree.searchPlaceholder' }),
+          navigateTarget: 'treeSearch',
+        };
+      case 'hardware':
+        return {
+          currentSearch: hardwareSearch,
+          searchPlaceholder: formatMessage({
+            id: 'hardware.searchPlaceholder',
+          }),
+          navigateTarget: 'hardwareSearch',
+        };
+      case 'issue':
+        return {
+          currentSearch: issueSearch,
+          searchPlaceholder: formatMessage({
+            id: 'issue.searchPlaceholder',
+          }),
+          navigateTarget: 'issueSearch',
+        };
+      default:
+        return {
+          currentSearch: '',
+          searchPlaceholder: '',
+          navigateTarget: '',
+        };
+    }
+  }, [routeInfo, treeSearch, formatMessage, hardwareSearch, issueSearch]);
+
+  const navigate = useNavigate();
+
+  const onInputSearchTextChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      // using routeInfo as a dependency instead of searchData so that we don't depend on useSearch
+      const forwardSearch = { [forwardFields[routeInfo]]: value };
+
+      navigate({
+        to: '.',
+        search: previousSearch => ({
+          ...previousSearch,
+          ...forwardSearch,
+        }),
+      });
+    },
+    [navigate, routeInfo],
+  );
+
+  const sharedInput = useMemo(() => {
+    return (
+      <DebounceInput
+        key={`${routeInfo}`}
+        debouncedSideEffect={onInputSearchTextChange}
+        type="text"
+        autoFocus
+        startingValue={searchData.currentSearch}
+        placeholder={searchData.searchPlaceholder}
+      />
+    );
+  }, [
+    onInputSearchTextChange,
+    routeInfo,
+    searchData.currentSearch,
+    searchData.searchPlaceholder,
+  ]);
+
+  if (routeInfo === 'unknown') {
+    console.error('SearchBoxNavigate shown on an invalid route.');
+    console.error('Route is ', matches);
+    return <></>;
+  }
+
+  return (
+    <div className="flex w-full max-w-3xl items-center">
+      {/* Mobile: icon button */}
+      <CustomDialog
+        trigger={
+          <button className="min-[475px]:hidden">
+            <HiSearch className="size-6" />
+          </button>
+        }
+        content={sharedInput}
+        contentClassName="w-9/10 top-10 border-0 bg-transparent p-0 shadow-none min-[475px]:hidden"
+        showCloseButton={false}
+        showCancel={false}
+      />
+
+      {/* Desktop: inline input */}
+      <div className="hidden w-full min-[475px]:block">{sharedInput}</div>
+    </div>
+  );
+};

--- a/dashboard/src/components/SearchBoxNavigate/index.tsx
+++ b/dashboard/src/components/SearchBoxNavigate/index.tsx
@@ -1,0 +1,3 @@
+import { SearchBoxNavigate } from './SearchBoxNavigate';
+
+export { SearchBoxNavigate };

--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -17,6 +17,8 @@ import { useOrigins } from '@/api/origin';
 import { Button } from '@/components/ui/button';
 import MobileSideMenu from '@/components/SideMenu/MobileSideMenu';
 
+import { SearchBoxNavigate } from '@/components/SearchBoxNavigate';
+
 const OriginSelect = ({
   isHardwarePath,
 }: {
@@ -75,7 +77,7 @@ const OriginSelect = ({
 
   return (
     <div className="flex items-center">
-      <span className="text-dim-gray mr-4 text-base font-medium">
+      <span className="text-dim-gray mr-4 hidden text-base font-medium sm:block">
         <FormattedMessage id="global.origin" />
       </span>
       <Select
@@ -120,11 +122,16 @@ const TopBar = (): JSX.Element => {
     const lastMatch = matches[matches.length - 1];
     const firstUrlLocation = lastMatch?.pathname.split('/')[1] ?? '';
     const cleanFullPath = lastMatch?.fullPath.replace(/\//g, '') ?? '';
+    const isTreeListing = ['tree', 'treev1', 'treev2'].includes(cleanFullPath);
+    const isListingPage =
+      isTreeListing ||
+      ['hardware', 'hardwarev1', 'issues'].includes(cleanFullPath);
 
     return {
       firstUrlLocation,
-      isTreeListing: ['tree', 'treev1', 'treev2'].includes(cleanFullPath),
+      isTreeListing: isTreeListing,
       isHardwarePage: cleanFullPath.includes('hardware'),
+      isListingPage: isListingPage,
     };
   }, [matches]);
 
@@ -132,9 +139,9 @@ const TopBar = (): JSX.Element => {
 
   return (
     <>
-      <div className="fixed top-0 z-10 flex h-20 w-full bg-white px-6 md:px-16">
+      <div className="fixed top-0 z-10 flex h-20 w-full max-w-full bg-white px-6 md:max-w-[calc(100%-14rem)] md:px-16">
         <div className="flex w-full flex-row items-center justify-between">
-          <div className="flex flex-row items-center gap-4">
+          <div className="flex w-full flex-row items-center gap-4">
             <Button
               variant="ghost"
               size="icon"
@@ -144,12 +151,15 @@ const TopBar = (): JSX.Element => {
             >
               <HiMenu className="size-6" />
             </Button>
-            <span className="mr-10 text-2xl">
+            <span className="mr-2 text-2xl sm:mr-10">
               <TitleName basePath={basePath} />
             </span>
             {(routeInfo.isTreeListing || routeInfo.isHardwarePage) && (
               <OriginSelect isHardwarePath={routeInfo.isHardwarePage} />
             )}
+            <span className="ml-0 flex w-full px-6 lg:ml-14">
+              {routeInfo.isListingPage && <SearchBoxNavigate />}
+            </span>
           </div>
         </div>
       </div>

--- a/dashboard/src/components/ui/dialog.tsx
+++ b/dashboard/src/components/ui/dialog.tsx
@@ -29,12 +29,28 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  showOverlay?: boolean;
+  showCloseButton?: boolean;
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(
+  (
+    {
+      className,
+      children,
+      showOverlay = true,
+      showCloseButton = true,
+      ...props
+    },
+    ref,
+  ) => (
   <DialogPortal>
-    <DialogOverlay />
+    {showOverlay && <DialogOverlay />}
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
@@ -44,13 +60,16 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-slate-100 data-[state=open]:text-slate-500 dark:ring-offset-slate-950 dark:focus:ring-slate-300 dark:data-[state=open]:bg-slate-800 dark:data-[state=open]:text-slate-400">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {showCloseButton && (
+        <DialogPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-slate-100 data-[state=open]:text-slate-500 dark:ring-offset-slate-950 dark:focus:ring-slate-300 dark:data-[state=open]:bg-slate-800 dark:data-[state=open]:text-slate-400">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
-));
+  ),
+);
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({

--- a/dashboard/src/pages/Hardware/Hardware.tsx
+++ b/dashboard/src/pages/Hardware/Hardware.tsx
@@ -1,13 +1,9 @@
-import type { ChangeEvent, JSX } from 'react';
-import { useCallback } from 'react';
+import type { JSX } from 'react';
 
-import { useIntl } from 'react-intl';
-
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useSearch } from '@tanstack/react-router';
 
 import HardwareListingPage from '@/pages/Hardware/HardwareListingPage';
 
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
 import { OldPageBanner } from '@/components/Banner/PageBanner';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
@@ -23,38 +19,9 @@ const Hardware = ({
     from: urlFromMap.search,
   });
 
-  const navigate = useNavigate({ from: urlFromMap.navigate });
-
-  const onInputSearchTextChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      navigate({
-        search: previousSearch => ({
-          ...previousSearch,
-          hardwareSearch: e.target.value,
-        }),
-      });
-    },
-    [navigate],
-  );
-
-  const { formatMessage } = useIntl();
-
   return (
     <>
       <MemoizedListingOGTags monitor="/hardware" search={hardwareSearch} />
-      <div className="fixed top-0 z-10 mx-[380px] flex w-full pt-5 pr-12 pl-6">
-        <div className="flex w-2/3 items-center px-6">
-          <DebounceInput
-            debouncedSideEffect={onInputSearchTextChange}
-            className="w-2/3"
-            type="text"
-            startingValue={hardwareSearch}
-            placeholder={formatMessage({
-              id: 'hardware.searchPlaceholder',
-            })}
-          />
-        </div>
-      </div>
       {hardwareListingVersion !== 'v1' && (
         <OldPageBanner
           pageNameId="hardwareListing.bannerTitle"

--- a/dashboard/src/pages/Hardware/HardwareV2.tsx
+++ b/dashboard/src/pages/Hardware/HardwareV2.tsx
@@ -1,13 +1,9 @@
-import type { ChangeEvent, JSX } from 'react';
-import { useCallback } from 'react';
+import type { JSX } from 'react';
 
-import { useIntl } from 'react-intl';
-
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useSearch } from '@tanstack/react-router';
 
 import HardwareListingPageV2 from '@/pages/Hardware/HardwareListingPageV2';
 
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
 import { NewPageBanner } from '@/components/Banner/PageBanner';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
@@ -23,39 +19,9 @@ export const HardwareV2 = ({
     from: urlFromMap.search,
   });
 
-  const navigate = useNavigate({ from: urlFromMap.navigate });
-
-  const onInputSearchTextChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      navigate({
-        search: previousSearch => ({
-          ...previousSearch,
-          hardwareSearch: e.target.value,
-        }),
-        state: s => s,
-      });
-    },
-    [navigate],
-  );
-
-  const { formatMessage } = useIntl();
-
   return (
     <>
       <MemoizedListingOGTags monitor="/hardware" search={hardwareSearch} />
-      <div className="fixed top-0 z-10 mx-[380px] flex w-full pt-5 pr-12 pl-6">
-        <div className="flex w-2/3 items-center px-6">
-          <DebounceInput
-            debouncedSideEffect={onInputSearchTextChange}
-            className="w-2/3"
-            type="text"
-            startingValue={hardwareSearch}
-            placeholder={formatMessage({
-              id: 'hardware.searchPlaceholder',
-            })}
-          />
-        </div>
-      </div>
       {hardwareListingVersion !== 'v2' && (
         <NewPageBanner
           pageNameId="hardwareListing.bannerTitle"

--- a/dashboard/src/pages/IssueListing/IssueListing.tsx
+++ b/dashboard/src/pages/IssueListing/IssueListing.tsx
@@ -1,13 +1,8 @@
-import type { ChangeEvent, JSX } from 'react';
-import { useCallback } from 'react';
+import type { JSX } from 'react';
 
-import { useIntl } from 'react-intl';
-
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useSearch } from '@tanstack/react-router';
 
 import { z } from 'zod';
-
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
 
@@ -20,36 +15,9 @@ const IssueListing = (): JSX.Element => {
 
   const issueSearch = z.string().catch('').parse(unsafeIssueSearch);
 
-  const navigate = useNavigate({ from: '/issues' });
-
-  const onInputSearchTextChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      navigate({
-        search: previousSearch => ({
-          ...previousSearch,
-          issueSearch: e.target.value,
-        }),
-      });
-    },
-    [navigate],
-  );
-
-  const { formatMessage } = useIntl();
-
   return (
     <>
       <MemoizedListingOGTags monitor="/issues" search={issueSearch} />
-      <div className="fixed top-0 z-10 mx-[380px] flex w-full pt-5 pr-12 pl-6">
-        <div className="flex w-2/3 items-center px-6">
-          <DebounceInput
-            debouncedSideEffect={onInputSearchTextChange}
-            className="w-2/3"
-            type="text"
-            startingValue={issueSearch}
-            placeholder={formatMessage({ id: 'issue.searchPlaceholder' })}
-          />
-        </div>
-      </div>
       <div className="bg-light-gray w-full py-10">
         <IssueListingPage inputFilter={issueSearch} />
       </div>

--- a/dashboard/src/pages/TreeListing/Trees.tsx
+++ b/dashboard/src/pages/TreeListing/Trees.tsx
@@ -1,13 +1,9 @@
-import type { ChangeEvent, JSX } from 'react';
-import { useCallback } from 'react';
+import type { JSX } from 'react';
 
-import { useIntl } from 'react-intl';
-
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useSearch } from '@tanstack/react-router';
 
 import TreeListingPage from '@/components/TreeListingPage/TreeListingPage';
 
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
 import { OldPageBanner } from '@/components/Banner/PageBanner';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
@@ -23,36 +19,9 @@ const Trees = ({
     from: urlFromMap.search,
   });
 
-  const navigate = useNavigate({ from: urlFromMap.navigate });
-
-  const onInputSearchTextChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      navigate({
-        search: previousSearch => ({
-          ...previousSearch,
-          treeSearch: e.target.value,
-        }),
-      });
-    },
-    [navigate],
-  );
-
-  const { formatMessage } = useIntl();
-
   return (
     <>
       <MemoizedListingOGTags monitor="/tree" search={treeSearch} />
-      <div className="fixed top-0 z-10 mx-[380px] flex w-full pt-5 pr-12 pl-6">
-        <div className="flex w-2/3 items-center px-6">
-          <DebounceInput
-            debouncedSideEffect={onInputSearchTextChange}
-            className="w-2/3"
-            type="text"
-            startingValue={treeSearch}
-            placeholder={formatMessage({ id: 'tree.searchPlaceholder' })}
-          />
-        </div>
-      </div>
       {treeListingVersion !== 'v1' && (
         <OldPageBanner pageNameId="treeListing.treeListing" pageRoute="/tree" />
       )}

--- a/dashboard/src/pages/TreeListing/TreesV2.tsx
+++ b/dashboard/src/pages/TreeListing/TreesV2.tsx
@@ -1,11 +1,6 @@
-import type { ChangeEvent, JSX } from 'react';
-import { useCallback } from 'react';
+import type { JSX } from 'react';
+import { useSearch } from '@tanstack/react-router';
 
-import { useIntl } from 'react-intl';
-
-import { useNavigate, useSearch } from '@tanstack/react-router';
-
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags';
 import TreeListingV2 from '@/components/TreeListingPage/TreeListingV2';
 import { NewPageBanner } from '@/components/Banner/PageBanner';
@@ -22,36 +17,9 @@ const TreeListingPageV2 = ({
     from: urlFromMap.search,
   });
 
-  const navigate = useNavigate({ from: urlFromMap.navigate });
-
-  const onInputSearchTextChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      navigate({
-        search: previousSearch => ({
-          ...previousSearch,
-          treeSearch: e.target.value,
-        }),
-      });
-    },
-    [navigate],
-  );
-
-  const { formatMessage } = useIntl();
-
   return (
     <>
       <MemoizedListingOGTags monitor="/tree" search={treeSearch} />
-      <div className="fixed top-0 z-10 mx-[380px] flex w-full pt-5 pr-12 pl-6">
-        <div className="flex w-2/3 items-center px-6">
-          <DebounceInput
-            debouncedSideEffect={onInputSearchTextChange}
-            className="w-2/3"
-            type="text"
-            startingValue={treeSearch}
-            placeholder={formatMessage({ id: 'tree.searchPlaceholder' })}
-          />
-        </div>
-      </div>
       {treeListingVersion !== 'v2' && (
         <NewPageBanner
           pageNameId="treeListing.treeListing"


### PR DESCRIPTION
## Changes
- Removes the searchbar from all listing pages and moves the control to a specific component used in TopBar
- Improves usability of customDialog for use in the searchBox
- Adds media query and replaces box with just a search icon, but with the same behavior

## How to test
Go to any listing page, use the search box and also check the responsivity of the component. The search behavior should stil be the same.

## Visual examples
Large screen:
<img width="1759" height="122" alt="image" src="https://github.com/user-attachments/assets/d1fc2cec-7b2c-471b-822c-bb8e158b6de7" />

Medium-large screens:
<img width="1243" height="107" alt="image" src="https://github.com/user-attachments/assets/42a1a131-f996-4b81-a2e9-2ec7871ed830" />

Medium screens:
<img width="767" height="94" alt="image" src="https://github.com/user-attachments/assets/ba6aaafd-d93d-4d14-823b-e9ba64edcb7d" />

Medium-small screens:
<img width="559" height="95" alt="image" src="https://github.com/user-attachments/assets/12bc8803-8c71-44fb-9ce6-31e3c90adf7a" />

Small screens:
<img width="408" height="95" alt="image" src="https://github.com/user-attachments/assets/552e3586-1f17-442a-85a8-e7bc17894dec" />

When clicking on the search icon:
<img width="389" height="833" alt="image" src="https://github.com/user-attachments/assets/e73c3bcc-5462-434d-8b01-39024c5c45ef" />



Closes #1416