### PR TITLE
chore: add typecheck script and integrate it into pre-commit hook

### DIFF
--- a/dashboard/.husky/pre-commit
+++ b/dashboard/.husky/pre-commit
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-cd dashboard && pnpm lint-staged
+cd dashboard && pnpm lint-staged && pnpm typecheck
 pnpm pycommit

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "rm -rf ./node_modules/.vite && vite",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b",
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Description

Add TypeScript type-checking to the pre-commit workflow to catch TS errors before commits

## Changes

- Add typecheck script (tsc -b) to dashboard/package.json
- Update dashboard/.husky/pre-commit to run pnpm typecheck after pnpm lint-staged in the dashboard pre-commit step