### PR TITLE
feat(notifications): CC public mailing list on hardware status emails

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -175,6 +175,7 @@ else:
             [
                 "notifications",
                 "--action=hardware_summary",
+                "--cc=kernelci-results@groups.io",
                 "--send",
                 "--yes",
             ],


### PR DESCRIPTION
As suggested by @MarceloRobert, this PR makes the hardware status command send an email copy to the public mailing list for confirmation.
Related: #1738 