### PR TITLE
Fix: hardware details build commits

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -192,6 +192,15 @@ We are not using sessions or anything like that right now, so changing the secre
 ## Requests
 In the `/requests` directory we have scripts that execute requests to endpoints using [httpie](https://httpie.io/). They serve as examples of how you could use the API, and what responses you can expect. If you are contributing to some endpoint and change any of the responses, please remember to update those files.
 
+### Tree commits builds scope
+
+For `GET /api/tree/<commit_hash>/commits` (and direct tree variant), when requesting only builds (`types=builds`) there are two supported scopes:
+
+- default behavior (no extra flag): returns builds that match the active filters directly (used by treeDetails);
+- relation-gated behavior: set `builds_related_to_filtered_tests_only=true` to return only builds related to tests/boots that pass the active filters (used by hardwareDetails commit navigation).
+
+This flag is optional and defaults to `false` to preserve existing behavior.
+
 ## Debug
 
 For debugging we have four env variables:

--- a/backend/kernelCI_app/tests/unitTests/views/treeCommitsHistory_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/treeCommitsHistory_test.py
@@ -1,0 +1,280 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from rest_framework.test import APIRequestFactory
+
+from kernelCI_app.views.treeCommitsHistory import (
+    TreeCommitsHistory,
+    TreeCommitsHistoryDirect,
+)
+
+
+class TestTreeCommitsHistory(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view = TreeCommitsHistory()
+        self.direct_view = TreeCommitsHistoryDirect()
+        self.commit_hash = "1f44358e5057873ced21617aca6443b8b9e9c191"
+        self.url = f"/api/tree/{self.commit_hash}/commits"
+
+    @patch("kernelCI_app.views.treeCommitsHistory.get_tree_commit_history")
+    def test_builds_with_hardware_filter_returns_non_empty_response(
+        self, mock_get_tree_commit_history
+    ):
+        mock_get_tree_commit_history.return_value = [
+            (
+                self.commit_hash,
+                "commit-name",
+                ["v1"],
+                datetime(2026, 2, 1, tzinfo=timezone.utc),
+                120,
+                "x86_64",
+                "gcc",
+                "defconfig",
+                "PASS",
+                "maestro",
+                "build-1",
+                {"platform": "acer-cp514-2h-1160g7-volteer", "lab": "lab-a"},
+                "boot",
+                "PASS",
+                30,
+                ["acer-cp514-2h-1160g7-volteer"],
+                {"runtime": {"platform": "acer-cp514-2h-1160g7-volteer"}},
+                "maestro",
+                "lab-a",
+                "test-1",
+                None,
+                None,
+                None,
+                None,
+            )
+        ]
+
+        request = self.factory.get(
+            self.url,
+            {
+                "origin": "maestro",
+                "git_url": "https://chromium.googlesource.com/chromiumos/third_party/kernel.git",
+                "git_branch": "chromeos-5.4",
+                "start_timestamp_in_seconds": "1769779800",
+                "end_timestamp_in_seconds": "1771507800",
+                "types": "builds",
+                "builds_related_to_filtered_tests_only": "true",
+                "filter_test.hardware": "acer-cp514-2h-1160g7-volteer",
+            },
+        )
+
+        response = self.view.get(request, commit_hash=self.commit_hash)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["git_commit_hash"], self.commit_hash)
+        self.assertEqual(response.data[0]["builds"]["PASS"], 1)
+        self.assertEqual(sum(response.data[0]["boots"].values()), 0)
+        self.assertEqual(sum(response.data[0]["tests"].values()), 0)
+
+        mock_get_tree_commit_history.assert_called_once_with(
+            commit_hash=self.commit_hash,
+            origin="maestro",
+            git_url="https://chromium.googlesource.com/chromiumos/third_party/kernel.git",
+            git_branch="chromeos-5.4",
+            tree_name=None,
+            include_types=["builds", "boots", "tests"],
+        )
+
+    @patch("kernelCI_app.views.treeCommitsHistory.get_tree_commit_history")
+    def test_builds_default_scope_does_not_expand_include_types(
+        self, mock_get_tree_commit_history
+    ):
+        mock_get_tree_commit_history.return_value = [
+            (
+                self.commit_hash,
+                "commit-name",
+                ["v1"],
+                datetime(2026, 2, 1, tzinfo=timezone.utc),
+                120,
+                "x86_64",
+                "gcc",
+                "defconfig",
+                "PASS",
+                "maestro",
+                "build-1",
+                {"platform": "acer-cp514-2h-1160g7-volteer", "lab": "lab-a"},
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        ]
+
+        request = self.factory.get(
+            self.url,
+            {
+                "origin": "maestro",
+                "git_url": "https://chromium.googlesource.com/chromiumos/third_party/kernel.git",
+                "git_branch": "chromeos-5.4",
+                "types": "builds",
+            },
+        )
+
+        response = self.view.get(request, commit_hash=self.commit_hash)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data[0]["builds"]["PASS"], 1)
+
+        mock_get_tree_commit_history.assert_called_once_with(
+            commit_hash=self.commit_hash,
+            origin="maestro",
+            git_url="https://chromium.googlesource.com/chromiumos/third_party/kernel.git",
+            git_branch="chromeos-5.4",
+            tree_name=None,
+            include_types=["builds"],
+        )
+
+    @patch("kernelCI_app.views.treeCommitsHistory.get_tree_commit_history")
+    def test_builds_relation_scope_counts_only_builds_linked_to_filtered_tests(
+        self, mock_get_tree_commit_history
+    ):
+        target_hardware = "acer-cp514-2h-1160g7-volteer"
+
+        mock_get_tree_commit_history.return_value = [
+            (
+                self.commit_hash,
+                "commit-name",
+                ["v1"],
+                datetime(2026, 2, 1, tzinfo=timezone.utc),
+                120,
+                "x86_64",
+                "gcc",
+                "defconfig",
+                "PASS",
+                "maestro",
+                "build-unrelated",
+                {"platform": target_hardware, "lab": "lab-a"},
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),
+            (
+                self.commit_hash,
+                "commit-name",
+                ["v1"],
+                datetime(2026, 2, 1, tzinfo=timezone.utc),
+                180,
+                "x86_64",
+                "gcc",
+                "defconfig",
+                "PASS",
+                "maestro",
+                "build-related",
+                {"platform": "some-other-platform", "lab": "lab-a"},
+                "boot",
+                "PASS",
+                30,
+                [target_hardware],
+                {"runtime": {"platform": target_hardware}},
+                "maestro",
+                "lab-a",
+                "test-related",
+                None,
+                None,
+                None,
+                None,
+            ),
+        ]
+
+        request = self.factory.get(
+            self.url,
+            {
+                "origin": "maestro",
+                "git_url": "https://chromium.googlesource.com/chromiumos/third_party/kernel.git",
+                "git_branch": "chromeos-5.4",
+                "types": "builds",
+                "builds_related_to_filtered_tests_only": "true",
+                "filter_test.hardware": target_hardware,
+            },
+        )
+
+        response = self.view.get(request, commit_hash=self.commit_hash)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data[0]["builds"]["PASS"], 1)
+        self.assertEqual(sum(response.data[0]["boots"].values()), 0)
+        self.assertEqual(sum(response.data[0]["tests"].values()), 0)
+
+    @patch("kernelCI_app.views.treeCommitsHistory.get_tree_commit_history")
+    def test_direct_tree_details_builds_with_hardware_filter_is_not_empty(
+        self, mock_get_tree_commit_history
+    ):
+        commit_hash = "6bd9ed02871f22beb0e50690b0c3caf457104f7c"
+        hardware = "fsl,imx8mp-evk"
+        direct_url = "/api/tree/mainline/master/" f"{commit_hash}/commits"
+
+        mock_get_tree_commit_history.return_value = [
+            (
+                commit_hash,
+                "commit-name",
+                ["v1"],
+                datetime(2026, 2, 1, tzinfo=timezone.utc),
+                120,
+                "arm64",
+                "gcc",
+                "defconfig",
+                "PASS",
+                "maestro",
+                "build-1",
+                {"platform": hardware, "lab": "lab-a"},
+                None,
+                None,
+                None,
+                None,
+                {"platform": "unknown"},
+                None,
+                "lab-a",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        ]
+
+        request = self.factory.get(
+            direct_url,
+            {
+                "origin": "maestro",
+                "git_url": "",
+                "git_branch": "master",
+                "types": "builds",
+                "filter_test.hardware": hardware,
+            },
+        )
+
+        response = self.direct_view.get(
+            request,
+            commit_hash=commit_hash,
+            tree_name="mainline",
+            git_branch="master",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(len(response.data), 0)
+        self.assertEqual(response.data[0]["builds"]["PASS"], 1)

--- a/backend/kernelCI_app/typeModels/treeCommits.py
+++ b/backend/kernelCI_app/typeModels/treeCommits.py
@@ -35,6 +35,13 @@ class DirectTreeCommitsQueryParameters(BaseModel):
         None,
         description="List of types to include (builds, boots, tests)",
     )
+    builds_related_to_filtered_tests_only: bool = Field(
+        False,
+        description=(
+            "When true, and requesting only builds, count only builds related to "
+            "tests/boots that pass the current filters."
+        ),
+    )
     # TODO: Add filters field in this model
 
     @field_validator("types", mode="before")

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -28,6 +28,7 @@ from kernelCI_app.typeModels.treeCommits import (
     DirectTreeCommitsQueryParameters,
     TreeCommitsQueryParameters,
     TreeCommitsResponse,
+    TreeEntityTypes,
 )
 from pydantic import ValidationError
 from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
@@ -45,6 +46,7 @@ class BaseTreeCommitsHistory(APIView):
         self.end_datetime = None
         self.processed_builds = set()
         self.processed_tests = set()
+        self.builds_related_to_filtered_tests_only = False
 
     def setup_filters(self):
         self.filterTestDurationMin = self.filterParams.filterTestDurationMin
@@ -160,26 +162,10 @@ class BaseTreeCommitsHistory(APIView):
         test_id: str,
         test_status: str,
         commit_hash: str,
-        test_duration: int,
-        test_path: str,
-        issue_id: str,
-        issue_version: int,
-        incident_test_id: str,
-        test_origin: str,
     ) -> None:
-        is_boot_filter_out = self.filterParams.is_boot_filtered_out(
-            duration=test_duration,
-            issue_id=issue_id,
-            issue_version=issue_version,
-            path=test_path,
-            status=test_status,
-            incident_test_id=incident_test_id,
-            origin=test_origin,
-        )
-
         is_boot_processed = test_id in self.processed_tests
 
-        if is_boot_filter_out or is_boot_processed:
+        if is_boot_processed:
             return
 
         self.processed_tests.add(test_id)
@@ -192,26 +178,10 @@ class BaseTreeCommitsHistory(APIView):
         test_id: str,
         test_status: str,
         commit_hash: str,
-        test_duration: int,
-        test_path: str,
-        issue_id: str,
-        issue_version: int,
-        incident_test_id: str,
-        test_origin: str,
     ) -> None:
-        is_nonboot_filter_out = self.filterParams.is_test_filtered_out(
-            duration=test_duration,
-            issue_id=issue_id,
-            issue_version=issue_version,
-            path=test_path,
-            status=test_status,
-            incident_test_id=incident_test_id,
-            origin=test_origin,
-        )
-
         is_test_processed = test_id in self.processed_tests
 
-        if is_nonboot_filter_out or is_test_processed:
+        if is_test_processed:
             return
 
         self.processed_tests.add(test_id)
@@ -257,20 +227,9 @@ class BaseTreeCommitsHistory(APIView):
 
     def _process_tests(self, row: dict) -> None:
         test_id = row["test_id"]
-        issue_id = row["issue_id"]
         test_status = row["test_status"] or "NULL"
-        test_duration = row["test_duration"]
         test_path = row["test_path"]
-        issue_version = row["issue_version"]
-        incident_test_id = row["incidents_test_id"]
-        build_status = row["build_status"]
-        test_origin = row["test_origin"]
         commit_hash = row["git_commit_hash"]
-
-        if issue_id is None and (
-            build_status in [FAIL_STATUS, NULL_STATUS] or test_status == FAIL_STATUS
-        ):
-            issue_id = UNCATEGORIZED_STRING
 
         if test_id is None:
             return
@@ -280,28 +239,18 @@ class BaseTreeCommitsHistory(APIView):
                 test_id=test_id,
                 test_status=test_status,
                 commit_hash=commit_hash,
-                test_duration=test_duration,
-                test_path=test_path,
-                issue_id=issue_id,
-                issue_version=issue_version,
-                incident_test_id=incident_test_id,
-                test_origin=test_origin,
             )
         else:
             self._process_nonboots_count(
                 test_id=test_id,
                 test_status=test_status,
                 commit_hash=commit_hash,
-                test_duration=test_duration,
-                test_path=test_path,
-                issue_id=issue_id,
-                issue_version=issue_version,
-                incident_test_id=incident_test_id,
-                test_origin=test_origin,
             )
 
     def _process_builds(self, row: dict) -> None:
         build_id = row["build_id"]
+        if build_id is None:
+            return
         commit_hash = row["git_commit_hash"]
         build_origin = row["build_origin"]
 
@@ -328,7 +277,47 @@ class BaseTreeCommitsHistory(APIView):
             return start_time >= self.start_datetime and start_time <= self.end_datetime
         return True
 
-    def _process_rows(self, rows: dict) -> None:
+    def _is_test_row_filtered_out(self, row: dict) -> bool:
+        test_id = row["test_id"]
+        if test_id is None:
+            return True
+
+        issue_id = row["issue_id"]
+        test_status = row["test_status"] or "NULL"
+        test_duration = row["test_duration"]
+        test_path = row["test_path"]
+        issue_version = row["issue_version"]
+        incident_test_id = row["incidents_test_id"]
+        build_status = row["build_status"]
+        test_origin = row["test_origin"]
+
+        if issue_id is None and (
+            build_status in [FAIL_STATUS, NULL_STATUS] or test_status == FAIL_STATUS
+        ):
+            issue_id = UNCATEGORIZED_STRING
+
+        if is_boot(test_path):
+            return self.filterParams.is_boot_filtered_out(
+                duration=test_duration,
+                issue_id=issue_id,
+                issue_version=issue_version,
+                path=test_path,
+                status=test_status,
+                incident_test_id=incident_test_id,
+                origin=test_origin,
+            )
+
+        return self.filterParams.is_test_filtered_out(
+            duration=test_duration,
+            issue_id=issue_id,
+            issue_version=issue_version,
+            path=test_path,
+            status=test_status,
+            incident_test_id=incident_test_id,
+            origin=test_origin,
+        )
+
+    def _process_rows(self, rows: dict, requested_types: list[TreeEntityTypes]) -> None:
         sanitized_rows = self.sanitize_rows(rows)
 
         for row in sanitized_rows:
@@ -339,7 +328,7 @@ class BaseTreeCommitsHistory(APIView):
                 hardware_filter = row["hardware_compatibles"]
             if test_environment_misc is not None:
                 platform = misc_value_or_default(test_environment_misc).get("platform")
-                if len(hardware_filter) == 0 or platform != UNKNOWN_STRING:
+                if platform and str(platform).lower() != UNKNOWN_STRING.lower():
                     hardware_filter.append(platform)
             # Only consider build platform if there is neither compatibles nor env platform
             if len(hardware_filter) == 0:
@@ -375,7 +364,16 @@ class BaseTreeCommitsHistory(APIView):
                     "earliest_start_time"
                 ]
 
-            self._process_tests(row)
+            is_test_filtered_out = self._is_test_row_filtered_out(row)
+
+            # Ignore the boots/tests counts if we just asked for builds
+            if not requested_types == ["builds"] and not is_test_filtered_out:
+                self._process_tests(row)
+
+            # Only process the builds if either we allow any build or
+            # if we only asked for builds related to tests that passed the filter and it did
+            if self.builds_related_to_filtered_tests_only and is_test_filtered_out:
+                continue
             self._process_builds(row)
 
     def _process_time_range(self, *, start_timestamp: str, end_timestamp: str) -> None:
@@ -387,7 +385,8 @@ class BaseTreeCommitsHistory(APIView):
         except Exception as ex:
             log_message(ex)
 
-    def get(
+    # TODO: lower the complexity of this function
+    def get(  # noqa: C901
         self,
         request: HttpRequest,
         commit_hash: str,
@@ -404,12 +403,12 @@ class BaseTreeCommitsHistory(APIView):
                 ),
                 end_timestamp_in_seconds=request.GET.get("end_timestamp_in_seconds"),
                 types=request.GET.get("types"),
+                builds_related_to_filtered_tests_only=request.GET.get(
+                    "builds_related_to_filtered_tests_only", False
+                ),
             )
         except ValidationError as e:
-            return create_api_error_response(
-                error_message=e.json(),
-                status_code=HTTPStatus.BAD_REQUEST,
-            )
+            return create_api_error_response(error_message=e.json())
 
         start_timestamp = params.start_timestamp_in_seconds
         end_timestamp = params.end_timestamp_in_seconds
@@ -424,13 +423,25 @@ class BaseTreeCommitsHistory(APIView):
         except InvalidComparisonOPError as e:
             return create_api_error_response(error_message=str(e))
 
+        # When relation-gated builds mode is enabled we need tests/boots rows to identify
+        # which builds are related to filtered tests.
+        self.builds_related_to_filtered_tests_only = (
+            params.builds_related_to_filtered_tests_only
+        )
+
+        include_types = params.types
+        if params.types == ["builds"] and (
+            self.builds_related_to_filtered_tests_only or len(self.filterHardware) > 0
+        ):
+            include_types = ["builds", "boots", "tests"]
+
         rows = get_tree_commit_history(
             commit_hash=commit_hash,
             origin=params.origin,
             git_url=params.git_url,
             git_branch=params.git_branch or git_branch,
             tree_name=tree_name,
-            include_types=params.types,
+            include_types=include_types,
         )
 
         if not rows:
@@ -439,7 +450,8 @@ class BaseTreeCommitsHistory(APIView):
                 status_code=HTTPStatus.OK,
             )
 
-        self._process_rows(rows)
+        self._process_rows(rows, params.types)
+
         # Format the results as JSON
         results = []
 

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -1158,6 +1158,14 @@ paths:
     get:
       operationId: tree_commits_retrieve
       parameters:
+      - in: query
+        name: builds_related_to_filtered_tests_only
+        schema:
+          default: false
+          title: Builds Related To Filtered Tests Only
+          type: boolean
+        description: When true, and requesting only builds, count only builds related
+          to tests/boots that pass the current filters.
       - in: path
         name: commit_hash
         schema:
@@ -1496,6 +1504,14 @@ paths:
     get:
       operationId: tree_commits_retrieve_2
       parameters:
+      - in: query
+        name: builds_related_to_filtered_tests_only
+        schema:
+          default: false
+          title: Builds Related To Filtered Tests Only
+          type: boolean
+        description: When true, and requesting only builds, count only builds related
+          to tests/boots that pass the current filters.
       - in: path
         name: commit_hash
         schema:

--- a/dashboard/src/api/commitHistory.ts
+++ b/dashboard/src/api/commitHistory.ts
@@ -26,6 +26,7 @@ const fetchCommitHistory = async (
   treeName?: string,
   treeUrlFrom?: TreeDetailsRouteFrom,
   types?: TreeEntityTypes[],
+  buildsRelatedToFilteredTestsOnly?: boolean,
 ): Promise<TTreeCommitHistoryResponse> => {
   const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
 
@@ -36,6 +37,7 @@ const fetchCommitHistory = async (
     start_timestamp_in_seconds: startTimestampInSeconds,
     end_timestamp_in_seconds: endTimestampInSeconds,
     types: types?.join(','),
+    builds_related_to_filtered_tests_only: buildsRelatedToFilteredTestsOnly,
     ...filtersFormatted,
   };
 
@@ -65,6 +67,7 @@ export const useCommitHistory = ({
   treeName,
   treeUrlFrom,
   types,
+  buildsRelatedToFilteredTestsOnly,
 }: {
   commitHash: string;
   origin: string;
@@ -76,6 +79,7 @@ export const useCommitHistory = ({
   treeName?: string;
   treeUrlFrom?: TreeDetailsRouteFrom;
   types?: TreeEntityTypes[];
+  buildsRelatedToFilteredTestsOnly?: boolean;
 }): UseQueryResult<TTreeCommitHistoryResponse> => {
   const testFilter = getTargetFilter(filter, 'test');
   const treeDetailsFilter = getTargetFilter(filter, 'treeDetails');
@@ -98,6 +102,7 @@ export const useCommitHistory = ({
       treeName,
       treeUrlFrom,
       types,
+      buildsRelatedToFilteredTestsOnly,
     ],
     queryFn: () =>
       fetchCommitHistory(
@@ -111,6 +116,7 @@ export const useCommitHistory = ({
         treeName,
         treeUrlFrom,
         types,
+        buildsRelatedToFilteredTestsOnly,
       ),
   });
 };

--- a/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
+++ b/dashboard/src/components/CommitNavigationGraph/CommitNavigationGraph.tsx
@@ -54,6 +54,7 @@ interface ICommitNavigationGraph {
   onMarkClick: (commitHash: string, commitName?: string) => void;
   treeName?: string;
   treeUrlFrom?: TreeDetailsRouteFrom;
+  buildsRelatedToFilteredTestsOnly?: boolean;
 }
 
 const CommitNavigationGraph = ({
@@ -69,6 +70,7 @@ const CommitNavigationGraph = ({
   startTimestampInSeconds,
   treeName,
   treeUrlFrom,
+  buildsRelatedToFilteredTestsOnly,
 }: ICommitNavigationGraph): JSX.Element => {
   const { formatMessage } = useIntl();
 
@@ -98,6 +100,7 @@ const CommitNavigationGraph = ({
     treeName,
     treeUrlFrom,
     types,
+    buildsRelatedToFilteredTestsOnly,
   });
 
   const displayableData = data ? data : null;

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareCommitNavigationGraph.tsx
@@ -66,6 +66,7 @@ const HardwareCommitNavigationGraph = ({
       currentPageTab={currentPageTab}
       endTimestampInSeconds={endTimestampInSeconds}
       startTimestampInSeconds={startTimestampInSeconds}
+      buildsRelatedToFilteredTestsOnly={true}
     />
   );
 };


### PR DESCRIPTION
Fixes a problem where when asking for builds with a hardware filter on hardware details, we would either get 0 builds with that hardware or builds with that hardware that weren't necessarily related to tests with that hardware. This is done by adding a paramenter to the endpoint to identify this exact scenario and rewiring the flow accordingly. This parameter is needed because if we filter on treeListing, we will want any build related to that hardware to be returned, even if they are not related to tests from that hardware.

## Changes
- Fixes small typo on "time_stamp" (should always be timestamp with no separation)
- Adds parameter to distinct between hardware details behavior and treeDetails behavior on commitHistory endpoint
- Fixes logic when expecting just builds related to tests that pass

## How to test
- Check some treeDetails pages, see if the number of builds in the commit graph matches the number of builds in the page
- Go to the hardwareDetails page when there's only one tree selected (then the commit graph will appear). Check if the number of builds in the graph matches the number of builds in the page. One special case is the kubernetes hardware, where a build itself can be tied to it even without tests.

Closes #1747