### PR TITLE
fix: always create prometheus multiproc dir

### DIFF
--- a/backend/utils/docker/backend_entrypoint.sh
+++ b/backend/utils/docker/backend_entrypoint.sh
@@ -30,15 +30,17 @@ file_env DB_DEFAULT_PASSWORD
 
 # Initialize Prometheus metrics before Django starts
 PROMETHEUS_METRICS_ENABLED=$(echo "$PROMETHEUS_METRICS_ENABLED" | tr '[:upper:]' '[:lower:]')
+PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR:-/tmp/prometheus_multiproc_dir}
+export PROMETHEUS_MULTIPROC_DIR
+mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
+
 if [ "$PROMETHEUS_METRICS_ENABLED" = "true" ]; then
     echo "Initializing Prometheus metrics before Django startup..."
     PROMETHEUS_METRICS_PORT=${PROMETHEUS_METRICS_PORT:-8001}
-    PROMETHEUS_MULTIPROC_DIR=${PROMETHEUS_MULTIPROC_DIR:-/tmp/prometheus_multiproc_dir}
-    export PROMETHEUS_MULTIPROC_DIR
     export PROMETHEUS_METRICS_PORT
-    
+
     rm -f $PROMETHEUS_MULTIPROC_DIR/*.db || true
-    
+
     python3 utils/prometheus_aggregator.py &
 fi
 


### PR DESCRIPTION
## Description

Ensures the Prometheus multiprocess directory is always created on container startup, regardless of whether Prometheus metrics are enabled. Previously, PROMETHEUS_MULTIPROC_DIR was only set and created inside the if block gated on PROMETHEUS_METRICS_ENABLED=true, which caused failures when the directory was referenced but metrics were disabled.

## Changes

- Move PROMETHEUS_MULTIPROC_DIR setup and mkdir -p outside the PROMETHEUS_METRICS_ENABLED guard so the directory is always created
- Export PROMETHEUS_MULTIPROC_DIR unconditionally so it is available to all processes