### PR TITLE
chore: update database service port configuration in docker-compose-[next].yml

### DIFF
--- a/docker-compose-next.yml
+++ b/docker-compose-next.yml
@@ -27,7 +27,7 @@ services:
         networks:
             - private
         ports:
-            - "5434:5432"
+            - "${DB_PORT:-5434}:5432"
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-admin}"]
             interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
         networks:
             - private
         ports:
-            - "5434:5432"
+            - "${DB_PORT:-5434}:5432"
 
     redis:
         image: redis:8.0-M04-alpine


### PR DESCRIPTION
## Description
Makes the host-side database port configurable via an environment variable instead of being hardcoded, while preserving 5434 as the default.

## Changes

- Replace hardcoded 5434 host port with ${DB_PORT:-5434} in docker-compose.yml
- Apply the same dynamic port configuration to docker-compose-next.yml

Closes #1769