### PR TITLE
docker-compose: Updates based on deploy issues

### DIFF
--- a/docker-compose-next.yml
+++ b/docker-compose-next.yml
@@ -59,7 +59,7 @@ services:
             - private
             - public
         ports:
-            - 2001:2001
+            - ${EXTERNAL_PROM_METRICS_PORT:-2001}:${PROM_METRICS_PORT:-8002}
         depends_on:
             - redis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,20 +120,20 @@ services:
         volumes:
             - static-data:/data/static
 
-#    proxy:
-#        build: ./proxy
-#        image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_REPOSITORY:-local}/dashboard-proxy:${IMAGE_TAG:-latest}
-#        restart: always
-#        depends_on:
-#            - backend
-#            - dashboard
-#        networks:
-#            - public
-#        volumes:
-#            - static-data:/data/static
-#            - /etc/letsencrypt/live/staging.dashboard.kernelci.org/fullchain.pem:/etc/nginx/ssl/fullchain.pem
-#            - /etc/letsencrypt/live/staging.dashboard.kernelci.org/privkey.pem:/etc/nginx/ssl/privkey.pem
-#        ports:
-#            - 9000:9000
-#        env_file:
-#            - .env
+    proxy:
+        build: ./proxy
+        image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_REPOSITORY:-local}/dashboard-proxy:${IMAGE_TAG:-latest}
+        restart: always
+        depends_on:
+            - backend
+            - dashboard
+        networks:
+            - public
+        volumes:
+            - static-data:/data/static
+            - /etc/letsencrypt/live/staging.dashboard.kernelci.org/fullchain.pem:/etc/nginx/ssl/fullchain.pem
+            - /etc/letsencrypt/live/staging.dashboard.kernelci.org/privkey.pem:/etc/nginx/ssl/privkey.pem
+        ports:
+            - ${STAGING_EXTERNAL_HTTP_PORT:-9000}:80
+        env_file:
+            - .env


### PR DESCRIPTION
Some ports better to make configurable from ENV.
Staging port is actually 9000, not 8000 (i forgot that), so taking opportunity also hiding staging behind proxy. Production right now are proxied over local nginx (easier certbot), so we need to make ports configurable too.