### PR TITLE
Fix: cronjob run and log

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -128,6 +128,10 @@ SKIP_CRONJOBS = is_boolean_or_string_true(os.environ.get("SKIP_CRONJOBS", False)
 if SKIP_CRONJOBS:
     CRONJOBS = []
 else:
+    # Make cron task output visible in `docker compose logs backend`.
+    CRONTAB_COMMAND_SUFFIX = os.environ.get(
+        "CRONTAB_COMMAND_SUFFIX", ">> /proc/1/fd/1 2>&1"
+    )
     CRONJOBS = [
         ("0 * * * *", "kernelCI_app.tasks.update_checkout_cache"),
         (

--- a/backend/utils/docker/backend_entrypoint.sh
+++ b/backend/utils/docker/backend_entrypoint.sh
@@ -49,7 +49,9 @@ chmod +x ./setup-dashboard-db.sh
 
 # Add and start cronjobs
 poetry run ./manage.py crontab add
-crond start
+# BusyBox crond doesn't support a "start" subcommand.
+# Start cronjobs in background and emit logs to container stdout.
+crond -b -L /proc/1/fd/1
 
 # Update the sqlite cache db
 chmod +x ./migrate-cache-db.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
             - 8000:8000
         restart: always
         image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_REPOSITORY:-local}/dashboard-backend:${IMAGE_TAG:-latest}
-        environment:
-            - CONTAINER_MODE=backend
         command:
             - poetry
             - run


### PR DESCRIPTION
## Changes
- Makes cronjob logs go to the docker output, making it easier to debug.
- Also changes the command from 'crond start' to just 'crond' so that it works best with busybox.

## How to test
You must have data in your local database so that you can run the cronjobs within the backend container. Having the data, edit the cronjobs so that they run in a smaller interval, then check if their logs are going to the container logs.
The notification and other commands behavior stay the same.