### PR TITLE
fix: always initialize Prometheus multiproc directory on process_pending

### DIFF
--- a/backend/kernelCI_app/management/commands/process_pending_aggregations.py
+++ b/backend/kernelCI_app/management/commands/process_pending_aggregations.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import shutil
 import signal
 import time
 from datetime import datetime
@@ -10,6 +11,7 @@ from django.db import connection, transaction
 from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 from kernelCI_app.helpers.logger import out
 from kernelCI_app.management.commands.helpers.aggregation_helpers import simplify_status
+from kernelCI_app.constants.ingester import PROMETHEUS_MULTIPROC_DIR
 from prometheus_client import start_http_server
 from kernelCI_app.models import (
     Builds,
@@ -528,6 +530,11 @@ class Command(BaseCommand):
         interval = options["interval"]
 
         metrics_port = int(os.environ.get("PROMETHEUS_METRICS_PORT", 8001))
+        if PROMETHEUS_MULTIPROC_DIR:
+            if os.path.exists(PROMETHEUS_MULTIPROC_DIR):
+                shutil.rmtree(PROMETHEUS_MULTIPROC_DIR)
+            os.makedirs(PROMETHEUS_MULTIPROC_DIR, exist_ok=True)
+
         if settings.PROMETHEUS_METRICS_ENABLED:
             start_http_server(metrics_port)
             out(f"Prometheus metrics server started on port {metrics_port}")


### PR DESCRIPTION
## Description

Fixes a crash in process_pending_aggregations by always creating the multiproc_dir directory. The command was failing with FileNotFoundError: [Errno 2] No such file or directory: '/tmp/metrics/counter_1.db' because the Prometheus multiprocess directory was not being initialized before the metrics server started.

## Changes

- Add import shutil for directory removal
- Import PROMETHEUS_MULTIPROC_DIR from kernelCI_app.constants.ingester
- Add directory initialization logic that removes existing directory (if present) and recreates it before starting Prometheus HTTP server

## How to test

1. Run the pending aggregations processor: docker compose --profile=with_commands up pending_aggregations_processor
2. Verify the service starts without `FileNotFoundError`