### PR TITLE
Refactor: feedback on metrics email structure

### DIFF
--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -824,6 +824,10 @@ def generate_metrics_report(
 
     deltas = compute_metrics_deltas(data)
 
+    # Compute the text spacing for the labs so it isn't too big or too small
+    lab_spacing = max((len(lab_key) for lab_key in data.lab_maps.keys()), default=0)
+    lab_spacing += 7  # add spacing for leading tab and possible * mark for new labs
+
     report = {}
     template = setup_jinja_template("metrics_report.txt.j2")
     report["content"] = template.render(
@@ -831,6 +835,7 @@ def generate_metrics_report(
         start_datetime=start_datetime.strftime("%Y-%m-%d %H:%M %Z"),
         end_datetime=end_datetime.strftime("%Y-%m-%d %H:%M %Z"),
         deltas=deltas,
+        lab_spacing=lab_spacing,
     )
 
     report["title"] = "KernelCI Metrics Report - %s" % now.strftime("%Y-%m-%d %H:%M %Z")

--- a/backend/kernelCI_app/management/commands/templates/metrics_report.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/metrics_report.txt.j2
@@ -20,27 +20,53 @@ Period: {{ start_datetime }} to {{ end_datetime }}
 
   BUILD REGRESSIONS
   -----------------
-  A "regression" is a newly detected failure (first occurrence).
-  An "occurrence" is each subsequent hit of that same failure.
+  A "regression" is defined as a reported problem affecting 0 or multiple builds.
 
 {% if build_incidents_by_origin -%}
-{{ "{:<14}".format("  Origin") -}}
-{{ "{:<15}".format("Occurrences") -}}
-New regressions
-  ────────────────────────────────────────────
+
+{{ "{:<12}".format("  Origin") -}}
+{{ "{:<18}".format("Regressions") -}}
+{{ "{:<19}".format("Affected") -}}
+Affected builds by top issues
+{{ "{:<12}".format("") -}}
+{{ "{:<18}".format("(known + new)") -}}
+{{ "{:<19}".format("Builds (total)") -}}
+{{ "{:<8}".format("#1") -}}{{ "{:<8}".format("#2") -}}#3
+  ─────────────────────────────────────────────────────────────────────────
 {% for origin, data in build_incidents_by_origin.items() | sort -%}
-{{ "{:<14}".format("  " + origin) -}}
-{{ "{:<15}".format(fmt(data.total)) -}}
-{{ fmt(data.new_regressions) }}
-{% endfor %}  ────────────────────────────────────────────
-{{ "{:<14}".format("  Total") -}}
-{{ "{:<15}".format(fmt(build_incidents_by_origin.values() | map(attribute='total') | sum)) -}}
-{{ fmt(build_incidents_by_origin.values() | map(attribute='new_regressions') | sum) }}
+  {{ "{:<12}".format("  " + origin) -}}
+  {{ "{:<4}".format(fmt(data['n_existing_issues'])) -}} +{{" "}}
+  {{- "{:<4}".format(fmt(data['n_new_issues'])) -}} ={{" "}}
+  {{- "{:<6}".format(fmt(data['n_total_issues'])) -}}
+  {{ "{:<19}".format(fmt(data['total_incidents'])) -}}
+  {% for issue_key, data in top_issues_by_origin.get(origin, {}).items() -%}
+    {{ "{:<8}".format(fmt(data['total_incidents'])) -}}
+  {% endfor %}
+{% endfor %}  ─────────────────────────────────────────────────────────────────────────
+{{ "{:<12}".format("  Total") -}}
+{{ "{:<4}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_existing_issues') | sum)) -}} +{{" "}}
+{{- "{:<4}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_new_issues') | sum)) -}} ={{" "}}
+{{- "{:<6}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_total_issues') | sum)) -}}
+{{ fmt(build_incidents_by_origin.values() | map(attribute='total_incidents') | sum) }}
 {%- else %}  No build regressions to show in this period. {%- endif %}
 
 
-  LAB ACTIVITY
-  ------------
+  TOP REGRESSIONS PER ORIGIN
+  --------------------------
+{%- if top_issues_by_origin %}
+  {%- for origin, data in top_issues_by_origin.items() | sort %}
+  {{ origin }}:
+    {%- for issue_key, issue_data in data.items() %}
+    #{{ loop.index }} ({{ fmt(issue_data['total_incidents']) }} occurrences) - {{ issue_data['comment'] | truncate(70, True, '...', 0)}}
+      Dashboard: https://d.kernelci.org/issue/{{issue_data['id']}}?iv={{issue_data['version']}}
+    {%- endfor %}
+  {% endfor -%}
+{%- else %}
+  No regression details to show in this period.
+{%- endif %}
+
+  TEST LABS ACTIVITY
+  ------------------
 {%- set n_labs = lab_maps | length %}
 {%- set prev_n_labs = prev_lab_maps | length %}
 {%- set lab_diff = n_labs - prev_n_labs %}
@@ -53,36 +79,32 @@ New regressions
 {%- endif %}
 
   Labs marked with an asterisk (*) are new.
-  Labs that stopped reporting are shown with a -100% change.
 
 {% if n_labs -%}
-{{ "{:<20}".format("  Origin") -}}
-{{ "{:<25}".format("Lab") -}}
-{{ "{:<9}".format("Builds") -}}
+{{ "{:<{width}}".format("  Lab", width=lab_spacing) -}}
+{{ "{:<16}".format("Covered builds") -}}
 {{ "{:<9}".format("Boots") -}}
 {{ "{:<15}".format("Tests") -}}
 Change (tests)
-  ──────────────────────────────────────────────────────────────────────────────────────────
+  ────────────────────────────────────────────────────────────────────────────────
 {% for lab_key, lab_values in lab_maps.items() | sort -%}
     {%- set display_name = lab_key + " *" if lab_key in deltas.new_lab_keys else lab_key -%}
-    {{ "{:<20}".format("  " + lab_values["origin"]) -}}
-    {{ "{:<25}".format(display_name) -}}
-    {{ "{:<9}".format(fmt(lab_values["builds"])) -}}
+  {{ "{:<{width}}".format("  " + display_name, width=lab_spacing) -}}
+    {{ "{:<16}".format(fmt(lab_values["builds"])) -}}
     {{ "{:<9}".format(fmt(lab_values["boots"])) -}}
     {{ "{:<15}".format(fmt(lab_values["tests"])) -}}
     {{ deltas.labs.get(lab_key, "") }}
 {% endfor %}
 {%- for lab_key in deltas.extinct_lab_keys | sort -%}
     {%- set lab_values = prev_lab_maps[lab_key] -%}
-    {{ "{:<20}".format("  " + lab_values["origin"]) -}}
-    {{ "{:<25}".format(lab_key) -}}
-    {{ "{:<9}".format(fmt(0)) -}}
+  {{ "{:<{width}}".format("  " + lab_key, width=lab_spacing) -}}
+    {{ "{:<16}".format(fmt(0)) -}}
     {{ "{:<9}".format(fmt(0)) -}}
     {{ "{:<15}".format(fmt(0)) -}}
     {{ deltas.labs.get(lab_key, "") }}
-{% endfor %}  ──────────────────────────────────────────────────────────────────────────────────────────
-{{ "{:<45}".format("  Total") -}}
-{{ "{:<9}".format(fmt(lab_maps.values() | map(attribute='builds') | sum)) -}}
+{% endfor %}  ────────────────────────────────────────────────────────────────────────────────
+{{ "{:<{width}}".format("  Total", width=lab_spacing) -}}
+{{ "{:<16}".format(fmt(lab_maps.values() | map(attribute='builds') | sum)) -}}
 {{ "{:<9}".format(fmt(lab_maps.values() | map(attribute='boots') | sum)) -}}
 {{ "{:<15}".format(fmt(lab_maps.values() | map(attribute='tests') | sum)) -}}
 {{ deltas.n_total_lab_activity }}

--- a/backend/kernelCI_app/queries/notifications.py
+++ b/backend/kernelCI_app/queries/notifications.py
@@ -8,9 +8,10 @@ from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.logger import out
 from kernelCI_app.queries.tree import get_tree_listing_query
 from kernelCI_app.typeModels.metrics_notifications import (
-    BuildIncidentsByOrigin,
+    BuildIncidentsCount,
     LabMetricsData,
     MetricsReportData,
+    TopIssue,
 )
 from pydantic import ValidationError
 
@@ -696,78 +697,95 @@ def get_metrics_data(
     """
 
     build_incidents_query = """
-    WITH ranked AS (
+    -- Ranks incidents of each issue by time to check which incident was the first incident of an issue
+    WITH time_rank AS (
         SELECT
             _timestamp,
             origin,
-            id,
+            issue_id,
             ROW_NUMBER() OVER (PARTITION BY issue_id ORDER BY _timestamp) AS rn
         FROM incidents
             where build_id is not null
+    ),
+    -- counts total incidents in interval and how many were the first incident of an issue
+    numbers AS (
+        SELECT
+            origin,
+            COUNT(*) FILTER (
+                WHERE _timestamp BETWEEN
+                    NOW() - INTERVAL %(start_days_ago)s
+                    AND NOW() - INTERVAL %(end_days_ago)s
+            ) AS total_incidents,
+            COUNT(*) FILTER (
+                WHERE _timestamp BETWEEN
+                    NOW() - INTERVAL %(start_days_ago)s
+                    AND NOW() - INTERVAL %(end_days_ago)s
+                AND rn = 1
+            ) AS n_new_issues,
+            COUNT(DISTINCT issue_id) FILTER (
+                WHERE _timestamp BETWEEN
+                    NOW() - INTERVAL %(start_days_ago)s
+                    AND NOW() - INTERVAL %(end_days_ago)s
+            ) AS n_issues
+        FROM time_rank
+        GROUP BY origin
+    ),
+    -- counts incidents by issue
+    grouped_counted AS (
+        SELECT
+            inc.origin,
+            inc.issue_id,
+            inc.issue_version,
+            i.comment,
+            COUNT(inc.*) AS total
+        FROM incidents inc
+        JOIN issues i ON inc.issue_id = i.id AND inc.issue_version = i.version
+        WHERE
+            inc.build_id is not null
+            AND inc._timestamp BETWEEN
+                NOW() - INTERVAL %(start_days_ago)s
+                AND NOW() - INTERVAL %(end_days_ago)s
+        GROUP BY inc.origin, inc.issue_id, inc.issue_version, i.comment
+        ORDER BY inc.origin, total DESC
+    ),
+    -- ranks issues by number of incidents
+    ranked_counted AS (
+        SELECT
+            *,
+            ROW_NUMBER() OVER (PARTITION BY origin ORDER BY total DESC) as ranked
+        FROM grouped_counted
     )
+    -- combines data into single output,
+    -- repeating total incidents by origin and adding the top 3 issues per origin
     SELECT
-        origin,
-        COUNT(*) FILTER (
-            WHERE _timestamp BETWEEN
-                NOW() - INTERVAL %(start_days_ago)s
-                AND NOW() - INTERVAL %(end_days_ago)s
-        ) AS total_incidents,
-        COUNT(*) FILTER (
-            WHERE rn = 1
-            AND _timestamp BETWEEN
-                NOW() - INTERVAL %(start_days_ago)s
-                AND NOW() - INTERVAL %(end_days_ago)s
-        ) AS first_incidents_in_interval
-    FROM ranked
-    GROUP BY origin;
+        n.origin,
+        n.total_incidents,
+        n.n_new_issues,
+        n.n_issues,
+        r.issue_id,
+        r.issue_version,
+        r.comment,
+        r.total
+    FROM numbers n
+    JOIN ranked_counted r
+    ON n.origin = r.origin
+    WHERE r.ranked <= 3 AND n.total_incidents > 0
     """
 
-    # For the lab query, we can't simply join the builds of the tests by lab,
-    # because we want the builds made by a lab and tests made by a lab,
-    # not the builds related to tests made by a lab, neither the tests related to builds made by a lab.
     lab_summary_query = """
-    WITH unioned_results AS (
-        (SELECT
-            b.misc->>'lab' AS lab,
-            b.origin,
-            COUNT(DISTINCT b.id) AS n_builds,
-            0 AS n_boots,
-            0 AS n_tests
-        FROM builds b
-        WHERE
-            b.misc->>'lab' IS NOT NULL
-            AND b._timestamp BETWEEN
-                NOW() - INTERVAL %(start_days_ago)s
-                AND NOW() - INTERVAL %(end_days_ago)s
-        GROUP BY lab, origin
-        )
-        UNION ALL
-        (
-        SELECT
-            t.misc->>'runtime' AS lab,
-            t.origin,
-            0 AS n_builds,
-            COUNT(CASE WHEN (t.path LIKE 'boot.%%' OR t.path = 'boot') THEN 1 END) AS n_boots,
-            COUNT(CASE WHEN (t.path NOT LIKE 'boot.%%' AND t.path != 'boot') THEN 1 END) AS n_tests
-        FROM tests t
-        WHERE
-            t.misc->>'runtime' IS NOT NULL
-            AND t._timestamp BETWEEN
-                NOW() - INTERVAL %(start_days_ago)s
-                AND NOW() - INTERVAL %(end_days_ago)s
-        GROUP BY lab, origin
-        )
-    )
+    -- get count of tests of each lab and how many builds are related to those tests
     SELECT
-        lab,
-        origin,
-        SUM(n_builds) AS n_builds,
-        SUM(n_boots) AS n_boots,
-        SUM(n_tests) AS n_tests
-    FROM
-        unioned_results u
-    GROUP BY u.lab, u.origin
-    ORDER BY u.lab, u.origin
+        t.misc->>'runtime' AS lab,
+        COUNT(DISTINCT t.build_id) AS n_builds,
+        COUNT(*) FILTER (WHERE t.path LIKE 'boot.%%' OR t.path = 'boot') AS n_boots,
+        COUNT(*) FILTER (WHERE t.path NOT LIKE 'boot.%%' AND t.path != 'boot') AS n_tests
+    FROM tests t
+    WHERE
+        t.misc->>'runtime' IS NOT NULL
+        AND t._timestamp BETWEEN
+            NOW() - INTERVAL %(start_days_ago)s
+            AND NOW() - INTERVAL %(end_days_ago)s
+    GROUP BY lab
     """
 
     with connections["default"].cursor() as cursor:
@@ -787,6 +805,27 @@ def get_metrics_data(
         prev_lab_summary_results = cursor.fetchall()
 
     try:
+        build_incidents_by_origin: dict[str, BuildIncidentsCount] = {}
+        top_issues_by_origin: dict[str, dict[tuple[str, int], TopIssue]] = {}
+        for row in build_incidents_result:
+            origin = row[0]
+            issue_id = row[4]
+            issue_version = row[5]
+            build_incidents_by_origin[origin] = BuildIncidentsCount(
+                total_incidents=row[1],
+                n_new_issues=row[2],
+                n_total_issues=row[3],
+                n_existing_issues=row[3] - row[2],
+            )
+            if top_issues_by_origin.get(origin) is None:
+                top_issues_by_origin[origin] = {}
+            top_issues_by_origin[origin][(issue_id, issue_version)] = TopIssue(
+                id=issue_id,
+                version=issue_version,
+                comment=row[6],
+                total_incidents=row[7],
+            )
+
         data = MetricsReportData(
             n_trees=total_objects_result[0],
             n_checkouts=total_objects_result[1],
@@ -794,20 +833,13 @@ def get_metrics_data(
             n_tests=total_objects_result[3],
             n_issues=total_objects_result[4],
             n_incidents=total_objects_result[5],
-            build_incidents_by_origin={
-                row[0]: BuildIncidentsByOrigin(
-                    total=row[1],
-                    new_regressions=row[2],
-                )
-                for row in build_incidents_result
-                if row[1] != 0 or row[2] != 0
-            },
+            build_incidents_by_origin=build_incidents_by_origin,
+            top_issues_by_origin=top_issues_by_origin,
             lab_maps={
                 row[0]: LabMetricsData(
-                    origin=row[1],
-                    builds=row[2],
-                    boots=row[3],
-                    tests=row[4],
+                    builds=row[1],
+                    boots=row[2],
+                    tests=row[3],
                 )
                 for row in lab_summary_results
             },
@@ -817,10 +849,9 @@ def get_metrics_data(
             prev_n_tests=prev_total_objects_result[3],
             prev_lab_maps={
                 row[0]: LabMetricsData(
-                    origin=row[1],
-                    builds=row[2],
-                    boots=row[3],
-                    tests=row[4],
+                    builds=row[1],
+                    boots=row[2],
+                    tests=row[3],
                 )
                 for row in prev_lab_summary_results
             },

--- a/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_example.txt
+++ b/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_example.txt
@@ -16,30 +16,42 @@ KernelCI Metrics Summary
 
   BUILD REGRESSIONS
   -----------------
-  A "regression" is a newly detected failure (first occurrence).
-  An "occurrence" is each subsequent hit of that same failure.
+  A "regression" is defined as a reported problem affecting 0 or multiple builds.
 
-  Origin      Occurrences    New regressions
-  ────────────────────────────────────────────
-  maestro     70             1
-  redhat      5              0
-  ────────────────────────────────────────────
-  Total       75             1
+  Origin    Regressions       Affected           Affected builds by top issues
+            (known + new)     Builds (total)     #1      #2      #3
+  ─────────────────────────────────────────────────────────────────────────
+  maestro   1   + 1   = 2     70                 50      20      
+  redhat    1   + 0   = 1     5                  5       
+  ─────────────────────────────────────────────────────────────────────────
+  Total     2   + 1   = 3     75
 
 
-  LAB ACTIVITY
-  ------------
+  TOP REGRESSIONS PER ORIGIN
+  --------------------------
+  maestro:
+    #1 (50 occurrences) - First issue
+      Dashboard: https://d.kernelci.org/issue/issue-1?iv=1
+    #2 (20 occurrences) - Second issue
+      Dashboard: https://d.kernelci.org/issue/issue-2?iv=1
+  
+  redhat:
+    #1 (5 occurrences) - Third issue
+      Dashboard: https://d.kernelci.org/issue/issue-3?iv=1
+  
+
+  TEST LABS ACTIVITY
+  ------------------
   2 labs reported results this week (unchanged from last week).
 
   Labs marked with an asterisk (*) are new.
-  Labs that stopped reporting are shown with a -100% change.
 
-  Origin            Lab                      Builds   Boots    Tests          Change (tests)
-  ──────────────────────────────────────────────────────────────────────────────────────────
-  maestro           lava-broonie             0        25,000   475,000        -175,000  (-27%)
-  maestro           lava-collabora           0        50,000   450,000        -250,000  (-36%)
-  ──────────────────────────────────────────────────────────────────────────────────────────
-  Total                                      0        75,000   925,000        -425,000  (-31%)
+  Lab                Covered builds  Boots    Tests          Change (tests)
+  ────────────────────────────────────────────────────────────────────────────────
+  lava-broonie       0               25,000   475,000        -175,000  (-27%)
+  lava-collabora     0               50,000   450,000        -250,000  (-36%)
+  ────────────────────────────────────────────────────────────────────────────────
+  Total              0               75,000   925,000        -425,000  (-31%)
 
 --
 This is an experimental report format. Please send feedback in!

--- a/backend/kernelCI_app/tests/unitTests/commands/metrics_notifications_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/metrics_notifications_test.py
@@ -12,9 +12,10 @@ from kernelCI_app.tests.unitTests.commands.fixtures.metrics_notifications_data i
     METRICS_NOTIFICATIONS_EXAMPLE_FILEPATH,
 )
 from kernelCI_app.typeModels.metrics_notifications import (
-    BuildIncidentsByOrigin,
+    BuildIncidentsCount,
     LabMetricsData,
     MetricsReportData,
+    TopIssue,
 )
 
 
@@ -28,8 +29,39 @@ def make_metrics_data(**overrides) -> MetricsReportData:
         n_issues=10,
         n_incidents=75,
         build_incidents_by_origin={
-            "maestro": BuildIncidentsByOrigin(total=70, new_regressions=1),
-            "redhat": BuildIncidentsByOrigin(total=5, new_regressions=0),
+            "maestro": BuildIncidentsCount(
+                total_incidents=70,
+                n_new_issues=1,
+                n_total_issues=2,
+                n_existing_issues=1,
+            ),
+            "redhat": BuildIncidentsCount(
+                total_incidents=5, n_new_issues=0, n_total_issues=1, n_existing_issues=1
+            ),
+        },
+        top_issues_by_origin={
+            "maestro": {
+                ("issue-1", 1): TopIssue(
+                    id="issue-1",
+                    version=1,
+                    comment="First issue",
+                    total_incidents=50,
+                ),
+                ("issue-2", 1): TopIssue(
+                    id="issue-2",
+                    version=1,
+                    comment="Second issue",
+                    total_incidents=20,
+                ),
+            },
+            "redhat": {
+                ("issue-3", 1): TopIssue(
+                    id="issue-3",
+                    version=1,
+                    comment="Third issue",
+                    total_incidents=5,
+                ),
+            },
         },
         lab_maps={
             "lava-collabora": LabMetricsData(
@@ -210,6 +242,7 @@ class TestGenerateMetricsReport(TestCase):
             n_issues=10,
             n_incidents=75,
             build_incidents_by_origin=mock.ANY,
+            top_issues_by_origin=mock.ANY,
             lab_maps=mock.ANY,
             prev_n_trees=100,
             prev_n_checkouts=1000,
@@ -219,6 +252,7 @@ class TestGenerateMetricsReport(TestCase):
             start_datetime=mock.ANY,
             end_datetime=mock.ANY,
             deltas=mock.ANY,
+            lab_spacing=mock.ANY,
         )
 
     @patch(f"{MOCK_MODULE}.send_email_report")
@@ -272,6 +306,7 @@ class TestMetricsReportTemplate(TestCase):
         # and update the known report.
         with open(METRICS_NOTIFICATIONS_EXAMPLE_FILEPATH) as f:
             expected = f.read()
+
         assert content == expected
 
     def test_no_build_regressions_message_shown(self):
@@ -321,7 +356,7 @@ class TestMetricsReportTemplate(TestCase):
             prev_lab_maps={"lava-collabora": lab, "gone-lab": lab},
         )
         assert re.search(
-            r"^.*maestro.*gone-lab.*0.*0.*0.*-500.*\(-100%\).*$",
+            r"^.*gone-lab.*0.*0.*0.*-500.*\(-100%\).*$",
             content,
             re.MULTILINE,
         )

--- a/backend/kernelCI_app/typeModels/metrics_notifications.py
+++ b/backend/kernelCI_app/typeModels/metrics_notifications.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from pydantic import BaseModel
 
 
@@ -5,12 +7,20 @@ class LabMetricsData(BaseModel):
     builds: int
     boots: int
     tests: int
-    origin: str
 
 
-class BuildIncidentsByOrigin(BaseModel):
-    total: int
-    new_regressions: int
+class BuildIncidentsCount(TypedDict):
+    total_incidents: int
+    n_new_issues: int
+    n_existing_issues: int
+    n_total_issues: int
+
+
+class TopIssue(TypedDict):
+    id: str
+    version: int
+    comment: str
+    total_incidents: int
 
 
 class MetricsReportData(BaseModel):
@@ -21,7 +31,9 @@ class MetricsReportData(BaseModel):
     n_tests: int
     n_issues: int
     n_incidents: int
-    build_incidents_by_origin: dict[str, BuildIncidentsByOrigin]
+    build_incidents_by_origin: dict[str, BuildIncidentsCount]
+    # top_issues = origin -> (issue_id, version) -> TopIssue
+    top_issues_by_origin: dict[str, dict[tuple[str, int], TopIssue]]
     lab_maps: dict[str, LabMetricsData]
     # Previous interval (for comparison)
     prev_n_trees: int


### PR DESCRIPTION
## Changes
- Changed build issues query to return "number of unique issues in the interval" + "number of unique issues that had their first incident in the interval" + "total number of incidents in the interval"
- Added subquery to return "which issue had the most incidents in the interval grouped by origin" (limited to top 3) and added that section to the email
- Changed lab query to make the `build count` be "builds related to tests performed by each lab" instead of "builds directly related to each lab", and removed origin grouping
- Updated email formatting
- Updated unit tests accordingly

## How to test
This PR changes the existing queries and format of the metrics summary email, so to test it just connect to a database and run `poetry run python3 manage.py notifications --action metrics_summary`

Closes #1780 

## Example with real data
```
KernelCI Metrics Summary
========================
Period: 2026-03-26 19:46 UTC to 2026-04-02 19:46 UTC


  COVERAGE
  --------
                      This week    Last week    Change
                      ─────────    ─────────    ──────
  Trees monitored     50           44           +6
  Checkouts           4,030        4,004        +26  (+1%)
  Builds              11,777       7,730        +4,047  (+52%)
  Tests               784,875      422,611      +362,264  (+86%)


  BUILD REGRESSIONS
  -----------------
  A "regression" is defined as a reported problem affecting 0 or multiple builds.

  Origin    Regressions       Affected           Affected builds by top issues
            (known + new)     Builds (total)     #1      #2      #3
  ─────────────────────────────────────────────────────────────────────────
  maestro   16  + 27  = 43    438                63      45      37      
  redhat    1   + 1   = 2     9                  6       3       
  ─────────────────────────────────────────────────────────────────────────
  Total     17  + 28  = 45    447


  TOP REGRESSIONS PER ORIGIN
  --------------------------
  maestro:
    #1 (63 occurrences) -  ‘done’ is used uninitialized [-Werror=uninitialized] in drivers/cp...
      Dashboard: https://d.kernelci.org/issue/maestro:e84b665ddd4424ed72a8bbede90636bdce186f99?iv=1
    #2 (45 occurrences) -  'HMAC_Update' is deprecated [-Wdeprecated-declarations] in crypto/...
      Dashboard: https://d.kernelci.org/issue/maestro:cfb7db7bad026f784ab5093df91515e27c634b34?iv=1
    #3 (37 occurrences) -  alignment may not be specified for ‘pidfd’ in drivers/block/zram/z...
      Dashboard: https://d.kernelci.org/issue/maestro:5a652717b9a5090a029aaeee303245bd07ee330c?iv=1
  
  redhat:
    #1 (6 occurrences) -  error: target emulation unknown: -m or at least one .o file requir...
      Dashboard: https://d.kernelci.org/issue/redhat:a8b090056d8e6bc4eee9ffa4389946c992a6e989?iv=1
    #2 (3 occurrences) -  ‘at91_default_usrio’ undeclared here (not in a function) in driver...
      Dashboard: https://d.kernelci.org/issue/redhat:e385e5050284ef5d130dbb06ffd633dadfd81c18?iv=1
  

  TEST LABS ACTIVITY
  ------------------
  8 labs reported results this week (1 more than last week).

  Labs marked with an asterisk (*) are new.

  Lab                   Covered builds  Boots    Tests          Change (tests)
  ────────────────────────────────────────────────────────────────────────────────
  lava-broonie          522             2,392    279,594        +108,272  (+63%)
  lava-cip              643             1,562    251            +179  (+249%)
  lava-collabora        913             5,517    318,892        +169,708  (+114%)
  lava-foundriesio      170             233      0              0  (0%)
  lava-kci-qualcomm *   48              122      75,087         +75,087
  lava-pengutronix      360             950      0              0  (0%)
  opentest-ti           46              1,477    35             +35
  pull-labs-demo        586             913      2,401          -182  (-7%)
  ────────────────────────────────────────────────────────────────────────────────
  Total                 3,288           13,166   676,260        +353,099  (+109%)

--
This is an experimental report format. Please send feedback in!
Talk to us at kernelci@lists.linux.dev

Made with love by the KernelCI team - https://kernelci.org

==============================================
```