### PR TITLE
fix: Fix/treedetails smallscreen

### DIFF
--- a/dashboard/eslint.config.mjs
+++ b/dashboard/eslint.config.mjs
@@ -20,7 +20,7 @@ const compat = new FlatCompat({
 });
 
 export default [{
-    ignores: ["**/.eslintrc.cjs", "**/*.config.*js", "src/components/ui/*", ".storybook/**", "dist/*"],
+    ignores: ["**/.eslintrc.cjs", "**/*.config.*js", "src/components/ui/*", ".storybook/**", "dist/*", "e2e/*.js", "e2e/*.d.ts"],
 }, ...fixupConfigRules(compat.extends(
     "eslint:recommended",
     "plugin:@tanstack/eslint-plugin-query/recommended",

--- a/dashboard/src/components/Tabs/Tabs.tsx
+++ b/dashboard/src/components/Tabs/Tabs.tsx
@@ -71,8 +71,8 @@ const TabsComponent = ({
       className="w-full"
     >
       <div className="bg-light-gray sticky top-18 z-5 flex flex-col gap-6 rounded-md pt-6 pb-6">
-        <div className="flex w-full flex-wrap justify-between gap-6">
-          <TabsList className="border-dark-gray flex-1 items-baseline justify-start rounded-none border-b bg-transparent">
+        <div className="flex w-full flex-col justify-between gap-6 md:flex-row">
+          <TabsList className="border-dark-gray flex-1 items-baseline justify-start overflow-x-auto overflow-y-hidden rounded-none border-b bg-transparent">
             {tabsTrigger}
           </TabsList>
           {headerExtra}


### PR DESCRIPTION
## Description
* Includes horizontal scroll for tabs that do not fit the screen.

## Changes
* Includes a CSS property to horizontal auto scroll only if needed.

## How to test
* Run application locally.
* Open the browser using a small screen (360x780), and assess that the tabs do not overflow screen horizontal size.

| Before| After |
| --- | --- |
| ![before_scroll](https://github.com/user-attachments/assets/dfb000d5-8a1b-4105-907b-6c74f63a5b08) | ![tabs_scroll](https://github.com/user-attachments/assets/904411fe-a1cf-4456-a00f-bfccfa58d5d1) |



Closes #1422 


