### PR TITLE
fix: sidemenu without vertical scrolling

### DIFF
--- a/dashboard/src/components/SideMenu/SideMenu.tsx
+++ b/dashboard/src/components/SideMenu/SideMenu.tsx
@@ -4,7 +4,7 @@ import SideMenuContent from './SideMenuContent';
 
 const SideMenu = (): JSX.Element => {
   return (
-    <div className="bg-bg-secondary hidden md:block">
+    <div className="bg-bg-secondary sticky top-0 hidden h-screen overflow-y-scroll md:block">
       <SideMenuContent className="min-h-screen" />
     </div>
   );


### PR DESCRIPTION
 ## Description
 
 Uses a sticky side menu fixed on top of the page, to avoid scrolling along side page content.

 ## How to Test
 
* Run application locally.
* Open the browser, and navigate to any screen larger than the screen (Tree Details for example).
* Verify you can scroll the content without scrolling the side menu.

![static_sidebar](https://github.com/user-attachments/assets/a85ae578-89fa-420d-8f19-248796bd3a9e)

 
  Closes #1413 