### PR TITLE
Fix: checkout cache cronjob

### DIFF
--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -239,7 +239,10 @@ def get_tree_listing_fast(
     return list(checkouts)
 
 
-def get_tree_listing_data_by_checkout_id(*, checkout_ids: list[str]):
+def get_tree_listing_data_by_checkout_id(*, checkout_ids: list[str]) -> list[dict]:
+    if not checkout_ids:
+        return []
+
     count_clauses = _get_tree_listing_count_clause()
 
     # TODO: check if those conditions of case, coalesce and group by are necessary

--- a/backend/kernelCI_app/tasks.py
+++ b/backend/kernelCI_app/tasks.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from kernelCI_app.helpers.logger import out, log_message
 from kernelCI_app.models import Checkouts
 from kernelCI_app.queries.tree import (
     get_tree_listing_data_by_checkout_id,
@@ -51,6 +53,34 @@ def _is_checkout_unstable(*, checkout: dict | Checkouts) -> bool:
         return True
 
 
+def _is_checkout_newer(
+    *,
+    cached_start_time,
+    old_checkout_start_time,
+    old_checkout_id,
+) -> bool:
+    if cached_start_time is None or old_checkout_start_time is None:
+        return False
+
+    try:
+        cached_start_time = make_aware(cached_start_time)
+        old_checkout_start_time = make_aware(old_checkout_start_time)
+    except ValueError as e:  # datetime is already aware, log but still compare
+        log_message(
+            "Value Error on _is_checkout_newer for %s: %s" % (old_checkout_id, str(e))
+        )
+    except Exception as e:  # other exceptions, don't compare
+        log_message(
+            "Exception on _is_checkout_newer for %s: %s" % (old_checkout_id, str(e))
+        )
+        return False
+
+    if old_checkout_start_time > cached_start_time:
+        return True
+    else:
+        return False
+
+
 def get_checkout_ids_for_update(
     *,
     kcidb_checkouts: list[Checkouts],
@@ -85,21 +115,23 @@ def get_checkout_ids_for_update(
             continue
 
         # Even if the current checkout is stable, if it is newer than the cached one, update it
-        cached_start_time = same_tree_on_sqlite.get("start_time")
-        if cached_start_time is not None:
-            if (
-                cached_start_time.tzinfo is None
-                and make_aware(checkout.start_time) > make_aware(cached_start_time)
-                or checkout.start_time > cached_start_time
-            ):
-                checkout_ids_for_update.add(checkout.id)
-                continue
+        if _is_checkout_newer(
+            cached_start_time=same_tree_on_sqlite.get("start_time"),
+            old_checkout_start_time=checkout.start_time,
+            old_checkout_id=checkout.id,
+        ):
+            checkout_ids_for_update.add(checkout.id)
 
     return checkout_ids_for_update
 
 
 def update_checkout_cache():
     checkout_ids_for_update: set[str] = set()
+
+    out(
+        "Started Updating checkout cache at %s/cache.sqlite3"
+        % settings.BACKEND_VOLUME_DIR
+    )
 
     kcidb_checkouts = get_tree_listing_fast(interval={"days": UPDATE_INTERVAL_IN_DAYS})
 
@@ -129,3 +161,8 @@ def update_checkout_cache():
         checkout.update({"unstable": _is_checkout_unstable(checkout=checkout)})
 
     populate_checkouts_cache_db(data=updated_checkouts_data)
+
+    out(
+        "Finished checkout cache update task, updated %d checkouts"
+        % len(checkout_ids_for_update)
+    )

--- a/backend/kernelCI_app/tests/unitTests/tasks_test.py
+++ b/backend/kernelCI_app/tests/unitTests/tasks_test.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch, MagicMock
-from datetime import datetime
+from datetime import datetime, timezone
 from kernelCI_app.tasks import (
     _is_checkout_done,
     _is_checkout_unstable,
+    _is_checkout_newer,
     get_checkout_ids_for_update,
     update_checkout_cache,
     UPDATE_INTERVAL_IN_DAYS,
@@ -134,6 +135,88 @@ class TestIsCheckoutUnstable:
             result = _is_checkout_unstable(checkout=mock_checkout)
 
         assert result is True
+
+
+class TestIsCheckoutNewer:
+    def test_cached_start_time_none_returns_false(self):
+        result = _is_checkout_newer(
+            cached_start_time=None,
+            old_checkout_start_time=datetime(2024, 1, 15, 12, 0, 0),
+            old_checkout_id="checkout1",
+        )
+
+        assert result is False
+
+    def test_checkout_start_time_none_returns_false(self):
+        result = _is_checkout_newer(
+            cached_start_time=datetime(2024, 1, 14, 12, 0, 0),
+            old_checkout_start_time=None,
+            old_checkout_id="checkout1",
+        )
+
+        assert result is False
+
+    def test_both_none_returns_false(self):
+        result = _is_checkout_newer(
+            cached_start_time=None,
+            old_checkout_start_time=None,
+            old_checkout_id="checkout1",
+        )
+
+        assert result is False
+
+    def test_newer_checkout_returns_true(self):
+        result = _is_checkout_newer(
+            cached_start_time=datetime(2024, 1, 14, 12, 0, 0),
+            old_checkout_start_time=datetime(2024, 1, 15, 12, 0, 0),
+            old_checkout_id="checkout1",
+        )
+
+        assert result is True
+
+    def test_older_checkout_returns_false(self):
+        result = _is_checkout_newer(
+            cached_start_time=datetime(2024, 1, 15, 12, 0, 0),
+            old_checkout_start_time=datetime(2024, 1, 14, 12, 0, 0),
+            old_checkout_id="checkout1",
+        )
+
+        assert result is False
+
+    def test_equal_start_times_returns_false(self):
+        same_time = datetime(2024, 1, 15, 12, 0, 0)
+
+        result = _is_checkout_newer(
+            cached_start_time=same_time,
+            old_checkout_start_time=same_time,
+            old_checkout_id="checkout1",
+        )
+
+        assert result is False
+
+    def test_already_aware_datetimes_still_compared(self):
+        cached = datetime(2024, 1, 14, 12, 0, 0, tzinfo=timezone.utc)
+        newer = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        result = _is_checkout_newer(
+            cached_start_time=cached,
+            old_checkout_start_time=newer,
+            old_checkout_id="checkout1",
+        )
+
+        assert result is True
+
+    def test_exception_during_make_aware_returns_false(self):
+        with patch(
+            "kernelCI_app.tasks.make_aware", side_effect=Exception("unexpected")
+        ):
+            result = _is_checkout_newer(
+                cached_start_time=datetime(2024, 1, 14, 12, 0, 0),
+                old_checkout_start_time=datetime(2024, 1, 15, 12, 0, 0),
+                old_checkout_id="checkout1",
+            )
+
+        assert result is False
 
 
 class TestGetCheckoutIdsForUpdate:


### PR DESCRIPTION
Fixes cronjob that updates checkout cache with type/empty checking and adds debug logs

## Changes
- Type checks/fixes on the checkout cache task and query used by it
- Added logs for that task since it is used in a cronjob

## How to test
You can add this task somewhere to trigger it manually (like inside a view for example) or you can change the interval that it runs on in the cron job (in settings.py, you can use the interval `*/2 * * * *` for example to run every 2 minutes) and run it locally or within docker.

This might fix the problem that we are running on production, or at least it will give some more insight into where the sqlite file is being searched