### PR TITLE
fix: use single columns on smaller screens

### DIFF
--- a/dashboard/src/components/BuildDetails/BuildDetails.tsx
+++ b/dashboard/src/components/BuildDetails/BuildDetails.tsx
@@ -159,7 +159,7 @@ const BuildDetails = ({
             infos: [
               {
                 children: (
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
                     <DetailsInfoCard
                       cardTitle="buildDetails.buildInfo"
                       data={[

--- a/dashboard/src/components/Section/Section.tsx
+++ b/dashboard/src/components/Section/Section.tsx
@@ -95,9 +95,11 @@ export const Subsection = ({ infos, title }: ISubsection): JSX.Element => {
     <div className="border-dark-gray border-t pt-4">
       {title && <span className="text-xl">{title}</span>}
       {items.length > 0 && (
-        <div className="grid grid-cols-2 gap-x-8 gap-y-11 pb-4">{items}</div>
+        <div className="grid grid-cols-1 gap-x-8 gap-y-11 pb-4 md:grid-cols-2">
+          {items}
+        </div>
       )}
-      {children.length > 0 && <div className="mb-4 w-[80vw]">{children}</div>}
+      {children.length > 0 && <div className="mb-4">{children}</div>}
     </div>
   );
 };

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -338,7 +338,7 @@ const TestDetailsSections = ({
           infos: [
             {
               children: (
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
                   <DetailsInfoCard
                     cardTitle="testDetails.testInfo"
                     data={[


### PR DESCRIPTION
Fixes layout responsiveness for smaller viewpoints by setting the grid size for default, medium and/or large screens

## Changes

- On `BuildDetails` component, I have wrapped the `DetailsInfoCard` with grid classes changing on large views, as I thought it was okay to have only one column on small and medium screens
- On `Subsection` component, I have made it change the grid size on medium screens as sub sets generally represent more granular data

## How to test
- Visit `build/$buildId` page, inspect it and check different viewpoints to look for points of improval
- This page can be reached by checking a hardware details page and then you check on builds details

## Related issue

- Closes #1432