### PR TITLE
fix: too many logs on cronjob

### DIFF
--- a/backend/kernelCI_app/tasks.py
+++ b/backend/kernelCI_app/tasks.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from kernelCI_app.helpers.logger import out, log_message
+from kernelCI_app.helpers.logger import out
 from kernelCI_app.models import Checkouts
 from kernelCI_app.queries.tree import (
     get_tree_listing_data_by_checkout_id,
@@ -9,7 +9,7 @@ from kernelCI_cache.checkouts import populate_checkouts_cache_db
 from kernelCI_cache.constants import NO_CACHE_ORIGINS, UNSTABLE_CHECKOUT_THRESHOLD
 from kernelCI_cache.queries.checkouts import get_cached_tree_listing_fast
 from datetime import timedelta
-from django.utils.timezone import now, make_aware
+from django.utils.timezone import now, make_aware, is_aware
 
 UPDATE_INTERVAL_IN_DAYS = 90
 
@@ -57,28 +57,17 @@ def _is_checkout_newer(
     *,
     cached_start_time,
     old_checkout_start_time,
-    old_checkout_id,
 ) -> bool:
     if cached_start_time is None or old_checkout_start_time is None:
         return False
 
-    try:
+    if not is_aware(cached_start_time):
         cached_start_time = make_aware(cached_start_time)
-        old_checkout_start_time = make_aware(old_checkout_start_time)
-    except ValueError as e:  # datetime is already aware, log but still compare
-        log_message(
-            "Value Error on _is_checkout_newer for %s: %s" % (old_checkout_id, str(e))
-        )
-    except Exception as e:  # other exceptions, don't compare
-        log_message(
-            "Exception on _is_checkout_newer for %s: %s" % (old_checkout_id, str(e))
-        )
-        return False
 
-    if old_checkout_start_time > cached_start_time:
-        return True
-    else:
-        return False
+    if not is_aware(old_checkout_start_time):
+        old_checkout_start_time = make_aware(old_checkout_start_time)
+
+    return old_checkout_start_time > cached_start_time
 
 
 def get_checkout_ids_for_update(
@@ -118,7 +107,6 @@ def get_checkout_ids_for_update(
         if _is_checkout_newer(
             cached_start_time=same_tree_on_sqlite.get("start_time"),
             old_checkout_start_time=checkout.start_time,
-            old_checkout_id=checkout.id,
         ):
             checkout_ids_for_update.add(checkout.id)
 

--- a/backend/kernelCI_app/tests/unitTests/tasks_test.py
+++ b/backend/kernelCI_app/tests/unitTests/tasks_test.py
@@ -142,7 +142,6 @@ class TestIsCheckoutNewer:
         result = _is_checkout_newer(
             cached_start_time=None,
             old_checkout_start_time=datetime(2024, 1, 15, 12, 0, 0),
-            old_checkout_id="checkout1",
         )
 
         assert result is False
@@ -151,7 +150,6 @@ class TestIsCheckoutNewer:
         result = _is_checkout_newer(
             cached_start_time=datetime(2024, 1, 14, 12, 0, 0),
             old_checkout_start_time=None,
-            old_checkout_id="checkout1",
         )
 
         assert result is False
@@ -160,7 +158,6 @@ class TestIsCheckoutNewer:
         result = _is_checkout_newer(
             cached_start_time=None,
             old_checkout_start_time=None,
-            old_checkout_id="checkout1",
         )
 
         assert result is False
@@ -168,8 +165,7 @@ class TestIsCheckoutNewer:
     def test_newer_checkout_returns_true(self):
         result = _is_checkout_newer(
             cached_start_time=datetime(2024, 1, 14, 12, 0, 0),
-            old_checkout_start_time=datetime(2024, 1, 15, 12, 0, 0),
-            old_checkout_id="checkout1",
+            old_checkout_start_time=datetime(2024, 1, 15, 12, 0, 0, 0, timezone.utc),
         )
 
         assert result is True
@@ -177,19 +173,17 @@ class TestIsCheckoutNewer:
     def test_older_checkout_returns_false(self):
         result = _is_checkout_newer(
             cached_start_time=datetime(2024, 1, 15, 12, 0, 0),
-            old_checkout_start_time=datetime(2024, 1, 14, 12, 0, 0),
-            old_checkout_id="checkout1",
+            old_checkout_start_time=datetime(2024, 1, 14, 12, 0, 0, 0, timezone.utc),
         )
 
         assert result is False
 
     def test_equal_start_times_returns_false(self):
-        same_time = datetime(2024, 1, 15, 12, 0, 0)
+        same_time = datetime(2024, 1, 15, 12, 0, 0, 0, timezone.utc)
 
         result = _is_checkout_newer(
             cached_start_time=same_time,
             old_checkout_start_time=same_time,
-            old_checkout_id="checkout1",
         )
 
         assert result is False
@@ -201,22 +195,9 @@ class TestIsCheckoutNewer:
         result = _is_checkout_newer(
             cached_start_time=cached,
             old_checkout_start_time=newer,
-            old_checkout_id="checkout1",
         )
 
         assert result is True
-
-    def test_exception_during_make_aware_returns_false(self):
-        with patch(
-            "kernelCI_app.tasks.make_aware", side_effect=Exception("unexpected")
-        ):
-            result = _is_checkout_newer(
-                cached_start_time=datetime(2024, 1, 14, 12, 0, 0),
-                old_checkout_start_time=datetime(2024, 1, 15, 12, 0, 0),
-                old_checkout_id="checkout1",
-            )
-
-        assert result is False
 
 
 class TestGetCheckoutIdsForUpdate:
@@ -305,7 +286,7 @@ class TestGetCheckoutIdsForUpdate:
         mock_checkout.tree_name = "tree1"
         mock_checkout.git_repository_branch = "branch1"
         mock_checkout.git_repository_url = "url1"
-        mock_checkout.start_time = datetime(2024, 1, 15, 12, 0, 0)
+        mock_checkout.start_time = datetime(2024, 1, 15, 12, 0, 0, 0, timezone.utc)
 
         tree_key = ("tree1", "branch1", "url1")
         sqlite_trees_map = {


### PR DESCRIPTION
Postgres start_time is already timezone-aware, meaning that we don't need to try to make it aware and log the error all the time

## How to test

You can add this task somewhere to trigger it manually (like inside a view for example) or you can change the interval that it runs on in the cron job (in settings.py, you can use the interval */2 * * * * for example to run every 2 minutes) and run the cronjob locally or within docker.

Closes #1806 