### PR TITLE
feat: add env var for db migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ ALLOWED_HOSTS=["backend", "localhost"]
 CORS_ALLOWED_ORIGINS=[]
 DEBUG=False
 SKIP_CRONJOBS=False
+RUN_APP_MIGRATIONS_ON_STARTUP=False
 
 # -----------------------------------------------------------------------------
 # Debug Flags (uncomment to enable)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -145,10 +145,11 @@ the `Publish GHCR Images` workflow is triggered manually.
 The GitHub workflow for production is defined at: [deploy-production](.github/workflows/deploy-production.yaml)
 
 > [!WARNING]
-> It is important to point out that the backend entrypoint in Docker container
-> will run database migrations.
+> By default, backend startup skips app migrations.
+> To run them automatically on startup, set `RUN_APP_MIGRATIONS_ON_STARTUP=true` in the `.env` file.
 > Changes that involve alterations in database schema should be previously communicated
 > via [Discord channel](https://discord.com/channels/1245820301053530313/1301896040349433957).
+
 
 ### Setup
 
@@ -163,6 +164,7 @@ cp .env.example .env
 #    DJANGO_SECRET_KEY → a strong random string
 #    ALLOWED_HOSTS → e.g. ["backend", "your-domain.com"]
 #    CORS_ALLOWED_ORIGINS → e.g. ["https://your-domain.com"]
+#    RUN_APP_MIGRATIONS_ON_STARTUP → true (if you want backend startup to apply app migrations)
 
 # 3. Start services
 docker compose -f docker-compose-next.yml up -d
@@ -208,8 +210,7 @@ significantly impact the database.
 A GitHub workflow for staging is defined at [deploy-staging](.github/workflows/deploy-staging.yaml)
 
 > [!WARNING]
-> Migrations are automatically executed in the backend entrypoint
-> when the docker container is executed.
+> Migrations can be automatically executed by setting `RUN_APP_MIGRATIONS_ON_STARTUP=true` in the `.env` file.
 > And as the staging environment is shared with production, the same precautions should follow.
 > Changes that involve alterations in database schema should be previously communicated
 > via [Discord channel](https://discord.com/channels/1245820301053530313/1301896040349433957).

--- a/backend/utils/docker/backend_entrypoint.sh
+++ b/backend/utils/docker/backend_entrypoint.sh
@@ -57,8 +57,14 @@ chmod +x ./migrate-cache-db.sh
 ./migrate-cache-db.sh
 
 # Update the MAIN db
-chmod +x ./migrate-app-db.sh
-./migrate-app-db.sh
+RUN_APP_MIGRATIONS_ON_STARTUP=$(echo "${RUN_APP_MIGRATIONS_ON_STARTUP:-false}" | tr '[:upper:]' '[:lower:]')
+if [ "$RUN_APP_MIGRATIONS_ON_STARTUP" = "true" ]; then
+  echo "Applying app DB migrations..."
+  chmod +x ./migrate-app-db.sh
+  ./migrate-app-db.sh
+else
+  echo "Skipping app DB migrations at startup (set RUN_APP_MIGRATIONS_ON_STARTUP=true to enable)."
+fi
 
 # Add and start cronjobs in background and emit logs to container stdout.
 poetry run ./manage.py crontab add


### PR DESCRIPTION
Removes the automatic migrations in favor of a more granular environment variable to allow migrations; that variable defaults to false so auto migrations are essentially disabled until set

## How to test
Change the models with something, set the new variable to `false` (or just don't set it) and start the backend through docker (`docker compose up backend --build`); you'll see that the migrations will not be applied. Set the variable to `true` and restart the backend, then the migrations will be applied.

Closes #1818 