### PR TITLE
Fix: searchBox on hardwareV2

### DIFF
--- a/dashboard/src/components/SearchBoxNavigate/SearchBoxNavigate.tsx
+++ b/dashboard/src/components/SearchBoxNavigate/SearchBoxNavigate.tsx
@@ -6,6 +6,8 @@ import { HiSearch } from 'react-icons/hi';
 
 import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { CustomDialog } from '@/components/Dialog/CustomDialog';
+import { treeListingCleanFullPaths } from '@/utils/constants/treeListing';
+import { hwListingCleanFullPaths } from '@/utils/constants/hardwareListing';
 
 // Relates the type of listing to the corresponding search key
 const forwardFields: Record<string, string> = {
@@ -26,11 +28,11 @@ export const SearchBoxNavigate = (): JSX.Element => {
     const lastMatch = matches[matches.length - 1];
     const cleanFullPath = lastMatch?.fullPath.replace(/\//g, '') ?? '';
 
-    if (['tree', 'treev1', 'treev2'].includes(cleanFullPath)) {
+    if (treeListingCleanFullPaths.includes(cleanFullPath)) {
       return 'tree';
     }
 
-    if (['hardware', 'hardwarev1'].includes(cleanFullPath)) {
+    if (hwListingCleanFullPaths.includes(cleanFullPath)) {
       return 'hardware';
     }
 

--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -18,6 +18,8 @@ import { Button } from '@/components/ui/button';
 import MobileSideMenu from '@/components/SideMenu/MobileSideMenu';
 
 import { SearchBoxNavigate } from '@/components/SearchBoxNavigate';
+import { treeListingCleanFullPaths } from '@/utils/constants/treeListing';
+import { hwListingCleanFullPaths } from '@/utils/constants/hardwareListing';
 
 const OriginSelect = ({
   isHardwarePath,
@@ -122,10 +124,10 @@ const TopBar = (): JSX.Element => {
     const lastMatch = matches[matches.length - 1];
     const firstUrlLocation = lastMatch?.pathname.split('/')[1] ?? '';
     const cleanFullPath = lastMatch?.fullPath.replace(/\//g, '') ?? '';
-    const isTreeListing = ['tree', 'treev1', 'treev2'].includes(cleanFullPath);
+    const isTreeListing = treeListingCleanFullPaths.includes(cleanFullPath);
+    const isHardwareListing = hwListingCleanFullPaths.includes(cleanFullPath);
     const isListingPage =
-      isTreeListing ||
-      ['hardware', 'hardwarev1', 'issues'].includes(cleanFullPath);
+      isTreeListing || isHardwareListing || cleanFullPath.includes('issues');
 
     return {
       firstUrlLocation,

--- a/dashboard/src/utils/constants/hardwareListing.ts
+++ b/dashboard/src/utils/constants/hardwareListing.ts
@@ -13,3 +13,5 @@ export type HardwareListingRoutesMap = {
     search: ValidHardwareFroms<'/_main/hardware' | '/_main/hardware/v2'>;
   };
 };
+
+export const hwListingCleanFullPaths = ['hardware', 'hardwarev1', 'hardwarev2'];

--- a/dashboard/src/utils/constants/treeListing.ts
+++ b/dashboard/src/utils/constants/treeListing.ts
@@ -13,3 +13,5 @@ export type TreeListingRoutesMap = {
     search: ValidTreeFroms<'/_main/tree' | '/_main/tree/v2'>;
   };
 };
+
+export const treeListingCleanFullPaths = ['tree', 'treev1', 'treev2'];


### PR DESCRIPTION
Fixes the route matching in order to show the searchbox on the hardwareV2 listing page

## Changes
- Added constants for hardwareListing and treeListing "CleanFullPaths" to be shared between topBar and searchBox
- Included the hardwareV2 route as a valid "listing" path

## How to test
Go to the listing pages (including treeV2 and hardwareV2) and see that the searchBox is present and usable on all of them. The searchbox should not appear on other pages (tree/hardware/issue/build/test Details and logViewer)

Closes #1794