### PR TITLE
fix: Fix unecessary scroll on some SideMenu

### DIFF
--- a/dashboard/src/components/SideMenu/SideMenu.tsx
+++ b/dashboard/src/components/SideMenu/SideMenu.tsx
@@ -4,7 +4,7 @@ import SideMenuContent from './SideMenuContent';
 
 const SideMenu = (): JSX.Element => {
   return (
-    <div className="bg-bg-secondary sticky top-0 hidden h-screen overflow-y-scroll md:block">
+    <div className="bg-bg-secondary sticky top-0 hidden h-screen overflow-y-auto md:block">
       <SideMenuContent className="min-h-screen" />
     </div>
   );


### PR DESCRIPTION
## Description

Avoid showing scrollbar when SideMenu fits the screen.

## How to test

Run locally on a chromium based browser.
Verify that the left side menu does not show a scrollbar.
Reduce the window until the side menu no longer fits, and verify that a scrollbar is shown.

<img width="287" height="688" alt="left-menu-no-scroll" src="https://github.com/user-attachments/assets/80fe4f97-e1f9-4612-8b91-1622701fbda4" />

Closes #1822 