### PR TITLE
fix: Fix Hardware Details Link

### DIFF
--- a/dashboard/src/components/Log/LogViewerCard.tsx
+++ b/dashboard/src/components/Log/LogViewerCard.tsx
@@ -2,7 +2,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useMemo, type JSX } from 'react';
 
-import { Link, useParams, useRouterState } from '@tanstack/react-router';
+import { Link, useRouterState } from '@tanstack/react-router';
 
 import { SearchIcon } from '@/components/Icons/SearchIcon';
 import { StatusIcon } from '@/components/Icons/StatusIcons';
@@ -61,10 +61,10 @@ export const LogViewerCard = ({
     }
   }, [logUrl]);
 
-  const { hardwareId } = useParams({ strict: false });
-  const { treeName, branch, id } = useRouterState({
+  const { treeName, branch, id, from } = useRouterState({
     select: s => s.location.state,
   });
+  const hardwareId = from === 'hardware' ? id : undefined;
 
   const logDataTreeName = logData?.tree_name;
   const logDataBranch = logData?.git_repository_branch;


### PR DESCRIPTION
## Description

Uses the `from` property, instead of directly capturing the hardwareId from url.
This way, any page that uses a proper `id` and indicates that we are coming from a hardware page is going to be interpreted as a hardwareId.

## How to test

1. Open the hardware listing page
2. Click on a hardware to go to Hardware Details page
3. Go to TestDetails or BuildDetails tab
4. On the configs table access the BuildDetails/TestDetails page through the information icon (i).
5. Click on the `View Log Excerpt`.
6. Click on `View full log for` link.
7. The second breadcrumb should show (and link to) HardwareDetails page, and not TreeDetails page.

 Closes #1823 hardwareDetails -> boots tab -> testDetails/bootDetails -> log viewer