### PR TITLE
feat: use logExcerpt from output_files

### DIFF
--- a/backend/kernelCI_app/models.py
+++ b/backend/kernelCI_app/models.py
@@ -109,6 +109,7 @@ class Builds(models.Model):
     architecture = models.TextField(blank=True, null=True)
     command = models.TextField(blank=True, null=True)
     compiler = models.TextField(blank=True, null=True)
+    # input/output files are an array of objects containing file fields such as name and url
     input_files = models.JSONField(blank=True, null=True)
     output_files = models.JSONField(blank=True, null=True)
     config_name = models.TextField(blank=True, null=True)
@@ -170,6 +171,8 @@ class Tests(models.Model):
     )
     start_time = models.DateTimeField(blank=True, null=True)
     duration = models.FloatField(blank=True, null=True)
+    # input/output files are an array of objects containing file fields such as name and url
+    input_files = models.JSONField(blank=True, null=True)
     output_files = models.JSONField(blank=True, null=True)
     misc = models.JSONField(blank=True, null=True)
     number_value = models.FloatField(blank=True, null=True)
@@ -178,7 +181,6 @@ class Tests(models.Model):
         max_length=10, choices=UnitPrefix.choices, blank=True, null=True
     )
     number_unit = models.TextField(blank=True, null=True)
-    input_files = models.JSONField(blank=True, null=True)
 
     class Meta:
         db_table = "tests"

--- a/dashboard/src/hooks/useLogData.test.ts
+++ b/dashboard/src/hooks/useLogData.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { processLogData } from './useLogData';
+
+describe('processLogData', () => {
+  it('maps build fields and defaults status to NULL when missing', () => {
+    const result = processLogData('build-1', {
+      type: 'build',
+      git_commit_name: 'Fix scheduler race',
+      misc: { platform: 'qemu-x86' },
+      output_files: [{ name: 'other_file', url: 'https://example.com/other' }],
+    });
+
+    expect(result).toMatchObject({
+      id: 'build-1',
+      type: 'build',
+      title: 'Fix scheduler race',
+      status: 'NULL',
+      hardware: 'qemu-x86',
+      log_excerpt: undefined,
+    });
+  });
+
+  it('maps test fields and picks first hardware candidate from buildHardwareArray', () => {
+    const result = processLogData('test-1', {
+      type: 'test',
+      path: 'boot/smoke',
+      status: 'PASS',
+      environment_misc: { platform: 'rk3399' },
+      environment_compatible: ['arm64', 'lab-board'],
+    });
+
+    expect(result).toMatchObject({
+      id: 'test-1',
+      type: 'test',
+      title: 'boot/smoke',
+      status: 'PASS',
+      hardware: 'rk3399',
+    });
+  });
+
+  it('extracts log excerpt URL from output_files when present', () => {
+    const result = processLogData('build-2', {
+      type: 'build',
+      status: 'FAIL',
+      output_files: [
+        { name: 'artifact', url: 'https://example.com/artifact' },
+        { name: 'log_excerpt', url: 'https://example.com/log-excerpt' },
+      ],
+    });
+
+    expect(result.log_excerpt).toBe('https://example.com/log-excerpt');
+  });
+});

--- a/dashboard/src/hooks/useLogData.ts
+++ b/dashboard/src/hooks/useLogData.ts
@@ -55,6 +55,10 @@ export const processLogData = (
         ? data.misc.platform
         : undefined;
 
+  const logExcerptFileLink = data?.output_files?.find(
+    file => file && file['name'] === 'log_excerpt',
+  )?.['url'];
+
   return {
     id,
     type: data.type,
@@ -65,7 +69,7 @@ export const processLogData = (
     git_repository_url: data?.git_repository_url,
     architecture: data?.architecture,
     log_url: data?.log_url,
-    log_excerpt: data?.log_excerpt,
+    log_excerpt: data?.log_excerpt || logExcerptFileLink,
     status: handledStatus,
     hardware: handledHardware,
   };

--- a/dashboard/src/types/database.ts
+++ b/dashboard/src/types/database.ts
@@ -3,3 +3,9 @@ import type { status } from '@/utils/constants/database';
 export type Status = (typeof status)[number];
 
 export type InconclusiveStatus = Exclude<Status, 'PASS' | 'FAIL'>;
+
+// Follows kcidb schema: https://github.com/kernelci/kcidb-io/blob/8971c0269a80307ec6270ff8c78ff3816fc639f6/kcidb_io/schema/v05_03.py#L62
+export type Resource = {
+  name: string;
+  url: string;
+};

--- a/dashboard/src/types/tree/BuildDetails.tsx
+++ b/dashboard/src/types/tree/BuildDetails.tsx
@@ -1,4 +1,4 @@
-import type { Status } from '@/types/database';
+import type { Resource, Status } from '@/types/database';
 
 export type TBuildDetails = {
   timestamp: string;
@@ -24,6 +24,6 @@ export type TBuildDetails = {
   build_origin: string;
   log_excerpt?: string;
   misc?: Record<string, unknown>;
-  input_files?: Record<string, unknown>;
-  output_files?: Record<string, unknown>;
+  input_files?: Resource[];
+  output_files?: Resource[];
 };

--- a/dashboard/src/types/tree/TestDetails.tsx
+++ b/dashboard/src/types/tree/TestDetails.tsx
@@ -1,4 +1,4 @@
-import type { Status } from '@/types/database';
+import type { Resource, Status } from '@/types/database';
 
 export type TTestDetails = {
   architecture?: string;
@@ -18,8 +18,8 @@ export type TTestDetails = {
   environment_compatible?: string[];
   environment_misc?: Record<string, unknown>;
   misc?: Record<string, unknown>;
-  input_files?: Record<string, unknown>;
-  output_files?: Record<string, unknown>;
+  input_files?: Resource[];
+  output_files?: Resource[];
   tree_name?: string;
   origin?: string;
   field_timestamp: string;


### PR DESCRIPTION
## Description

Builds and tests have a "log" (aka full log) which can be really large, and a "logExcerpt" which is at most 16k characters long [by schema definition](https://github.com/kernelci/kcidb-io/blob/8971c0269a80307ec6270ff8c78ff3816fc639f6/kcidb_io/schema/v05_03.py#L538). However - in order to avoid even those 16k characters for every build and test - whenever the log_excerpt is >256 chars long it is uploaded to an external storage [by ingester definition](https://github.com/kernelci/dashboard/blob/f7b8318b21947dbcebe246c2d472a81390facf56/backend/kernelCI_app/management/commands/helpers/log_excerpt_utils.py#L117).

When the log_excerpt is uploaded to an external storage it is set to an empty string and the url that references it is appended to the output_files. The problem is that we are currently not using that url from the output_files, which means that most builds/tests are showing as having an empty log_excerpt.

This PR addresses this problem by using the url from output_files to fetch the log_excerpt and show it on the logSheet as it should be.

## Changes
- Corrected return type of build and test details on frontend
- Added a fallback for the logExcerpt, using the value stored in the `output_files` field of the buildDetails / testDetails response

> [!NOTE]
> This might look like "new" requests are being made for the log_excerpt url, but this was already expected and there are existing security guardrails defined in `dashboard/src/api/logViewer.ts > isAllowedUrl()`.

## How to test
Go to a treeDetails / hardwareDetails page and click on an individual item at the bottom table of any tab. They should show the log_excerpt correctly (if they have it in `output_files`, some items just don't have any log_excerpt). This also applies to buildDetails / testDetails pages

Example:
Localhost build - http://localhost:5173/build/maestro%3A69c186046d1f8ea2ad9f5fd1?l=true
Staging build - https://staging.dashboard.kernelci.org/build/maestro%3A69c186046d1f8ea2ad9f5fd1?l=true

Closes #1828 