### PR TITLE
feat: use tree_tests_rollup for tree details summary

### DIFF
--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -390,7 +390,7 @@ def process_test_summary(instance, row_data):
         instance.testStatusSummary.get(test_status, 0) + 1
     )
 
-    arch_key = "%s-%s" % (build_arch, build_compiler)
+    arch_key = (build_arch, build_compiler)
     arch_summary = instance.test_arch_summary.get(
         arch_key,
         {"arch": build_arch, "compiler": build_compiler, "status": {}},
@@ -442,7 +442,7 @@ def process_boots_summary(instance, row_data: dict[str, Any]) -> None:
         instance.bootStatusSummary.get(test_status, 0) + 1
     )
 
-    arch_key = "%s-%s" % (build_arch, build_compiler)
+    arch_key = (build_arch, build_compiler)
     arch_summary = instance.bootArchSummary.get(
         arch_key,
         {"arch": build_arch, "compiler": build_compiler, "status": {}},

--- a/backend/kernelCI_app/helpers/treeDetailsRollup.py
+++ b/backend/kernelCI_app/helpers/treeDetailsRollup.py
@@ -1,0 +1,326 @@
+from kernelCI_app.constants.process_pending import ROLLUP_STATUS_FIELDS
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING, UNKNOWN_STRING
+from kernelCI_app.helpers.commonDetails import PossibleTabs, add_unfiltered_issue
+from kernelCI_app.helpers.filters import (
+    is_status_failure,
+    should_filter_test_issue,
+    should_increment_build_issue,
+    should_increment_test_issue,
+)
+from kernelCI_app.helpers.misc import handle_misc
+from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.databases import (
+    FAIL_STATUS,
+    NULL_STATUS,
+    build_fail_status_list,
+    failure_status_list,
+)
+from kernelCI_app.typeModels.issues import Issue, IssueDict
+from kernelCI_app.utils import create_issue_typed
+
+ROLLUP_TEST_ID = "rollup_test"
+
+
+def normalize_build_dict(row_dict: dict) -> dict:
+    """Normalize a dict row from get_tree_details_builds into the shape
+    expected by existing build-processing helpers."""
+    row_dict["build_misc"] = handle_misc(row_dict.get("build_misc"))
+
+    defaults = {
+        "build_status": NULL_STATUS,
+        "build_architecture": UNKNOWN_STRING,
+        "build_compiler": UNKNOWN_STRING,
+        "build_config_name": UNKNOWN_STRING,
+    }
+    for key, default in defaults.items():
+        row_dict.setdefault(key, default)
+
+    if row_dict.get("issue_id") is None and is_status_failure(
+        row_dict["build_status"], build_fail_status_list
+    ):
+        row_dict["issue_id"] = UNCATEGORIZED_STRING
+
+    return row_dict
+
+
+def process_build_filters(instance, row_data: dict) -> None:
+    """Populate global filter sets and unfiltered build issues from a build row."""
+    build_status = row_data["build_status"]
+    issue_id = row_data.get("issue_id")
+    issue_version = row_data.get("issue_version")
+    incident_test_id = row_data.get("incident_test_id")
+
+    instance.global_configs.add(row_data["build_config_name"])
+    instance.global_architectures.add(row_data["build_architecture"])
+    instance.global_compilers.add(row_data["build_compiler"])
+    instance.unfiltered_origins["build"].add(row_data["build_origin"])
+
+    if (build_misc := row_data["build_misc"]) is not None:
+        instance.unfiltered_labs["build"].add(build_misc.get("lab", UNKNOWN_STRING))
+
+    build_issue_id, build_issue_version, is_build_issue = should_increment_build_issue(
+        issue_id=issue_id,
+        issue_version=issue_version,
+        incident_test_id=incident_test_id,
+        build_status=build_status,
+    )
+
+    add_unfiltered_issue(
+        issue_id=build_issue_id,
+        issue_version=build_issue_version,
+        should_increment=is_build_issue,
+        issue_set=instance.unfiltered_build_issues,
+        unknown_issue_flag_dict=instance.unfiltered_uncategorized_issue_flags,
+        unknown_issue_flag_tab="build",
+        is_failed_task=build_status == FAIL_STATUS,
+    )
+
+
+def process_rollup_filters(instance, row_dict: dict) -> None:
+    """Populate unfiltered issue/origin/lab sets from a rollup row."""
+    issue_id = row_dict.get("issue_id")
+    issue_version = row_dict.get("issue_version")
+    is_boot_row = row_dict["is_boot"]
+
+    incident_test_id = ROLLUP_TEST_ID if issue_id is not None else None
+
+    test_issue_id, test_issue_version, is_test_issue = should_increment_test_issue(
+        issue_id=issue_id,
+        issue_version=issue_version,
+        incident_test_id=incident_test_id,
+    )
+
+    if is_boot_row:
+        issue_set = instance.unfiltered_boot_issues
+        origin_set = instance.unfiltered_origins["boot"]
+        lab_set = instance.unfiltered_labs["boot"]
+        flag_tab: PossibleTabs = "boot"
+    else:
+        issue_set = instance.unfiltered_test_issues
+        origin_set = instance.unfiltered_origins["test"]
+        lab_set = instance.unfiltered_labs["test"]
+        flag_tab: PossibleTabs = "test"
+
+    has_failures = row_dict.get("issue_uncategorized", False)
+    add_unfiltered_issue(
+        issue_id=test_issue_id,
+        issue_version=test_issue_version,
+        should_increment=is_test_issue,
+        issue_set=issue_set,
+        is_failed_task=has_failures,
+        unknown_issue_flag_dict=instance.unfiltered_uncategorized_issue_flags,
+        unknown_issue_flag_tab=flag_tab,
+    )
+
+    test_origin = row_dict.get("test_origin", UNKNOWN_STRING) or UNKNOWN_STRING
+    test_lab = row_dict.get("test_lab", UNKNOWN_STRING) or UNKNOWN_STRING
+    origin_set.add(test_origin)
+    lab_set.add(test_lab)
+
+
+def rollup_test_or_boot_filtered_out(
+    instance,
+    *,
+    row_dict: dict,
+    is_boot_row: bool,
+) -> bool:
+    """Check if a rollup row is filtered by test/boot filters."""
+    issue_id = row_dict.get("issue_id")
+    issue_version = row_dict.get("issue_version")
+
+    if issue_id is None and row_dict.get("issue_uncategorized", False):
+        issue_id = UNCATEGORIZED_STRING
+
+    incident_test_id = ROLLUP_TEST_ID if issue_id is not None else None
+    path_group = row_dict.get("path_group", UNKNOWN_STRING)
+    test_origin = row_dict.get("test_origin")
+    test_platform = row_dict.get("test_platform")
+
+    if is_boot_row:
+        path_filter = instance.filters.filterBootPath
+        issue_filters = instance.filters.filterIssues["boot"]
+        platform_filters = instance.filters.filterPlatforms["boot"]
+        origin_filters = instance.filters.filter_boot_origin
+    else:
+        path_filter = instance.filters.filterTestPath
+        issue_filters = instance.filters.filterIssues["test"]
+        platform_filters = instance.filters.filterPlatforms["test"]
+        origin_filters = instance.filters.filter_test_origin
+
+    if path_filter != "" and path_filter not in path_group:
+        return True
+
+    if should_filter_test_issue(
+        issue_filters=issue_filters,
+        issue_id=issue_id,
+        issue_version=issue_version,
+        incident_test_id=incident_test_id,
+    ):
+        return True
+
+    if platform_filters and test_platform not in platform_filters:
+        return True
+
+    if origin_filters and test_origin not in origin_filters:
+        return True
+
+    return False
+
+
+def _get_rollup_status_filter(instance, *, is_boot_row: bool) -> set[str]:
+    """Return the active status filter set for boots or tests."""
+    if is_boot_row:
+        return set(instance.filters.filterBootStatus)
+    return set(instance.filters.filterTestStatus)
+
+
+def process_rollup_summary(instance, *, row_dict: dict, is_boot_row: bool) -> None:
+    """Accumulate pre-aggregated test/boot counts from a rollup row into
+    the instance's summary accumulators."""
+    build_config = row_dict["build_config_name"]
+    build_arch = row_dict["build_architecture"]
+    build_compiler = row_dict["build_compiler"]
+    hardware_key = row_dict["hardware_key"]
+    test_platform = row_dict.get("test_platform")
+    test_origin = row_dict.get("test_origin", UNKNOWN_STRING)
+    test_lab = row_dict.get("test_lab", UNKNOWN_STRING) or UNKNOWN_STRING
+
+    status_filter = _get_rollup_status_filter(instance, is_boot_row=is_boot_row)
+
+    # Skip row entirely if status filter excludes all its statuses
+    if status_filter:
+        has_matching_status = any(
+            row_dict.get(field_name, 0) > 0 and status_name in status_filter
+            for status_name, field_name in ROLLUP_STATUS_FIELDS.items()
+        )
+        if not has_matching_status:
+            return
+
+    if is_boot_row:
+        status_summary = instance.bootStatusSummary
+        arch_summary_map = instance.bootArchSummary
+        config_map = instance.bootConfigs
+        platforms_failing = instance.bootPlatformsFailing
+        env_compatible = instance.bootEnvironmentCompatible
+        env_misc = instance.bootEnvironmentMisc
+        origin_summary = instance.boot_summary["origins"]
+        typed_summary = instance.boot_summary_typed
+    else:
+        status_summary = instance.testStatusSummary
+        arch_summary_map = instance.test_arch_summary
+        config_map = instance.test_configs
+        platforms_failing = instance.testPlatformsWithErrors
+        env_compatible = instance.testEnvironmentCompatible
+        env_misc = instance.testEnvironmentMisc
+        origin_summary = instance.test_summary["origins"]
+        typed_summary = instance.test_summary_typed
+
+    arch_key = (build_arch, build_compiler)
+    arch_entry = arch_summary_map.setdefault(
+        arch_key,
+        {"arch": build_arch, "compiler": build_compiler, "status": {}},
+    )
+    config_entry = config_map.setdefault(build_config, {})
+
+    is_env_compatible = hardware_key not in (UNKNOWN_STRING, test_platform)
+
+    for status_name, field_name in ROLLUP_STATUS_FIELDS.items():
+        count = row_dict.get(field_name, 0)
+        if count <= 0:
+            continue
+        if status_filter and status_name not in status_filter:
+            continue
+
+        status_summary[status_name] = status_summary.get(status_name, 0) + count
+        arch_entry["status"][status_name] = (
+            arch_entry["status"].get(status_name, 0) + count
+        )
+        config_entry[status_name] = config_entry.get(status_name, 0) + count
+
+        if is_env_compatible:
+            env_compatible[hardware_key][status_name] += count
+        else:
+            env_misc[test_platform][status_name] += count
+
+        origin_entry = origin_summary.setdefault(test_origin, StatusCount())
+        setattr(
+            origin_entry,
+            status_name,
+            getattr(origin_entry, status_name) + count,
+        )
+
+        lab_entry = typed_summary.labs.setdefault(test_lab, StatusCount())
+        setattr(lab_entry, status_name, getattr(lab_entry, status_name) + count)
+
+        if is_status_failure(status_name):
+            platforms_failing.add(test_platform)
+
+
+def _ensure_issue_in_table(
+    *,
+    instance,
+    issue_id: str,
+    issue_version: int,
+    issue_comment: str | None,
+    issue_report_url: str | None,
+    is_boot_row: bool,
+) -> Issue:
+    if is_boot_row:
+        table: IssueDict = instance.boot_issues_dict
+    else:
+        table: IssueDict = instance.test_issues_dict
+
+    issue: Issue | None = table.get((issue_id, issue_version))
+    if issue is None:
+        issue = create_issue_typed(
+            issue_id=issue_id,
+            issue_version=issue_version,
+            issue_comment=issue_comment,
+            issue_report_url=issue_report_url,
+            starting_count_status=None,
+            autoincrement=False,
+        )
+        table[(issue_id, issue_version)] = issue
+    return issue
+
+
+def process_rollup_issues(instance, *, row_dict: dict, is_boot_row: bool) -> None:
+    """Accumulate issue information from a rollup row."""
+    issue_id = row_dict.get("issue_id")
+    issue_version = row_dict.get("issue_version")
+    issue_comment = row_dict.get("issue_comment")
+    issue_report_url = row_dict.get("issue_report_url")
+
+    incident_test_id = ROLLUP_TEST_ID if issue_id is not None else None
+
+    test_issue_id, test_issue_version, can_insert_issue = should_increment_test_issue(
+        issue_id=issue_id,
+        issue_version=issue_version,
+        incident_test_id=incident_test_id,
+    )
+
+    failure_counts = [
+        (status, row_dict.get(ROLLUP_STATUS_FIELDS[status], 0))
+        for status in failure_status_list
+    ]
+
+    if test_issue_id and test_issue_version is not None and can_insert_issue:
+        current_issue = _ensure_issue_in_table(
+            instance=instance,
+            issue_id=test_issue_id,
+            issue_version=test_issue_version,
+            issue_comment=issue_comment,
+            issue_report_url=issue_report_url,
+            is_boot_row=is_boot_row,
+        )
+
+        for status, count in failure_counts:
+            current_issue.incidents_info.increment(status, count)
+    elif row_dict.get("issue_uncategorized", False):
+        status_filter = _get_rollup_status_filter(instance, is_boot_row=is_boot_row)
+        if not status_filter or "FAIL" in status_filter:
+            fail_count = row_dict.get("fail_tests", 0)
+            if is_boot_row:
+                instance.failed_boots_with_unknown_issues += fail_count
+            else:
+                instance.failed_tests_with_unknown_issues += fail_count

--- a/backend/kernelCI_app/management/commands/seed_test_data.py
+++ b/backend/kernelCI_app/management/commands/seed_test_data.py
@@ -3,6 +3,11 @@ Management command to seed test database with realistic data.
 """
 
 import sys
+from kernelCI_app.constants.general import UNKNOWN_STRING
+from kernelCI_app.management.commands.helpers.process_pending_helpers import (
+    accumulate_rollup_entry,
+    extract_path_group,
+)
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from kernelCI_app.tests.factories import (
@@ -18,6 +23,8 @@ from kernelCI_app.models import (
     Builds,
     Checkouts,
     Incidents,
+    TreeTestsRollup,
+    StatusChoices,
 )
 from kernelCI_app.tests.factories.mocks import Build, Issue, Test
 from kernelCI_app.helpers.system import get_running_instance
@@ -64,6 +71,7 @@ class Command(BaseCommand):
             tests = self.create_tests_and_boots(builds=builds)
             issues = self.create_issues(count=options["issues"])
             incidents = self.create_incidents(issues=issues, builds=builds, tests=tests)
+            rollup_rows = self.create_tests_rollup(tests=tests, incidents=incidents)
 
         self.stdout.write(
             self.style.SUCCESS(
@@ -73,6 +81,7 @@ class Command(BaseCommand):
                 f"- {len(tests)} tests\n"
                 f"- {len(issues)} issues\n"
                 f"- {len(incidents)} incidents\n"
+                f"- {len(rollup_rows)} tree_tests_rollup rows\n"
             )
         )
 
@@ -101,6 +110,7 @@ class Command(BaseCommand):
 
     def clear_data(self) -> None:
         """Clear existing test data."""
+        TreeTestsRollup.objects.all().delete()
         Incidents.objects.all().delete()
         Issues.objects.all().delete()
         Tests.objects.all().delete()
@@ -226,3 +236,100 @@ class Command(BaseCommand):
                         incidents.append(incident)
 
         return incidents
+
+    def create_tests_rollup(
+        self, *, tests: list[Tests], incidents: list[Incidents]
+    ) -> list[TreeTestsRollup]:
+        """Aggregate seeded tests into tree_tests_rollup rows."""
+        self.stdout.write("Creating tree_tests_rollup aggregations...")
+
+        test_issue_map: dict[str, dict] = {}
+        for incident in incidents:
+            if incident.test_id:
+                test_issue_map.setdefault(
+                    incident.test_id,
+                    {
+                        "issue_id": incident.issue_id,
+                        "issue_version": incident.issue_version,
+                    },
+                )
+
+        rollup_data: dict[tuple, dict] = {}
+
+        for test in tests:
+            checkout = test.build.checkout
+            path = test.path or ""
+            path_group = extract_path_group(path)
+
+            compatible = test.environment_compatible
+            try:
+                platform = test.environment_misc.get("platform")
+            except AttributeError:
+                platform = None
+
+            hardware_key = UNKNOWN_STRING
+            if compatible:
+                hardware_key = compatible[0]
+            elif platform:
+                hardware_key = platform
+
+            issue_info = test_issue_map.get(test.id, {})
+            issue_id = issue_info.get("issue_id")
+            issue_version = issue_info.get("issue_version")
+            issue_uncategorized = issue_id is None and test.status == StatusChoices.FAIL
+
+            arch = test.build.architecture or UNKNOWN_STRING
+            compiler = (
+                test.build.compiler[0]
+                if isinstance(test.build.compiler, list) and test.build.compiler
+                else test.build.compiler or UNKNOWN_STRING
+            )
+            config = test.build.config_name or UNKNOWN_STRING
+            is_boot = bool(path) and path.startswith("boot")
+
+            accumulate_rollup_entry(
+                rollup_data,
+                {
+                    "checkout": checkout,
+                    "path_group": path_group,
+                    "config": config,
+                    "arch": arch,
+                    "compiler": compiler,
+                    "hardware_key": hardware_key,
+                    "platform": platform,
+                    "lab": None,
+                    "origin": test.origin,
+                    "issue_id": issue_id,
+                    "issue_version": issue_version,
+                    "issue_uncategorized": issue_uncategorized,
+                    "is_boot": is_boot,
+                    "status": test.status,
+                },
+            )
+
+        rollup_objects = [
+            TreeTestsRollup(
+                origin=key.origin,
+                tree_name=key.tree_name,
+                git_repository_branch=key.git_repository_branch,
+                git_repository_url=key.git_repository_url,
+                git_commit_hash=key.git_commit_hash,
+                path_group=key.path_group,
+                build_config_name=key.config,
+                build_architecture=key.arch,
+                build_compiler=key.compiler,
+                hardware_key=key.hardware_key,
+                test_platform=key.platform,
+                test_lab=key.lab,
+                test_origin=key.test_origin,
+                issue_id=key.issue_id,
+                issue_version=key.issue_version,
+                issue_uncategorized=key.issue_uncategorized,
+                is_boot=key.is_boot,
+                **counts,
+            )
+            for key, counts in rollup_data.items()
+        ]
+
+        created = TreeTestsRollup.objects.bulk_create(rollup_objects)
+        return created

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -468,6 +468,117 @@ def get_tree_details_data(
     return rows
 
 
+def get_tree_details_rollup(
+    *,
+    origin_param: str,
+    git_url_param: Optional[str],
+    git_branch_param: Optional[str],
+    commit_hash: Optional[str],
+    tree_name: Optional[str] = None,
+) -> Optional[list[dict]]:
+    """
+    Fetch denormalized test/boot rollup data for a given tree commit.
+
+    Returns aggregated data from tree_tests_rollup table which pre-aggregates
+    test results by various dimensions (path_group, config, arch, compiler,
+    hardware, platform, lab, origin, and issue).
+    """
+    cache_key = "treeDetailsRollup"
+
+    params = {
+        "commit_hash": commit_hash,
+        "tree_name": tree_name,
+        "origin_param": origin_param,
+        "git_url_param": git_url_param,
+        "git_branch_param": git_branch_param,
+    }
+
+    rows = get_query_cache(cache_key, params)
+    if rows is None:
+        checkout_clauses = create_checkouts_where_clauses(
+            git_url=git_url_param,
+            git_branch=git_branch_param,
+            tree_name=tree_name,
+        )
+
+        git_branch_clause = checkout_clauses.get("git_branch_clause")
+        tree_name_clause = checkout_clauses.get("tree_name_clause")
+        git_url_clause = checkout_clauses.get("git_url_clause")
+        tree_name_full_clause = "AND " + tree_name_clause if tree_name_clause else ""
+        git_url_full_clause = "AND " + git_url_clause if git_url_clause else ""
+
+        query = f"""
+        WITH RELEVANT_CHECKOUTS AS (
+            SELECT
+                c.git_commit_hash,
+                c.tree_name,
+                c.git_repository_branch,
+                c.git_repository_url,
+                c.origin
+            FROM
+                checkouts c
+            WHERE
+                (c.git_commit_hash = %(commit_hash)s
+                OR %(commit_hash)s = ANY (c.git_commit_tags))
+                {git_url_full_clause}
+                {tree_name_full_clause}
+                AND {git_branch_clause}
+                AND c.origin = %(origin_param)s
+            ORDER BY
+                c._timestamp DESC
+            LIMIT 1
+        )
+        SELECT
+            tr.origin,
+            tr.tree_name,
+            tr.git_repository_branch,
+            tr.git_repository_url,
+            tr.git_commit_hash,
+            tr.path_group,
+            tr.build_config_name,
+            tr.build_architecture,
+            tr.build_compiler,
+            tr.hardware_key,
+            tr.test_platform,
+            tr.test_lab,
+            tr.test_origin,
+            tr.issue_id,
+            tr.issue_version,
+            tr.issue_uncategorized,
+            tr.is_boot,
+            tr.pass_tests,
+            tr.fail_tests,
+            tr.skip_tests,
+            tr.error_tests,
+            tr.miss_tests,
+            tr.done_tests,
+            tr.null_tests,
+            tr.total_tests,
+            i.comment AS issue_comment,
+            i.report_url AS issue_report_url
+        FROM
+            tree_tests_rollup tr
+        INNER JOIN RELEVANT_CHECKOUTS rc ON (
+            tr.git_commit_hash = rc.git_commit_hash
+            AND tr.origin = rc.origin
+            AND tr.tree_name IS NOT DISTINCT FROM rc.tree_name
+            AND tr.git_repository_branch IS NOT DISTINCT FROM rc.git_repository_branch
+            AND tr.git_repository_url IS NOT DISTINCT FROM rc.git_repository_url
+        )
+        LEFT JOIN issues i
+            ON tr.issue_id = i.id AND tr.issue_version = i.version
+        ORDER BY
+            tr.total_tests DESC
+        """
+
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            rows = dict_fetchall(cursor=cursor)
+            set_query_cache(key=cache_key, params=params, rows=rows)
+
+    return rows
+
+
 def get_tree_data(
     *,
     data_type: Literal["builds", "boots", "tests"],
@@ -631,6 +742,108 @@ def get_tree_data(
         with connection.cursor() as cursor:
             cursor.execute(query, params)
             rows = cursor.fetchall()
+            set_query_cache(key=cache_key, params=params, rows=rows)
+
+    return rows
+
+
+def get_tree_details_builds(
+    *,
+    origin_param: str,
+    git_url_param: Optional[str],
+    git_branch_param: Optional[str],
+    commit_hash: Optional[str],
+    tree_name: Optional[str] = None,
+) -> Optional[list[dict]]:
+    """
+    Fetch builds for a given tree commit.
+    """
+    cache_key = "treeDetailsBuilds"
+
+    params = {
+        "commit_hash": commit_hash,
+        "tree_name": tree_name,
+        "origin_param": origin_param,
+        "git_url_param": git_url_param,
+        "git_branch_param": git_branch_param,
+    }
+
+    rows = get_query_cache(cache_key, params)
+    if rows is None:
+        checkout_clauses = create_checkouts_where_clauses(
+            git_url=git_url_param,
+            git_branch=git_branch_param,
+            tree_name=tree_name,
+        )
+
+        git_branch_clause = checkout_clauses.get("git_branch_clause")
+        tree_name_clause = checkout_clauses.get("tree_name_clause")
+        git_url_clause = checkout_clauses.get("git_url_clause")
+        tree_name_full_clause = "AND " + tree_name_clause if tree_name_clause else ""
+        git_url_full_clause = "AND " + git_url_clause if git_url_clause else ""
+
+        query = f"""
+        WITH RELEVANT_CHECKOUTS AS (
+            SELECT
+                c.id AS checkout_id,
+                c.git_repository_url,
+                c.git_repository_branch,
+                c.git_commit_tags,
+                c.origin
+            FROM
+                checkouts c
+            WHERE
+                (c.git_commit_hash = %(commit_hash)s
+                OR %(commit_hash)s = ANY (c.git_commit_tags))
+                {git_url_full_clause}
+                {tree_name_full_clause}
+                AND {git_branch_clause}
+                AND c.origin = %(origin_param)s
+            ORDER BY
+                c._timestamp DESC
+            LIMIT 1
+        )
+        SELECT
+            b.id AS build_id,
+            b.origin AS build_origin,
+            b.comment AS build_comment,
+            b.start_time AS build_start_time,
+            b.duration AS build_duration,
+            b.architecture AS build_architecture,
+            b.command AS build_command,
+            b.compiler AS build_compiler,
+            b.config_name AS build_config_name,
+            b.config_url AS build_config_url,
+            b.log_url AS build_log_url,
+            b.status AS build_status,
+            b.misc AS build_misc,
+            rc.checkout_id,
+            rc.git_repository_url AS checkout_git_repository_url,
+            rc.git_repository_branch AS checkout_git_repository_branch,
+            rc.git_commit_tags AS checkout_git_commit_tags,
+            rc.origin AS checkout_origin,
+            inc.id AS incident_id,
+            inc.test_id AS incident_test_id,
+            inc.present AS incident_present,
+            iss.id AS issue_id,
+            iss.version AS issue_version,
+            iss.comment AS issue_comment,
+            iss.report_url AS issue_report_url
+        FROM
+            builds b
+        INNER JOIN RELEVANT_CHECKOUTS rc ON b.checkout_id = rc.checkout_id
+        LEFT JOIN incidents inc
+            ON inc.build_id = b.id AND inc.test_id IS NULL
+        LEFT JOIN issues iss
+            ON inc.issue_id = iss.id AND inc.issue_version = iss.version
+        ORDER BY
+            iss."_timestamp" DESC NULLS LAST,
+            b.start_time DESC
+        """
+
+        with connection.cursor() as cursor:
+            cursor.execute(query, params)
+            rows = dict_fetchall(cursor=cursor)
             set_query_cache(key=cache_key, params=params, rows=rows)
 
     return rows

--- a/backend/kernelCI_app/tests/factories/__init__.py
+++ b/backend/kernelCI_app/tests/factories/__init__.py
@@ -7,6 +7,7 @@ from .build_factory import BuildFactory
 from .test_factory import TestFactory
 from .issue_factory import IssueFactory
 from .incident_factory import IncidentFactory
+from .tree_tests_rollup_factory import TreeTestsRollupFactory
 
 from .mocks import Checkout, Build, Test, Issue
 
@@ -16,6 +17,7 @@ __all__ = [
     "TestFactory",
     "IssueFactory",
     "IncidentFactory",
+    "TreeTestsRollupFactory",
     "Checkout",
     "Build",
     "Test",

--- a/backend/kernelCI_app/tests/factories/tree_tests_rollup_factory.py
+++ b/backend/kernelCI_app/tests/factories/tree_tests_rollup_factory.py
@@ -1,0 +1,55 @@
+"""
+Factory for generating TreeTestsRollup test data.
+"""
+
+import factory
+from factory.django import DjangoModelFactory
+from kernelCI_app.models import TreeTestsRollup
+
+
+class TreeTestsRollupFactory(DjangoModelFactory):
+    """Factory for creating TreeTestsRollup instances with realistic test data."""
+
+    class Meta:
+        model = TreeTestsRollup
+
+    origin = factory.Faker("word")
+    tree_name = factory.Faker("word")
+    git_repository_branch = factory.Faker("word")
+    git_repository_url = factory.Faker("url")
+    git_commit_hash = factory.Faker("sha1")
+
+    path_group = factory.Faker("word")
+    build_config_name = "defconfig"
+    build_architecture = "x86_64"
+    build_compiler = "gcc-12"
+    hardware_key = factory.Faker("word")
+
+    test_platform = None
+    test_lab = None
+    test_origin = None
+
+    issue_id = None
+    issue_version = None
+    issue_uncategorized = False
+
+    is_boot = False
+
+    pass_tests = 0
+    fail_tests = 0
+    skip_tests = 0
+    error_tests = 0
+    miss_tests = 0
+    done_tests = 0
+    null_tests = 0
+    total_tests = factory.LazyAttribute(
+        lambda obj: (
+            obj.pass_tests
+            + obj.fail_tests
+            + obj.skip_tests
+            + obj.error_tests
+            + obj.miss_tests
+            + obj.done_tests
+            + obj.null_tests
+        )
+    )

--- a/backend/kernelCI_app/tests/unitTests/helpers/treeDetailsRollup_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/treeDetailsRollup_test.py
@@ -1,0 +1,467 @@
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING, UNKNOWN_STRING
+from kernelCI_app.helpers.hardwareDetails import generate_test_summary_typed
+from kernelCI_app.helpers.treeDetailsRollup import (
+    ROLLUP_TEST_ID,
+    normalize_build_dict,
+    process_build_filters,
+    process_rollup_filters,
+    process_rollup_issues,
+    process_rollup_summary,
+    rollup_test_or_boot_filtered_out,
+)
+from kernelCI_app.typeModels.databases import FAIL_STATUS, NULL_STATUS
+
+
+def _base_rollup_row(**overrides):
+    row = {
+        "build_config_name": "defconfig",
+        "build_architecture": "arm64",
+        "build_compiler": "gcc",
+        "hardware_key": "hw-1",
+        "test_platform": "qemu",
+        "test_origin": "origin-a",
+        "test_lab": "lab-1",
+        "path_group": "group.a",
+        "issue_id": None,
+        "issue_version": None,
+        "issue_uncategorized": False,
+        "pass_tests": 0,
+        "fail_tests": 0,
+        "skip_tests": 0,
+        "error_tests": 0,
+        "miss_tests": 0,
+        "done_tests": 0,
+        "null_tests": 0,
+    }
+    row.update(overrides)
+    return row
+
+
+class FakeRollupTreeInstance:
+    """Minimal stand-in for tree details views used by rollup helpers."""
+
+    def __init__(self):
+        self.filters = MagicMock()
+        self.filters.filterBootPath = ""
+        self.filters.filterTestPath = ""
+        self.filters.filterIssues = {"boot": set(), "test": set()}
+        self.filters.filterPlatforms = {"boot": set(), "test": set()}
+        self.filters.filter_boot_origin = set()
+        self.filters.filter_test_origin = set()
+        self.filters.filterBootStatus = []
+        self.filters.filterTestStatus = []
+
+        self.bootStatusSummary = {}
+        self.testStatusSummary = {}
+        self.bootArchSummary = {}
+        self.test_arch_summary = {}
+        self.bootConfigs = {}
+        self.test_configs = {}
+        self.bootPlatformsFailing = set()
+        self.testPlatformsWithErrors = set()
+        self.bootEnvironmentCompatible = defaultdict(lambda: defaultdict(int))
+        self.testEnvironmentCompatible = defaultdict(lambda: defaultdict(int))
+        self.bootEnvironmentMisc = defaultdict(lambda: defaultdict(int))
+        self.testEnvironmentMisc = defaultdict(lambda: defaultdict(int))
+        self.boot_summary = {"origins": {}}
+        self.test_summary = {"origins": {}}
+        self.boot_summary_typed = generate_test_summary_typed()
+        self.test_summary_typed = generate_test_summary_typed()
+
+        self.global_configs = set()
+        self.global_architectures = set()
+        self.global_compilers = set()
+        self.unfiltered_origins = {"build": set(), "boot": set(), "test": set()}
+        self.unfiltered_labs = {"build": set(), "boot": set(), "test": set()}
+        self.unfiltered_build_issues = set()
+        self.unfiltered_boot_issues = set()
+        self.unfiltered_test_issues = set()
+        self.unfiltered_uncategorized_issue_flags = {
+            "build": False,
+            "boot": False,
+            "test": False,
+        }
+
+        self.boot_issues_dict = {}
+        self.test_issues_dict = {}
+        self.failed_boots_with_unknown_issues = 0
+        self.failed_tests_with_unknown_issues = 0
+
+
+class TestNormalizeBuildDict:
+    @patch("kernelCI_app.helpers.treeDetailsRollup.is_status_failure")
+    @patch("kernelCI_app.helpers.treeDetailsRollup.handle_misc")
+    def test_sets_defaults_and_normalizes_misc(
+        self, mock_handle_misc, mock_is_status_failure
+    ):
+        mock_handle_misc.return_value = {"lab": "lab-x"}
+        mock_is_status_failure.return_value = False
+
+        row = {"build_misc": None}
+        normalize_build_dict(row)
+
+        assert row["build_misc"] == {"lab": "lab-x"}
+        assert row["build_status"] == NULL_STATUS
+        assert row["build_architecture"] == UNKNOWN_STRING
+        assert row["build_compiler"] == UNKNOWN_STRING
+        assert row["build_config_name"] == UNKNOWN_STRING
+        mock_handle_misc.assert_called_once_with(None)
+
+    @patch("kernelCI_app.helpers.treeDetailsRollup.is_status_failure")
+    @patch("kernelCI_app.helpers.treeDetailsRollup.handle_misc")
+    def test_sets_uncategorized_issue_on_failed_build_without_issue_id(
+        self, mock_handle_misc, mock_is_status_failure
+    ):
+        mock_handle_misc.return_value = None
+        mock_is_status_failure.return_value = True
+
+        row = {"build_status": FAIL_STATUS, "issue_id": None}
+        normalize_build_dict(row)
+
+        assert row["issue_id"] == UNCATEGORIZED_STRING
+
+    @patch("kernelCI_app.helpers.treeDetailsRollup.is_status_failure")
+    @patch("kernelCI_app.helpers.treeDetailsRollup.handle_misc")
+    def test_preserves_existing_issue_id_on_failure(
+        self, mock_handle_misc, mock_is_status_failure
+    ):
+        mock_handle_misc.return_value = None
+        mock_is_status_failure.return_value = True
+
+        row = {"build_status": FAIL_STATUS, "issue_id": "known"}
+        normalize_build_dict(row)
+
+        assert row["issue_id"] == "known"
+
+
+class TestProcessBuildFilters:
+    def test_populates_globals_and_build_issue_for_failed_build(self):
+        inst = FakeRollupTreeInstance()
+        row = {
+            "build_status": FAIL_STATUS,
+            "build_config_name": "c1",
+            "build_architecture": "x86",
+            "build_compiler": "clang",
+            "build_origin": "maestro",
+            "build_misc": {"lab": "l1"},
+            "issue_id": "issue123",
+            "issue_version": 2,
+            "incident_test_id": None,
+        }
+        process_build_filters(inst, row)
+
+        assert inst.global_configs == {"c1"}
+        assert inst.global_architectures == {"x86"}
+        assert inst.global_compilers == {"clang"}
+        assert inst.unfiltered_origins["build"] == {"maestro"}
+        assert inst.unfiltered_labs["build"] == {"l1"}
+        assert ("issue123", 2) in inst.unfiltered_build_issues
+
+    def test_skips_build_issue_increment_for_test_only_incident(self):
+        inst = FakeRollupTreeInstance()
+        row = {
+            "build_status": FAIL_STATUS,
+            "build_config_name": "c1",
+            "build_architecture": "x86",
+            "build_compiler": "clang",
+            "build_origin": "maestro",
+            "build_misc": None,
+            "issue_id": "issue456",
+            "issue_version": 2,
+            "incident_test_id": "some-test",
+        }
+        process_build_filters(inst, row)
+
+        assert inst.unfiltered_build_issues == set()
+        assert inst.unfiltered_labs["build"] == set()
+
+
+class TestProcessRollupFilters:
+    def test_boot_row_updates_boot_sets(self):
+        inst = FakeRollupTreeInstance()
+        row = {
+            "is_boot": True,
+            "issue_id": "issue123",
+            "issue_version": 1,
+            "issue_uncategorized": False,
+            "test_origin": "origin1",
+            "test_lab": "lab1",
+        }
+        process_rollup_filters(inst, row)
+
+        assert inst.unfiltered_origins["boot"] == {"origin1"}
+        assert inst.unfiltered_labs["boot"] == {"lab1"}
+        assert ("issue123", 1) in inst.unfiltered_boot_issues
+
+    def test_test_row_updates_test_sets(self):
+        inst = FakeRollupTreeInstance()
+        row = {
+            "is_boot": False,
+            "issue_id": None,
+            "issue_version": None,
+            "issue_uncategorized": True,
+        }
+        process_rollup_filters(inst, row)
+
+        assert inst.unfiltered_origins["test"] == {UNKNOWN_STRING}
+        assert inst.unfiltered_labs["test"] == {UNKNOWN_STRING}
+        assert inst.unfiltered_uncategorized_issue_flags["test"] is True
+
+    def test_none_origin_and_lab_are_normalized_to_unknown(self):
+        inst = FakeRollupTreeInstance()
+        row = {
+            "is_boot": False,
+            "issue_id": None,
+            "issue_version": None,
+            "issue_uncategorized": False,
+            "test_origin": None,
+            "test_lab": None,
+        }
+        process_rollup_filters(inst, row)
+
+        assert inst.unfiltered_origins["test"] == {UNKNOWN_STRING}
+        assert inst.unfiltered_labs["test"] == {UNKNOWN_STRING}
+
+
+class TestRollupTestOrBootFilteredOut:
+    def test_filtered_by_path(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterTestPath = "wanted"
+        row = _base_rollup_row(path_group="other")
+
+        assert (
+            rollup_test_or_boot_filtered_out(inst, row_dict=row, is_boot_row=False)
+            is True
+        )
+
+    def test_not_filtered_when_filter_path_empty(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterTestPath = ""
+        row = _base_rollup_row()
+
+        assert (
+            rollup_test_or_boot_filtered_out(inst, row_dict=row, is_boot_row=False)
+            is False
+        )
+
+    @patch("kernelCI_app.helpers.treeDetailsRollup.should_filter_test_issue")
+    def test_delegates_to_issue_filter(self, mock_should_filter):
+        mock_should_filter.return_value = True
+        inst = FakeRollupTreeInstance()
+        row = _base_rollup_row(issue_id="i1", issue_version=1)
+
+        assert (
+            rollup_test_or_boot_filtered_out(inst, row_dict=row, is_boot_row=False)
+            is True
+        )
+        mock_should_filter.assert_called_once()
+        call_kw = mock_should_filter.call_args.kwargs
+        assert call_kw["incident_test_id"] == ROLLUP_TEST_ID
+
+    def test_filtered_by_platform(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterPlatforms["test"] = {"p1"}
+        row = _base_rollup_row(test_platform="p2")
+
+        assert (
+            rollup_test_or_boot_filtered_out(inst, row_dict=row, is_boot_row=False)
+            is True
+        )
+
+    def test_filtered_by_origin(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filter_test_origin = {"allowed"}
+        row = _base_rollup_row(test_origin="other")
+
+        assert (
+            rollup_test_or_boot_filtered_out(inst, row_dict=row, is_boot_row=False)
+            is True
+        )
+
+    @patch("kernelCI_app.helpers.treeDetailsRollup.should_filter_test_issue")
+    def test_uncategorized_sets_issue_id_for_filtering(self, mock_should_filter):
+        mock_should_filter.return_value = False
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterIssues["test"] = {UNCATEGORIZED_STRING}
+        row = _base_rollup_row(issue_uncategorized=True)
+
+        assert (
+            rollup_test_or_boot_filtered_out(inst, row_dict=row, is_boot_row=False)
+            is False
+        )
+        call_kw = mock_should_filter.call_args.kwargs
+        assert call_kw["issue_id"] == UNCATEGORIZED_STRING
+
+    def test_boot_filtered_by_boot_path(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterBootPath = "wanted"
+        row = _base_rollup_row(path_group="other")
+
+        assert (
+            rollup_test_or_boot_filtered_out(inst, row_dict=row, is_boot_row=True)
+            is True
+        )
+
+    def test_boot_not_filtered_by_test_path_when_is_boot_row(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterTestPath = "wanted"
+        inst.filters.filterBootPath = ""
+        row = _base_rollup_row(path_group="other")
+
+        assert (
+            rollup_test_or_boot_filtered_out(inst, row_dict=row, is_boot_row=True)
+            is False
+        )
+
+
+class TestProcessRollupSummary:
+    def test_accumulates_test_counts_without_status_filter(self):
+        inst = FakeRollupTreeInstance()
+        row = _base_rollup_row(pass_tests=2, fail_tests=1)
+
+        process_rollup_summary(inst, row_dict=row, is_boot_row=False)
+
+        assert inst.testStatusSummary["PASS"] == 2
+        assert inst.testStatusSummary["FAIL"] == 1
+        assert inst.testPlatformsWithErrors == {"qemu"}
+        arch_key = ("arm64", "gcc")
+        assert inst.test_arch_summary[arch_key]["status"]["PASS"] == 2
+        assert inst.test_arch_summary[arch_key]["status"]["FAIL"] == 1
+        assert inst.test_configs["defconfig"]["PASS"] == 2
+        assert inst.test_configs["defconfig"]["FAIL"] == 1
+
+    def test_skips_row_when_status_filter_has_no_overlap(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterTestStatus = ["SKIP"]
+        row = _base_rollup_row(pass_tests=5)
+
+        process_rollup_summary(inst, row_dict=row, is_boot_row=False)
+
+        assert inst.testStatusSummary == {}
+
+    def test_applies_partial_status_filter_to_counts(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterTestStatus = ["PASS"]
+        row = _base_rollup_row(pass_tests=3, fail_tests=2)
+
+        process_rollup_summary(inst, row_dict=row, is_boot_row=False)
+
+        assert inst.testStatusSummary == {"PASS": 3}
+
+    def test_routes_compatible_vs_misc_environment(self):
+        inst = FakeRollupTreeInstance()
+        row = _base_rollup_row(
+            hardware_key="board-1",
+            test_platform="qemu",
+            pass_tests=1,
+        )
+
+        process_rollup_summary(inst, row_dict=row, is_boot_row=True)
+
+        assert inst.bootEnvironmentCompatible["board-1"]["PASS"] == 1
+        assert "qemu" not in inst.bootEnvironmentMisc
+
+    def test_misc_environment_when_hardware_matches_platform(self):
+        inst = FakeRollupTreeInstance()
+        row = _base_rollup_row(
+            hardware_key="same",
+            test_platform="same",
+            fail_tests=1,
+        )
+
+        process_rollup_summary(inst, row_dict=row, is_boot_row=False)
+
+        assert inst.testEnvironmentMisc["same"]["FAIL"] == 1
+
+    def test_origin_and_lab_typed_summary(self):
+        inst = FakeRollupTreeInstance()
+        row = _base_rollup_row(
+            test_origin="origin-x",
+            test_lab="lab-y",
+            error_tests=1,
+        )
+
+        process_rollup_summary(inst, row_dict=row, is_boot_row=False)
+
+        origin = inst.test_summary["origins"]["origin-x"]
+        assert origin.ERROR == 1
+        lab = inst.test_summary_typed.labs["lab-y"]
+        assert lab.ERROR == 1
+
+    def test_accumulates_boot_counts_into_boot_summary(self):
+        inst = FakeRollupTreeInstance()
+        row = _base_rollup_row(pass_tests=3, fail_tests=2)
+
+        process_rollup_summary(inst, row_dict=row, is_boot_row=True)
+
+        assert inst.bootStatusSummary["PASS"] == 3
+        assert inst.bootStatusSummary["FAIL"] == 2
+        assert inst.bootPlatformsFailing == {"qemu"}
+        arch_key = ("arm64", "gcc")
+        assert inst.bootArchSummary[arch_key]["status"]["PASS"] == 3
+        assert inst.bootConfigs["defconfig"]["PASS"] == 3
+
+
+class TestProcessRollupIssues:
+    def test_creates_issue_and_increments_failure_counts(self):
+        inst = FakeRollupTreeInstance()
+        row = _base_rollup_row(
+            issue_id="bug-1",
+            issue_version=1,
+            issue_comment="c",
+            issue_report_url="http://x",
+            fail_tests=2,
+            error_tests=1,
+            miss_tests=0,
+        )
+
+        process_rollup_issues(inst, row_dict=row, is_boot_row=False)
+
+        issue = inst.test_issues_dict[("bug-1", 1)]
+        assert issue.comment == "c"
+        assert issue.incidents_info.FAIL == 2
+        assert issue.incidents_info.ERROR == 1
+
+    def test_unknown_failures_respect_fail_status_filter(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterTestStatus = ["PASS"]
+        row = _base_rollup_row(
+            issue_id=None,
+            issue_version=None,
+            issue_uncategorized=True,
+            fail_tests=4,
+        )
+
+        process_rollup_issues(inst, row_dict=row, is_boot_row=False)
+
+        assert inst.failed_tests_with_unknown_issues == 0
+
+    def test_unknown_failures_when_filter_allows_fail_or_empty(self):
+        inst = FakeRollupTreeInstance()
+        inst.filters.filterTestStatus = []
+        row = _base_rollup_row(
+            issue_id=None,
+            issue_version=None,
+            issue_uncategorized=True,
+            fail_tests=3,
+        )
+
+        process_rollup_issues(inst, row_dict=row, is_boot_row=False)
+
+        assert inst.failed_tests_with_unknown_issues == 3
+
+    def test_boot_unknown_counter(self):
+        inst = FakeRollupTreeInstance()
+        row = _base_rollup_row(
+            issue_id=None,
+            issue_version=None,
+            issue_uncategorized=True,
+            fail_tests=2,
+        )
+
+        process_rollup_issues(inst, row_dict=row, is_boot_row=True)
+
+        assert inst.failed_boots_with_unknown_issues == 2

--- a/backend/kernelCI_app/tests/unitTests/helpers/treeDetails_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/treeDetails_test.py
@@ -717,7 +717,7 @@ class TestProcessTestSummary:
         process_test_summary(instance, base_row_data)
 
         assert instance.testStatusSummary["FAIL"] == 1
-        assert "x86_64-gcc" in instance.test_arch_summary
+        assert ("x86_64", "gcc") in instance.test_arch_summary
         assert "defconfig" in instance.test_configs
         assert "x86_64" in instance.testPlatformsWithErrors
         assert instance.testFailReasons["Test error"] == 1
@@ -790,7 +790,7 @@ class TestProcessBootsSummary:
         process_boots_summary(instance, base_row_data)
 
         assert instance.bootStatusSummary["FAIL"] == 1
-        assert "x86_64-gcc" in instance.bootArchSummary
+        assert ("x86_64", "gcc") in instance.bootArchSummary
         assert "defconfig" in instance.bootConfigs
         assert "x86_64" in instance.bootPlatformsFailing
         assert instance.bootFailReasons["Test error"] == 1

--- a/backend/kernelCI_app/typeModels/common.py
+++ b/backend/kernelCI_app/typeModels/common.py
@@ -14,12 +14,12 @@ class StatusCount(BaseModel):
     DONE: Optional[int] = 0
     NULL: Optional[int] = 0
 
-    def increment(self, status: Optional[str]) -> None:
+    def increment(self, status: Optional[str], count: int = 1) -> None:
         if status is None:
             status = "NULL"
 
         try:
-            setattr(self, status.upper(), getattr(self, status.upper()) + 1)
+            setattr(self, status.upper(), getattr(self, status.upper()) + count)
         except AttributeError:
             log_message(f"Unknown status: {status}")
 

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -23,9 +23,11 @@ def create_issue_typed(
     issue_comment: Optional[str],
     issue_report_url: Optional[str],
     starting_count_status: Optional[DatabaseStatusValues],
+    autoincrement: bool = True,
 ) -> Issue:
     incident_count = StatusCount()
-    incident_count.increment(starting_count_status)
+    if autoincrement:
+        incident_count.increment(starting_count_status)
     return Issue(
         id=issue_id,
         version=issue_version,

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -9,21 +9,20 @@ from kernelCI_app.helpers.discordWebhook import send_discord_notification
 from kernelCI_app.helpers.filters import FilterParams
 from kernelCI_app.helpers.logger import create_endpoint_notification
 from kernelCI_app.helpers.treeDetails import (
-    call_based_on_compatible_and_misc_platform,
-    decide_if_is_boot_filtered_out,
     decide_if_is_build_filtered_out,
-    decide_if_is_full_row_filtered_out,
-    decide_if_is_test_filtered_out,
     get_build,
-    get_current_row_data,
-    process_tree_url,
-    process_boots_summary,
     process_builds_issue,
-    process_test_summary,
-    process_tests_issue,
-    process_filters,
+    process_tree_url,
 )
-from kernelCI_app.queries.tree import get_tree_details_data
+from kernelCI_app.helpers.treeDetailsRollup import (
+    normalize_build_dict,
+    process_build_filters,
+    process_rollup_filters,
+    process_rollup_issues,
+    process_rollup_summary,
+    rollup_test_or_boot_filtered_out,
+)
+from kernelCI_app.queries.tree import get_tree_details_builds, get_tree_details_rollup
 from kernelCI_app.typeModels.commonDetails import (
     BaseBuildSummary,
     BuildSummary,
@@ -45,7 +44,7 @@ from kernelCI_app.typeModels.treeDetails import (
     TreeCommon,
     TreeQueryParameters,
 )
-from kernelCI_app.utils import convert_issues_dict_to_list_typed, is_boot
+from kernelCI_app.utils import convert_issues_dict_to_list_typed
 
 from collections import defaultdict
 
@@ -54,12 +53,15 @@ from rest_framework.views import APIView
 from kernelCI_app.viewCommon import create_details_build_summary
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from http import HTTPStatus
-from kernelCI_app.constants.general import DEFAULT_ORIGIN, MAESTRO_DUMMY_BUILD_PREFIX
+from kernelCI_app.constants.general import (
+    DEFAULT_ORIGIN,
+    MAESTRO_DUMMY_BUILD_PREFIX,
+    UNKNOWN_STRING,
+)
 
 
 class BaseTreeDetailsSummary(APIView):
     def __init__(self):
-        self.processedTests = set()
         self.filters = None
 
         self.testStatusSummary = {}
@@ -68,7 +70,6 @@ class BaseTreeDetailsSummary(APIView):
         self.testFailReasons = {}
         self.test_arch_summary = {}
         self.testIssues = []
-        self.testIssuesTable = {}
         self.testEnvironmentCompatible = defaultdict(lambda: defaultdict(int))
         self.testEnvironmentMisc = defaultdict(lambda: defaultdict(int))
         self.bootStatusSummary = {}
@@ -77,7 +78,6 @@ class BaseTreeDetailsSummary(APIView):
         self.bootFailReasons = {}
         self.bootArchSummary = {}
         self.bootIssues = []
-        self.bootsIssuesTable = {}
         self.bootEnvironmentCompatible = defaultdict(lambda: defaultdict(int))
         self.bootEnvironmentMisc = defaultdict(lambda: defaultdict(int))
         self.hardwareUsed = set()
@@ -128,33 +128,6 @@ class BaseTreeDetailsSummary(APIView):
         self.boot_summary: dict[str, Any] = {"origins": {}}
         self.boot_summary_typed: TestSummary = generate_test_summary_typed()
 
-    def _process_boots_test(self, row_data):
-        test_id = row_data["test_id"]
-
-        if decide_if_is_boot_filtered_out(self, row_data):
-            return
-
-        process_tests_issue(instance=self, row_data=row_data, is_boot=True)
-
-        if test_id in self.processedTests:
-            return
-        self.processedTests.add(test_id)
-        process_boots_summary(self, row_data)
-
-    def _process_non_boots_test(self, row_data):
-        test_id = row_data["test_id"]
-
-        if decide_if_is_test_filtered_out(self, row_data):
-            return
-
-        process_tests_issue(instance=self, row_data=row_data)
-
-        if test_id in self.processedTests:
-            return
-
-        self.processedTests.add(test_id)
-        process_test_summary(self, row_data)
-
     def _process_builds(self, row_data):
         build_id = row_data["build_id"]
 
@@ -167,44 +140,61 @@ class BaseTreeDetailsSummary(APIView):
             return
 
         self.processed_builds.add(build_id)
-
         self.builds.append(get_build(row_data))
 
-    def _sanitize_rows(self, rows):
-        first_iteration = True
-        for row in rows:
-            row_data = get_current_row_data(row)
-            if first_iteration is True:
-                self.git_commit_tags = row_data["checkout_git_commit_tags"]
-                first_iteration = False
+    def _sanitize_builds_rows(self, builds_rows: list[dict]) -> None:
+        for row_dict in builds_rows:
+            row_data = normalize_build_dict(row_dict)
 
-            call_based_on_compatible_and_misc_platform(row_data, self.hardwareUsed.add)
+            if not self.git_commit_tags:
+                self.git_commit_tags = row_data.get("checkout_git_commit_tags", [])
 
             process_tree_url(self, row_data)
-            process_filters(self, row_data)
+            process_build_filters(self, row_data)
 
-            is_record_filter_out = decide_if_is_full_row_filtered_out(self, row_data)
-
-            if is_record_filter_out:
+            if self.filters.is_record_filtered_out(
+                architecture=row_data["build_architecture"],
+                compiler=row_data["build_compiler"],
+                config_name=row_data["build_config_name"],
+            ):
                 continue
 
-            if row_data["build_id"] is not None and not row_data["build_id"].startswith(
+            build_id = row_data.get("build_id")
+            if build_id is not None and not build_id.startswith(
                 MAESTRO_DUMMY_BUILD_PREFIX
             ):
                 self._process_builds(row_data)
-
-            if row_data["test_id"] is None:
-                continue
-
-            if is_boot(row_data["test_path"]):
-                self._process_boots_test(row_data)
-            else:
-                self._process_non_boots_test(row_data)
 
         self.base_build_summary = create_details_build_summary(self.builds)
         self.build_issues = convert_issues_dict_to_list_typed(
             issues_dict=self.build_issues_dict
         )
+
+    def _sanitize_rollup_rows(self, rollup_rows: list[dict]) -> None:
+        for row_dict in rollup_rows:
+            self.hardwareUsed.add(row_dict["hardware_key"])
+
+            process_rollup_filters(self, row_dict)
+
+            if self.filters.is_record_filtered_out(
+                hardwares=[row_dict["hardware_key"]],
+                architecture=row_dict["build_architecture"],
+                compiler=row_dict["build_compiler"],
+                config_name=row_dict["build_config_name"],
+                lab=row_dict.get("test_lab", UNKNOWN_STRING),
+            ):
+                continue
+
+            is_boot_row = row_dict["is_boot"]
+
+            if rollup_test_or_boot_filtered_out(
+                self, row_dict=row_dict, is_boot_row=is_boot_row
+            ):
+                continue
+
+            process_rollup_issues(self, row_dict=row_dict, is_boot_row=is_boot_row)
+            process_rollup_summary(self, row_dict=row_dict, is_boot_row=is_boot_row)
+
         self.bootIssues = convert_issues_dict_to_list_typed(
             issues_dict=self.boot_issues_dict
         )
@@ -223,36 +213,38 @@ class BaseTreeDetailsSummary(APIView):
         git_url_param = request.GET.get("git_url")
         git_branch_param = request.GET.get("git_branch", git_branch)
 
-        rows = get_tree_details_data(
-            origin_param=origin_param,
-            git_url_param=git_url_param,
-            tree_name=tree_name,
-            git_branch_param=git_branch_param,
-            commit_hash=commit_hash,
-        )
+        query_params = {
+            "origin_param": origin_param,
+            "git_url_param": git_url_param,
+            "git_branch_param": git_branch_param,
+            "commit_hash": commit_hash,
+            "tree_name": tree_name,
+        }
 
-        if len(rows) == 0:
+        builds_rows = get_tree_details_builds(**query_params)
+        rollup_rows = get_tree_details_rollup(**query_params)
+
+        if not builds_rows and not rollup_rows:
             return create_api_error_response(
                 error_message=ClientStrings.TREE_NO_RESULTS,
                 status_code=HTTPStatus.OK,
             )
 
-        if len(rows) == 1:
-            row_data = get_current_row_data(rows[0])
-            if row_data["build_id"] is None:
-                notification = create_endpoint_notification(
-                    message="Found checkout without builds",
-                    request=request,
-                )
-                send_discord_notification(content=notification)
-                return create_api_error_response(
-                    error_message=ClientStrings.TREE_BUILDS_NO_RESULTS,
-                    status_code=HTTPStatus.OK,
-                )
+        if not builds_rows:
+            notification = create_endpoint_notification(
+                message="Found checkout without builds",
+                request=request,
+            )
+            send_discord_notification(content=notification)
+            return create_api_error_response(
+                error_message=ClientStrings.TREE_BUILDS_NO_RESULTS,
+                status_code=HTTPStatus.OK,
+            )
 
         self.filters = FilterParams(request)
 
-        self._sanitize_rows(rows)
+        self._sanitize_builds_rows(builds_rows)
+        self._sanitize_rollup_rows(rollup_rows or [])
 
         try:
             valid_response = SummaryResponse(


### PR DESCRIPTION
## Description

Tree details summary now reads pre-aggregated test and boot data from tree_tests_rollup instead of scanning per-test rows from a single large query. Builds still come from a dedicated builds query. This matches the denormalized rollup model and should reduce work for the summary endpoint.

## Changes

- Add treeDetailsRollup.py helpers to normalize build rows and to apply filters, issues, and status summaries from rollup rows.
- Refactor treeDetailsSummaryView to call both queries and process builds and rollup rows in separate sanitization paths.
- Extend seed_test_data to build tree_tests_rollup rows from seeded tests/incidents.
- Add TestsRollupFactory and export it from test factories.


## How to test

1. Ensure migrations/schema include tree_tests_rollup and run seed_test_data or populate database with ingester data.
2. Call the tree details summary API for a commit that has builds and rollup data; confirm summaries and filters behave as before for representative trees.
3. Run the backend test suite covering tree details / summary if present.

Closes #1801