### PR TITLE
fix: fallback to origin when lab/runtime is missing in standardize_labs

### DIFF
--- a/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
+++ b/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
@@ -93,15 +93,22 @@ def standardize_tree_names(
 
 def standardize_labs(input_data: dict[str, Any]) -> None:
     """
-    Standardize labs in data, moving automatic lab names to AUTOMATIC_LAB_FIELD
+    Standardize labs in data, moving automatic lab names to AUTOMATIC_LAB_FIELD.
+    Falls back to 'origin' when 'lab' (builds) or 'runtime' (tests) is missing.
     """
 
     builds: list[dict[str, Any]] = input_data.get("builds", [])
     for build in builds:
         lab = build.get("misc", {}).get("lab")
-        if lab and AUTOMATIC_LABS.match(lab):
+        is_automatic = lab and AUTOMATIC_LABS.match(lab)
+        if is_automatic:
             build["misc"][AUTOMATIC_LAB_FIELD] = lab
             build["misc"].pop("lab", None)
+
+        if not lab or is_automatic:
+            origin = build.get("origin")
+            if origin:
+                build.setdefault("misc", {})["lab"] = origin
 
     tests: list[dict[str, Any]] = input_data.get("tests", [])
     for test in tests:
@@ -109,6 +116,11 @@ def standardize_labs(input_data: dict[str, Any]) -> None:
         if lab and AUTOMATIC_LABS.match(lab):
             test["misc"][AUTOMATIC_LAB_FIELD] = lab
             test["misc"].pop("runtime", None)
+            lab = None
+        if not lab:
+            origin = test.get("origin")
+            if origin:
+                test.setdefault("misc", {})["runtime"] = origin
 
 
 def _extract_origins_info(data: Optional[dict[str, Any]]) -> str:

--- a/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
+++ b/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
@@ -91,36 +91,37 @@ def standardize_tree_names(
                 checkout["tree_name"] = correct_tree
 
 
+def _standardize_lab_field(item: dict[str, Any], field: str) -> None:
+    """
+    Moves automatic lab/runtime value to AUTOMATIC_LAB_FIELD and falls back to origin.
+
+        lab is AUTOMATIC_LAB -> fallback to origin
+        lab is None -> fallback to origin
+        lab is not None -> do nothing
+    """
+    lab = item.get("misc", {}).get(field)
+    is_automatic = lab and AUTOMATIC_LABS.match(lab)
+    if is_automatic:
+        item["misc"][AUTOMATIC_LAB_FIELD] = lab
+        item["misc"].pop(field, None)
+        lab = None
+
+    if not lab or is_automatic:
+        origin = item.get("origin")
+        if origin:
+            item.setdefault("misc", {})[field] = origin
+
+
 def standardize_labs(input_data: dict[str, Any]) -> None:
     """
     Standardize labs in data, moving automatic lab names to AUTOMATIC_LAB_FIELD.
     Falls back to 'origin' when 'lab' (builds) or 'runtime' (tests) is missing.
     """
+    for build in input_data.get("builds", []):
+        _standardize_lab_field(build, "lab")
 
-    builds: list[dict[str, Any]] = input_data.get("builds", [])
-    for build in builds:
-        lab = build.get("misc", {}).get("lab")
-        is_automatic = lab and AUTOMATIC_LABS.match(lab)
-        if is_automatic:
-            build["misc"][AUTOMATIC_LAB_FIELD] = lab
-            build["misc"].pop("lab", None)
-
-        if not lab or is_automatic:
-            origin = build.get("origin")
-            if origin:
-                build.setdefault("misc", {})["lab"] = origin
-
-    tests: list[dict[str, Any]] = input_data.get("tests", [])
-    for test in tests:
-        lab = test.get("misc", {}).get("runtime")
-        if lab and AUTOMATIC_LABS.match(lab):
-            test["misc"][AUTOMATIC_LAB_FIELD] = lab
-            test["misc"].pop("runtime", None)
-            lab = None
-        if not lab:
-            origin = test.get("origin")
-            if origin:
-                test.setdefault("misc", {})["runtime"] = origin
+    for test in input_data.get("tests", []):
+        _standardize_lab_field(test, "runtime")
 
 
 def _extract_origins_info(data: Optional[dict[str, Any]]) -> str:

--- a/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py
@@ -204,13 +204,16 @@ class TestStandardizeLabs:
     """Test cases for standardize_labs function."""
 
     # Test cases:
-    # - builds/tests with missing misc field
-    # - builds/tests with misc but not lab field
+    # - builds/tests with missing misc field, no origin
+    # - builds/tests with missing misc field, with origin (fallback)
+    # - builds/tests with misc but not lab field, no origin
+    # - builds/tests with misc but not lab field, with origin (fallback)
     # - empty builds/tests data
     # - builds/tests with real/automatic labs/runtimes
+    # - builds/tests with automatic lab and origin (origin IS used as fallback)
 
-    def test_standardize_labs_missing_misc(self):
-        """Test with builds/tests missing misc field."""
+    def test_standardize_labs_missing_misc_no_origin(self):
+        """Test with builds/tests missing misc field and no origin: misc not created."""
         input_data = {
             "builds": [
                 {"id": "build1"},
@@ -225,8 +228,25 @@ class TestStandardizeLabs:
         assert "misc" not in input_data["builds"][0]
         assert "misc" not in input_data["tests"][0]
 
-    def test_standardize_labs_missing_lab_runtime(self):
-        """Test with builds/tests having misc but missing lab/runtime field."""
+    def test_standardize_labs_missing_misc_with_origin_fallback(self):
+        """Test with builds/tests missing misc but with origin: misc created with origin as lab."""
+        origin = "broonie"
+        input_data = {
+            "builds": [
+                {"id": "build1", "origin": origin},
+            ],
+            "tests": [
+                {"id": "test1", "origin": origin},
+            ],
+        }
+
+        standardize_labs(input_data)
+
+        assert input_data["builds"][0]["misc"]["lab"] == origin
+        assert input_data["tests"][0]["misc"]["runtime"] == origin
+
+    def test_standardize_labs_missing_lab_runtime_no_origin(self):
+        """Test with builds/tests having misc but missing lab/runtime and no origin: unchanged."""
         input_data = {
             "builds": [
                 {
@@ -251,6 +271,25 @@ class TestStandardizeLabs:
         assert "runtime" not in input_data["tests"][0]["misc"]
         assert AUTOMATIC_LAB_FIELD not in input_data["tests"][0]["misc"]
 
+    def test_standardize_labs_missing_lab_runtime_with_origin_fallback(self):
+        """Test with builds/tests having misc but missing lab/runtime with origin: origin used."""
+        origin = "redhat"
+        input_data = {
+            "builds": [
+                {"misc": {"other_field": "value"}, "origin": origin},
+            ],
+            "tests": [
+                {"misc": {"platform": "x86"}, "origin": origin},
+            ],
+        }
+
+        standardize_labs(input_data)
+
+        assert input_data["builds"][0]["misc"]["lab"] == origin
+        assert AUTOMATIC_LAB_FIELD not in input_data["builds"][0]["misc"]
+        assert input_data["tests"][0]["misc"]["runtime"] == origin
+        assert AUTOMATIC_LAB_FIELD not in input_data["tests"][0]["misc"]
+
     def test_standardize_labs_empty_data(self):
         """Test with empty builds and tests."""
         input_data = {
@@ -262,6 +301,26 @@ class TestStandardizeLabs:
 
         assert input_data["builds"] == []
         assert input_data["tests"] == []
+
+    def test_standardize_labs_automatic_lab_with_origin_falls_back(self):
+        """Test that when an automatic lab is present, origin IS used as fallback for lab/runtime."""
+        origin = "maestro"
+        input_data = {
+            "builds": [
+                {"misc": {"lab": "shell"}, "origin": origin},
+            ],
+            "tests": [
+                {"misc": {"runtime": "k8s"}, "origin": origin},
+            ],
+        }
+
+        standardize_labs(input_data)
+
+        # Automatic lab moved to AUTOMATIC_LAB_FIELD, origin used as fallback for lab/runtime
+        assert input_data["builds"][0]["misc"][AUTOMATIC_LAB_FIELD] == "shell"
+        assert input_data["builds"][0]["misc"]["lab"] == origin
+        assert input_data["tests"][0]["misc"][AUTOMATIC_LAB_FIELD] == "k8s"
+        assert input_data["tests"][0]["misc"]["runtime"] == origin
 
     def test_standardize_labs_mixed_builds_and_tests(self):
         """Test with a mix of automatic and real labs/runtimes."""

--- a/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py
@@ -20,6 +20,7 @@ from kernelCI_app.management.commands.helpers.kcidbng_ingester import (
     SubmissionFileMetadata,
     standardize_tree_names,
     standardize_labs,
+    _standardize_lab_field,
     prepare_file_data,
     consume_buffer,
     flush_buffers,
@@ -198,6 +199,50 @@ class TestStandardizeTreeNames:
 
         assert input_data["checkouts"][0]["tree_name"] == "mainline"
         assert "tree_name" not in input_data["checkouts"][1]
+
+
+class TestStandardizeLabField:
+    """Test cases for _standardize_lab_field helper."""
+
+    # Test cases:
+    # - automatic value with origin → moved to AUTOMATIC_LAB_FIELD, origin used as fallback
+    # - automatic value without origin → moved to AUTOMATIC_LAB_FIELD, field left absent
+    # - missing field with origin → origin used as fallback
+    # - missing field without origin → field stays absent
+    # - real value → unchanged
+
+    def test_automatic_lab_with_origin(self):
+        """Automatic value is moved to AUTOMATIC_LAB_FIELD and origin fills the field."""
+        item = {"misc": {"lab": "shell"}, "origin": "maestro"}
+        _standardize_lab_field(item, "lab")
+        assert item["misc"][AUTOMATIC_LAB_FIELD] == "shell"
+        assert item["misc"]["lab"] == "maestro"
+
+    def test_automatic_lab_without_origin(self):
+        """Automatic value is moved to AUTOMATIC_LAB_FIELD; field stays absent."""
+        item = {"misc": {"lab": "k8s"}}
+        _standardize_lab_field(item, "lab")
+        assert item["misc"][AUTOMATIC_LAB_FIELD] == "k8s"
+        assert "lab" not in item["misc"]
+
+    def test_missing_field_with_origin(self):
+        """Missing field is filled with origin."""
+        item = {"misc": {}, "origin": "broonie"}
+        _standardize_lab_field(item, "runtime")
+        assert item["misc"]["runtime"] == "broonie"
+
+    def test_missing_field_without_origin(self):
+        """Missing field stays absent when there is no origin."""
+        item = {"misc": {}}
+        _standardize_lab_field(item, "runtime")
+        assert "runtime" not in item["misc"]
+
+    def test_real_value_unchanged(self):
+        """A real (non-automatic) lab value is left untouched."""
+        item = {"misc": {"lab": "collabora"}, "origin": "redhat"}
+        _standardize_lab_field(item, "lab")
+        assert item["misc"]["lab"] == "collabora"
+        assert AUTOMATIC_LAB_FIELD not in item["misc"]
 
 
 class TestStandardizeLabs:


### PR DESCRIPTION
## Summary

Closes #1752

When ingesting data via `standardize_labs`, builds and tests that have
no `lab` (builds) or `runtime` (tests) value in `misc` were silently
losing their origin context. This fix uses the `origin` field as a
fallback, ensuring entries without explicit lab information can still
be grouped and filtered by origin.

**Behavior:**
- If `lab`/`runtime` is missing and `origin` exists → `origin` is set as `lab`/`runtime` in `misc`
- If the lab matches an automatic lab pattern → existing behavior is preserved; `origin` is NOT used as fallback
- If neither `lab`/`runtime` nor `origin` is present → no change

## How to verify

Run the unit tests:

```bash
cd backend
poetry run pytest kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py::TestStandardizeLabs -v -m unit
```

All 8 test cases in `TestStandardizeLabs` should pass, including the 4 new ones added in this PR that cover the fallback scenarios.