### PR TITLE
fix: ensure default values are set for missing keys in normalize_build_dict

### DIFF
--- a/backend/kernelCI_app/helpers/treeDetailsRollup.py
+++ b/backend/kernelCI_app/helpers/treeDetailsRollup.py
@@ -33,7 +33,8 @@ def normalize_build_dict(row_dict: dict) -> dict:
         "build_config_name": UNKNOWN_STRING,
     }
     for key, default in defaults.items():
-        row_dict.setdefault(key, default)
+        if row_dict.get(key) is None:
+            row_dict[key] = default
 
     if row_dict.get("issue_id") is None and is_status_failure(
         row_dict["build_status"], build_fail_status_list


### PR DESCRIPTION
## Description

Fixes a Pydantic validation error where null values in database rows for build_config_name and build_compiler were being passed through to the API response, causing validation failures. The setdefault method only handles missing keys, not explicit None values. This change ensures that None values are also replaced with the "Unknown" fallback string.

## Changes
- Modified normalize_build_dict in treeDetailsRollup.py to check for both missing keys and None values when applying defaults for build_status, build_architecture, build_compiler, and build_config_name