### PR TITLE
fix: rename cache key for tree details builds to avoid key collision

### DIFF
--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -758,7 +758,7 @@ def get_tree_details_builds(
     """
     Fetch builds for a given tree commit.
     """
-    cache_key = "treeDetailsBuilds"
+    cache_key = "treeDetailsBuildsData"
 
     params = {
         "commit_hash": commit_hash,


### PR DESCRIPTION
## Description

Fixes a cache key collision between `get_tree_details_builds` and `get_tree_data(data_type="builds")`. Both functions used the identical cache key "treeDetailsBuilds", causing the summary endpoint to populate the cache with dict rows. When the builds endpoint subsequently accessed that cache, `get_tree_data` tried to read those dicts as tuples via positional indexing `row[0]`, triggering `KeyError: 0`.

## Changes

- Renamed `get_tree_details_builds` cache key from "treeDetailsBuilds" to "treeDetailsBuildsDirect" to avoid collision with `get_tree_data`