### PR TITLE
fix: sort aggregation values to avoid deadlocks in process_pending

### DIFF
--- a/backend/kernelCI_app/management/commands/helpers/aggregation_helpers.py
+++ b/backend/kernelCI_app/management/commands/helpers/aggregation_helpers.py
@@ -1,9 +1,13 @@
 import time
-from typing import Sequence
+from typing import Optional, Sequence
 
 
 from django.db import connections
 from kernelCI_app.helpers.logger import out
+from kernelCI_app.management.commands.helpers.tree_listing import (
+    CheckoutRow,
+    tree_listing_sort_key,
+)
 from kernelCI_app.models import (
     Checkouts,
     PendingTest,
@@ -14,7 +18,6 @@ from kernelCI_app.models import (
     Builds,
 )
 from kernelCI_app.utils import is_boot
-from typing import Optional
 
 
 def simplify_status(status: Optional[StatusChoices]) -> SimplifiedStatusChoices:
@@ -67,26 +70,20 @@ def update_tree_listing(checkouts_instances: Sequence[Checkouts]):
     t0 = time.time()
     checkout_values = sorted(
         [
-            (
-                checkout.id,
-                checkout.origin,
-                checkout.tree_name,
-                checkout.git_repository_url,
-                checkout.git_repository_branch,
-                checkout.git_commit_hash,
-                checkout.git_commit_name,
-                checkout.git_commit_tags,
-                checkout.start_time,
+            CheckoutRow(
+                checkout_id=checkout.id,
+                origin=checkout.origin,
+                tree_name=checkout.tree_name,
+                git_repository_url=checkout.git_repository_url,
+                git_repository_branch=checkout.git_repository_branch,
+                git_commit_hash=checkout.git_commit_hash,
+                git_commit_name=checkout.git_commit_name,
+                git_commit_tags=checkout.git_commit_tags,
+                start_time=checkout.start_time,
             )
             for checkout in checkouts_instances
         ],
-        key=lambda v: (
-            (v[1] is None, v[1] or ""),
-            (v[2] is None, v[2] or ""),
-            (v[3] is None, v[3] or ""),
-            (v[4] is None, v[4] or ""),
-            (v[5] is None, v[5] or ""),
-        ),
+        key=tree_listing_sort_key,
     )
 
     with connections["default"].cursor() as cursor:

--- a/backend/kernelCI_app/management/commands/helpers/aggregation_helpers.py
+++ b/backend/kernelCI_app/management/commands/helpers/aggregation_helpers.py
@@ -65,20 +65,29 @@ def update_tree_listing(checkouts_instances: Sequence[Checkouts]):
         return
 
     t0 = time.time()
-    checkout_values = [
-        (
-            checkout.id,
-            checkout.origin,
-            checkout.tree_name,
-            checkout.git_repository_url,
-            checkout.git_repository_branch,
-            checkout.git_commit_hash,
-            checkout.git_commit_name,
-            checkout.git_commit_tags,
-            checkout.start_time,
-        )
-        for checkout in checkouts_instances
-    ]
+    checkout_values = sorted(
+        [
+            (
+                checkout.id,
+                checkout.origin,
+                checkout.tree_name,
+                checkout.git_repository_url,
+                checkout.git_repository_branch,
+                checkout.git_commit_hash,
+                checkout.git_commit_name,
+                checkout.git_commit_tags,
+                checkout.start_time,
+            )
+            for checkout in checkouts_instances
+        ],
+        key=lambda v: (
+            (v[1] is None, v[1] or ""),
+            (v[2] is None, v[2] or ""),
+            (v[3] is None, v[3] or ""),
+            (v[4] is None, v[4] or ""),
+            (v[5] is None, v[5] or ""),
+        ),
+    )
 
     with connections["default"].cursor() as cursor:
         # Set values as 0 when inserting a new tree

--- a/backend/kernelCI_app/management/commands/helpers/tree_listing.py
+++ b/backend/kernelCI_app/management/commands/helpers/tree_listing.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from typing import Any, NamedTuple
+
+
+class CheckoutRow(NamedTuple):
+    checkout_id: str
+    origin: str
+    tree_name: str | None
+    git_repository_url: str | None
+    git_repository_branch: str | None
+    git_commit_hash: str | None
+    git_commit_name: str | None
+    git_commit_tags: list[str] | None
+    start_time: datetime | None
+
+
+class TreeListingRow(NamedTuple):
+    """Flat row passed to cursor.executemany() for UPDATE tree_listing.
+
+    Field order must match the SQL parameter placeholders in _process_tree_listing.
+    """
+
+    build_pass: int
+    build_failed: int
+    build_inc: int
+    boot_pass: int
+    boot_failed: int
+    boot_inc: int
+    test_pass: int
+    test_failed: int
+    test_inc: int
+    origin: str
+    tree_name: str | None
+    git_repository_branch: str | None
+    git_repository_url: str | None
+    git_commit_hash: str | None
+
+
+def tree_listing_sort_key(v: Any) -> tuple:
+    """Sort key for tree_listing rows by unique constraint columns.
+
+    Ensures deterministic lock acquisition order in concurrent transactions,
+    preventing deadlocks between the ingester and aggregation processor.
+    Compatible with both CheckoutRow and TreeListingRow.
+    """
+    return (
+        (v.origin is None, v.origin or ""),
+        (v.tree_name is None, v.tree_name or ""),
+        (v.git_repository_url is None, v.git_repository_url or ""),
+        (v.git_repository_branch is None, v.git_repository_branch or ""),
+        (v.git_commit_hash is None, v.git_commit_hash or ""),
+    )

--- a/backend/kernelCI_app/management/commands/process_pending_aggregations.py
+++ b/backend/kernelCI_app/management/commands/process_pending_aggregations.py
@@ -647,25 +647,37 @@ class Command(BaseCommand):
         if not tree_listing_data:
             return
 
-        values = [
-            (
-                data["build_pass"],
-                data["build_failed"],
-                data["build_inc"],
-                data["boot_pass"],
-                data["boot_failed"],
-                data["boot_inc"],
-                data["test_pass"],
-                data["test_failed"],
-                data["test_inc"],
-                data["origin"],
-                data["tree_name"],
-                data["git_repository_branch"],
-                data["git_repository_url"],
-                data["git_commit_hash"],
-            )
-            for data in tree_listing_data.values()
-        ]
+        values = sorted(
+            [
+                (
+                    data["build_pass"],
+                    data["build_failed"],
+                    data["build_inc"],
+                    data["boot_pass"],
+                    data["boot_failed"],
+                    data["boot_inc"],
+                    data["test_pass"],
+                    data["test_failed"],
+                    data["test_inc"],
+                    data["origin"],
+                    data["tree_name"],
+                    data["git_repository_branch"],
+                    data["git_repository_url"],
+                    data["git_commit_hash"],
+                )
+                for data in tree_listing_data.values()
+            ],
+            key=lambda v: (
+                (v[9] is None, v[9] or ""),
+                (v[10] is None, v[10] or ""),
+                (
+                    v[12] is None,
+                    v[12] or "",
+                ),  # git_repository_url before git_repository_branch
+                (v[11] is None, v[11] or ""),  # to match unique constraint order
+                (v[13] is None, v[13] or ""),
+            ),
+        )
 
         t0 = time.time()
         with connection.cursor() as cursor:

--- a/backend/kernelCI_app/management/commands/process_pending_aggregations.py
+++ b/backend/kernelCI_app/management/commands/process_pending_aggregations.py
@@ -14,6 +14,10 @@ from django.db import connection, transaction
 from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 from kernelCI_app.helpers.logger import out
 from kernelCI_app.management.commands.helpers.aggregation_helpers import simplify_status
+from kernelCI_app.management.commands.helpers.tree_listing import (
+    TreeListingRow,
+    tree_listing_sort_key,
+)
 from kernelCI_app.constants.ingester import PROMETHEUS_MULTIPROC_DIR
 from prometheus_client import start_http_server
 from kernelCI_app.models import (
@@ -649,34 +653,25 @@ class Command(BaseCommand):
 
         values = sorted(
             [
-                (
-                    data["build_pass"],
-                    data["build_failed"],
-                    data["build_inc"],
-                    data["boot_pass"],
-                    data["boot_failed"],
-                    data["boot_inc"],
-                    data["test_pass"],
-                    data["test_failed"],
-                    data["test_inc"],
-                    data["origin"],
-                    data["tree_name"],
-                    data["git_repository_branch"],
-                    data["git_repository_url"],
-                    data["git_commit_hash"],
+                TreeListingRow(
+                    build_pass=data["build_pass"],
+                    build_failed=data["build_failed"],
+                    build_inc=data["build_inc"],
+                    boot_pass=data["boot_pass"],
+                    boot_failed=data["boot_failed"],
+                    boot_inc=data["boot_inc"],
+                    test_pass=data["test_pass"],
+                    test_failed=data["test_failed"],
+                    test_inc=data["test_inc"],
+                    origin=data["origin"],
+                    tree_name=data["tree_name"],
+                    git_repository_branch=data["git_repository_branch"],
+                    git_repository_url=data["git_repository_url"],
+                    git_commit_hash=data["git_commit_hash"],
                 )
                 for data in tree_listing_data.values()
             ],
-            key=lambda v: (
-                (v[9] is None, v[9] or ""),
-                (v[10] is None, v[10] or ""),
-                (
-                    v[12] is None,
-                    v[12] or "",
-                ),  # git_repository_url before git_repository_branch
-                (v[11] is None, v[11] or ""),  # to match unique constraint order
-                (v[13] is None, v[13] or ""),
-            ),
+            key=tree_listing_sort_key,
         )
 
         t0 = time.time()


### PR DESCRIPTION
## Description

Fixes a PostgreSQL deadlock in the `tree_listing` table caused by concurrent updates from the ingester and aggregation processor. When two transactions locked overlapping rows in different orders, PostgreSQL detected a deadlock and killed one transaction. This fix ensures all transactions acquire row locks in a deterministic order by sorting values by their lock-key columns before executing `executemany()`.

## Why the deadlock happens

Two concurrent processes update the `tree_listing` table inside separate transactions:

1. The ingester runs `aggregate_checkouts_and_pendings()` inside `transaction.atomic()`, which calls `update_tree_listing()`, an `INSERT ... ON CONFLICT DO UPDATE` on `tree_listing`.

2. The aggregation processor runs `_process_tree_listing()` inside `transaction.atomic()` — a plain `UPDATE tree_listing` via `executemany()`.

Both processes use `cursor.executemany()` which sends one statement per row. PostgreSQL acquires row-level locks incrementally as each statement executes. When two transactions lock overlapping rows in different orders, PostgreSQL detects a deadlock and kills one of them.

The iteration order came from `dict.values()` (insertion order in Python 3.7+), which depends on the arrival order of tests/builds, not on any stable sort key. So two concurrent batches that touched overlapping `tree_listing` rows could easily lock them in opposite order, causing deadlocks.

By sorting both writers by the same lock-key columns in the same deterministic order, all transactions now acquire row locks consistently, making deadlocks theoretically impossible.

## Changes

- Sort `checkout_values` in `update_tree_listing()` by the unique constraint columns `(origin, tree_name, git_repository_url, git_repository_branch, git_commit_hash)` before the INSERT ... ON CONFLICT DO UPDATE
- Sort `values` in `_process_tree_listing()` (process_pending_aggregations.py) by the UPDATE WHERE clause columns `(origin, tree_name, git_repository_branch, git_repository_url, git_commit_hash)` before executing the UPDATE

## How to test

1. Run the backend test suite: `docker compose exec test_backend poetry run pytest`
2. Verify no regressions in tree listing aggregation tests