### PR TITLE
fix: handle invalid origin when navigating between pages

### DIFF
--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -41,15 +41,16 @@ const OriginSelect = ({
     [navigate],
   );
 
-  const selectItems = useMemo(() => {
-    if (originData === undefined) {
-      return <></>;
+  const pageOrigins = useMemo(() => {
+    if (!originData) {
+      return [];
     }
-
-    const pageOrigins = isHardwarePath
+    return isHardwarePath
       ? originData.test_origins
       : originData.checkout_origins;
+  }, [originData, isHardwarePath]);
 
+  const selectItems = useMemo(() => {
     return pageOrigins.map(option => (
       <SelectItem
         key={option}
@@ -59,10 +60,14 @@ const OriginSelect = ({
         {option}
       </SelectItem>
     ));
-  }, [originData, isHardwarePath]);
+  }, [pageOrigins]);
 
   useEffect(() => {
-    if (origin === undefined) {
+    if (pageOrigins.length === 0) {
+      return;
+    }
+
+    if (origin === undefined || !pageOrigins.includes(origin)) {
       navigate({
         to: '.',
         search: previousSearch => ({
@@ -71,7 +76,7 @@ const OriginSelect = ({
         }),
       });
     }
-  }, [navigate, origin]);
+  }, [navigate, origin, pageOrigins]);
 
   if (originStatus === 'pending') {
     return <FormattedMessage id="global.loading" />;


### PR DESCRIPTION
## Description

Fixes the origin selector appearing blank and causing empty backend responses when navigating between Hardware and Tree pages. The issue occurred because the `origin` search parameter is global, but Hardware pages use `test_origins` while Tree pages use `checkout_origins`. When a selected origin from one page type didn't exist in the other, the selector showed nothing and the backend returned no data.

## Changes

- Extract `pageOrigins` into a separate `useMemo` to compute page-specific origins
- Update `selectItems` to use the pre-computed `pageOrigins`
- Expand the origin validation `useEffect` to check if the current origin is invalid for the page and auto-correct to `DEFAULT_ORIGIN`

## How to test

1. Go to the Hardware page and select an origin that exists in `test_origins` but not in `checkout_origins`
2. Navigate to the Trees page
3. Verify the origin selector now shows a valid fallback origin instead of being blank
4. Verify tree data loads correctly instead of showing empty results if there are results for the origin

Closes #1841