### PR TITLE
Refactor: ruff formatting

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,8 +1,9 @@
-import tomllib
-from pytest import Item
 import os
+import tomllib
+
 import django
 from django.conf import settings
+from pytest import Item
 
 
 def pytest_addoption(parser):

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -56,10 +56,10 @@ def get_test_markers() -> list[str]:
 
         return marker_names
 
-    except FileNotFoundError:
-        raise FileNotFoundError("pyproject.toml not found")
+    except FileNotFoundError as file_err:
+        raise FileNotFoundError("pyproject.toml not found") from file_err
     except Exception as e:
-        raise e(f"Error reading markers from pyproject.toml: {e}")
+        raise e(f"Error reading markers from pyproject.toml: {e}") from e
 
 
 def pytest_collection_modifyitems(items: list[Item]):

--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -10,13 +10,14 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
-from pathlib import Path
+import json
+import os
 import sys
 import threading
-from utils.validation import is_boolean_or_string_true
+from pathlib import Path
+
 from utils.development_metrics import start_development_metrics_server
-import os
-import json
+from utils.validation import is_boolean_or_string_true
 
 
 def get_json_env_var(name, default):

--- a/backend/kernelCI/test_settings.py
+++ b/backend/kernelCI/test_settings.py
@@ -3,6 +3,7 @@ Test-specific Django settings for integration tests with local database.
 """
 
 import os
+
 from kernelCI.settings import *  # noqa: F403, F401
 
 # Override database configuration for tests

--- a/backend/kernelCI/urls.py
+++ b/backend/kernelCI/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/backend/kernelCI_app/cache.py
+++ b/backend/kernelCI_app/cache.py
@@ -1,6 +1,7 @@
 from typing import Optional
-from django.core.cache import cache
+
 from django.conf import settings
+from django.core.cache import cache
 
 timeout = settings.CACHE_TIMEOUT
 DISCORD_NOTIFICATION_COOLDOWN = 600

--- a/backend/kernelCI_app/constants/ingester.py
+++ b/backend/kernelCI_app/constants/ingester.py
@@ -1,8 +1,9 @@
 """Constant settings for the ingester functions"""
 
-import os
 import logging
+import os
 import re
+
 from kernelCI_app.constants.tree_names import TREE_NAMES_FILENAME
 from utils.validation import is_boolean_or_string_true
 

--- a/backend/kernelCI_app/helpers/database.py
+++ b/backend/kernelCI_app/helpers/database.py
@@ -5,4 +5,4 @@ def dict_fetchall(cursor) -> list[dict]:
     This has a performance cost so avoid using it in large unprocessed data.
     """
     columns = [col[0] for col in cursor.description]
-    return [dict(zip(columns, row)) for row in cursor.fetchall()]
+    return [dict(zip(columns, row, strict=False)) for row in cursor.fetchall()]

--- a/backend/kernelCI_app/helpers/dateRange.py
+++ b/backend/kernelCI_app/helpers/dateRange.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta, timezone as dt_timezone
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
 from typing import Optional, Tuple
 
 from django.utils.timezone import now

--- a/backend/kernelCI_app/helpers/discordWebhook.py
+++ b/backend/kernelCI_app/helpers/discordWebhook.py
@@ -1,9 +1,8 @@
+import os
 from datetime import datetime, timezone
 from typing import Any, Optional, TypedDict
 
 import requests
-import os
-
 from kernelCI_app.cache import (
     DISCORD_NOTIFICATION_COOLDOWN,
     get_notification_cache,

--- a/backend/kernelCI_app/helpers/email.py
+++ b/backend/kernelCI_app/helpers/email.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 from email.utils import make_msgid
 
 from django.core.mail import EmailMessage, get_connection

--- a/backend/kernelCI_app/helpers/email.py
+++ b/backend/kernelCI_app/helpers/email.py
@@ -3,7 +3,7 @@
 
 from email.utils import make_msgid
 
-from django.core.mail import get_connection, EmailMessage
+from django.core.mail import EmailMessage, get_connection
 
 
 def smtp_setup_connection():

--- a/backend/kernelCI_app/helpers/environment.py
+++ b/backend/kernelCI_app/helpers/environment.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 import yaml
 
 from kernelCI_app.constants.general import (

--- a/backend/kernelCI_app/helpers/errorHandling.py
+++ b/backend/kernelCI_app/helpers/errorHandling.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+
 from rest_framework.response import Response
 
 

--- a/backend/kernelCI_app/helpers/filters.py
+++ b/backend/kernelCI_app/helpers/filters.py
@@ -1,15 +1,17 @@
-from collections.abc import Callable
-from typing import Optional, Dict, List, Tuple, TypedDict, Literal, Any, Union
-from django.http import HttpRequest, HttpResponseBadRequest
 import re
-from kernelCI_app.constants.general import UNCATEGORIZED_STRING
+from collections.abc import Callable
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, Union
+
+from django.http import HttpRequest, HttpResponseBadRequest
+
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING, UNKNOWN_STRING
 from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.models import StatusChoices
 from kernelCI_app.typeModels.databases import (
     StatusValues,
-    failure_status_list,
     build_fail_status_list,
+    failure_status_list,
 )
 from kernelCI_app.typeModels.issues import (
     ISSUE_FILTER_OPTIONS,
@@ -18,7 +20,6 @@ from kernelCI_app.typeModels.issues import (
     PossibleIssueCulprits,
 )
 from kernelCI_app.utils import get_error_body_response
-from kernelCI_app.constants.general import UNKNOWN_STRING
 
 NULL_STRINGS = set(["null", UNKNOWN_STRING, "NULL"])
 

--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -363,7 +363,7 @@ def handle_test_summary(
         task.failed_platforms.add(test_platform)
         task.fail_reasons[extract_error_message(record["misc"])] += 1
 
-    arch_key = f'{record["build__architecture"]}{record["build__compiler"]}'
+    arch_key = f"{record['build__architecture']}{record['build__compiler']}"
     arch_summary = processed_archs.get(arch_key)
     if not arch_summary:
         arch_summary = get_arch_summary_typed(record)

--- a/backend/kernelCI_app/helpers/hardwareDetails.py
+++ b/backend/kernelCI_app/helpers/hardwareDetails.py
@@ -1,17 +1,19 @@
 import bisect
+import json
 from collections import defaultdict
 from datetime import datetime, timezone
-import json
 from typing import Any, Dict, List, Literal, Optional, Set
 
+from pydantic import ValidationError
+
 from kernelCI_app.constants.general import (
-    UNCATEGORIZED_STRING,
     MAESTRO_DUMMY_BUILD_PREFIX,
+    UNCATEGORIZED_STRING,
+    UNKNOWN_STRING,
 )
 from kernelCI_app.constants.hardwareDetails import (
     SELECTED_HEAD_TREE_VALUE,
 )
-from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.helpers.commonDetails import PossibleTabs, add_unfiltered_issue
 from kernelCI_app.helpers.filters import (
     FilterParams,
@@ -25,25 +27,26 @@ from kernelCI_app.helpers.misc import (
     handle_misc,
     misc_value_or_default,
 )
+from kernelCI_app.typeModels.commonDetails import (
+    BuildArchitectures,
+    BuildSummary,
+    EnvironmentMisc,
+    StatusCount,
+    TestArchSummaryItem,
+    TestSummary,
+)
 from kernelCI_app.typeModels.databases import (
     FAIL_STATUS,
     NULL_STATUS,
     StatusValues,
     build_fail_status_list,
 )
-from kernelCI_app.typeModels.commonDetails import (
-    BuildArchitectures,
-    BuildSummary,
-    EnvironmentMisc,
-    TestArchSummaryItem,
-    StatusCount,
-    TestSummary,
-)
 from kernelCI_app.typeModels.hardwareDetails import (
     DefaultRecordValues,
     HardwareBuildHistoryItem,
-    HardwareTestHistoryItem,
     HardwareDetailsPostBody,
+    HardwareTestHistoryItem,
+    PossibleTestType,
     Tree,
 )
 from kernelCI_app.typeModels.issues import Issue, IssueDict
@@ -53,10 +56,6 @@ from kernelCI_app.utils import (
     extract_error_message,
     is_boot,
     sanitize_dict,
-)
-from pydantic import ValidationError
-from kernelCI_app.typeModels.hardwareDetails import (
-    PossibleTestType,
 )
 
 

--- a/backend/kernelCI_app/helpers/issueExtras.py
+++ b/backend/kernelCI_app/helpers/issueExtras.py
@@ -1,15 +1,15 @@
 from collections import defaultdict
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 from kernelCI_app.constants.general import UNCATEGORIZED_STRING
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.queries.issues import get_issue_first_seen_data, get_issue_trees_data
 from kernelCI_app.typeModels.issues import (
     ExtraIssuesData,
+    FirstIncident,
     IssueWithExtraInfo,
     ProcessedExtraDetailedIssues,
     TreeSetItem,
-    FirstIncident,
 )
 
 

--- a/backend/kernelCI_app/helpers/logger.py
+++ b/backend/kernelCI_app/helpers/logger.py
@@ -1,9 +1,10 @@
+import logging
 import time
+
 from django.http import HttpRequest
 
 from kernelCI_app.constants.general import PRODUCTION_HOST, STAGING_HOST
 from kernelCI_app.helpers.system import get_running_instance
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/backend/kernelCI_app/helpers/misc.py
+++ b/backend/kernelCI_app/helpers/misc.py
@@ -1,4 +1,5 @@
-from typing import Union, TypedDict, Optional
+from typing import Optional, TypedDict, Union
+
 from kernelCI_app.helpers.filters import UNKNOWN_STRING
 from kernelCI_app.utils import sanitize_dict
 

--- a/backend/kernelCI_app/helpers/system.py
+++ b/backend/kernelCI_app/helpers/system.py
@@ -1,4 +1,5 @@
 from typing import Literal
+
 from django.conf import settings
 
 from kernelCI_app.constants.general import PRODUCTION_HOST

--- a/backend/kernelCI_app/helpers/treeDetails.py
+++ b/backend/kernelCI_app/helpers/treeDetails.py
@@ -1,28 +1,32 @@
 from collections.abc import Callable
 from typing import Any, Optional, TypedDict
-from kernelCI_app.constants.general import UNCATEGORIZED_STRING
+
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING, UNKNOWN_STRING
 from kernelCI_app.helpers.commonDetails import PossibleTabs, add_unfiltered_issue
-from kernelCI_app.typeModels.common import StatusCount
-from kernelCI_app.typeModels.commonDetails import BuildHistoryItem
 from kernelCI_app.helpers.filters import (
     is_status_failure,
     should_increment_build_issue,
     should_increment_test_issue,
 )
-from kernelCI_app.constants.general import UNKNOWN_STRING
+from kernelCI_app.helpers.misc import (
+    get_environment_misc_value,
+    handle_misc,
+    misc_value_or_default,
+)
+from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.commonDetails import BuildHistoryItem
 from kernelCI_app.typeModels.databases import (
     FAIL_STATUS,
     NULL_STATUS,
     build_fail_status_list,
 )
 from kernelCI_app.typeModels.issues import Issue, IssueDict
-from kernelCI_app.utils import create_issue_typed, extract_error_message, sanitize_dict
-from kernelCI_app.helpers.misc import (
-    get_environment_misc_value,
-    handle_misc,
-    misc_value_or_default,
+from kernelCI_app.utils import (
+    create_issue_typed,
+    extract_error_message,
+    is_boot,
+    sanitize_dict,
 )
-from kernelCI_app.utils import is_boot
 
 
 class CheckoutWhereClauses(TypedDict):

--- a/backend/kernelCI_app/helpers/treeDetailsRollup.py
+++ b/backend/kernelCI_app/helpers/treeDetailsRollup.py
@@ -1,5 +1,5 @@
-from kernelCI_app.constants.process_pending import ROLLUP_STATUS_FIELDS
 from kernelCI_app.constants.general import UNCATEGORIZED_STRING, UNKNOWN_STRING
+from kernelCI_app.constants.process_pending import ROLLUP_STATUS_FIELDS
 from kernelCI_app.helpers.commonDetails import PossibleTabs, add_unfiltered_issue
 from kernelCI_app.helpers.filters import (
     is_status_failure,

--- a/backend/kernelCI_app/helpers/trees.py
+++ b/backend/kernelCI_app/helpers/trees.py
@@ -1,13 +1,14 @@
 import json
 import os
-import typing_extensions
 
-from django.conf import settings
+import typing_extensions
 import yaml
+from django.conf import settings
+
+from kernelCI_app.constants.tree_names import TREE_NAMES_FILENAME
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.treeListing import Checkout
-from kernelCI_app.constants.tree_names import TREE_NAMES_FILENAME
 
 
 def make_tree_identifier_key(

--- a/backend/kernelCI_app/management/commands/backfill_hardware_aggregations.py
+++ b/backend/kernelCI_app/management/commands/backfill_hardware_aggregations.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from django.db.models.query import QuerySet
 from django.utils import timezone
 
+from kernelCI_app.helpers.logger import out
 from kernelCI_app.management.commands.helpers.aggregation_helpers import (
     aggregate_checkouts,
     aggregate_tests,
@@ -17,7 +18,6 @@ from kernelCI_app.models import (
     PendingTest,
     Tests,
 )
-from kernelCI_app.helpers.logger import out
 
 
 class Command(BaseCommand):

--- a/backend/kernelCI_app/management/commands/delete_unused_hardware_status.py
+++ b/backend/kernelCI_app/management/commands/delete_unused_hardware_status.py
@@ -5,8 +5,10 @@ Removes HardwareStatus entries that have no corresponding checkout_id in the Lat
 """
 
 import logging
+
 from django.core.management.base import BaseCommand
 from django.db import transaction
+
 from kernelCI_app.management.commands.helpers.healthcheck import (
     MONITORING_ID_PARAM_HELP_TEXT,
     run_with_healthcheck_monitoring,

--- a/backend/kernelCI_app/management/commands/generate_insert_queries.py
+++ b/backend/kernelCI_app/management/commands/generate_insert_queries.py
@@ -1,8 +1,10 @@
-from django.core.management.base import BaseCommand
-from kernelCI_app.typeModels.modelTypes import MODEL_MAP
 import os
 from datetime import datetime
+
+from django.core.management.base import BaseCommand
 from jinja2 import Template
+
+from kernelCI_app.typeModels.modelTypes import MODEL_MAP
 
 
 class Command(BaseCommand):

--- a/backend/kernelCI_app/management/commands/generate_insert_queries.py
+++ b/backend/kernelCI_app/management/commands/generate_insert_queries.py
@@ -59,19 +59,19 @@ class Command(BaseCommand):
                 )
 
             query = f"""
-                INSERT INTO {table_name} ({','.join(updateable_db_fields_clauses)}
+                INSERT INTO {table_name} ({",".join(updateable_db_fields_clauses)}
                 )
                 VALUES (
-                    {', '.join(['%s'] * len(updateable_db_fields))}
+                    {", ".join(["%s"] * len(updateable_db_fields))}
                 )
                 ON CONFLICT (id)
-                DO UPDATE SET{','.join(conflict_clauses)};
+                DO UPDATE SET{",".join(conflict_clauses)};
             """
 
             var_insert_queries[table_name] = {}
-            var_insert_queries[table_name][
-                "updateable_model_fields"
-            ] = updateable_model_fields
+            var_insert_queries[table_name]["updateable_model_fields"] = (
+                updateable_model_fields
+            )
             var_insert_queries[table_name]["query"] = query
 
         # Read the template file

--- a/backend/kernelCI_app/management/commands/helpers/aggregation_helpers.py
+++ b/backend/kernelCI_app/management/commands/helpers/aggregation_helpers.py
@@ -1,21 +1,21 @@
 import time
 from typing import Optional, Sequence
 
-
 from django.db import connections
+
 from kernelCI_app.helpers.logger import out
 from kernelCI_app.management.commands.helpers.tree_listing import (
     CheckoutRow,
     tree_listing_sort_key,
 )
 from kernelCI_app.models import (
-    Checkouts,
-    PendingTest,
-    PendingBuilds,
-    StatusChoices,
-    SimplifiedStatusChoices,
-    Tests,
     Builds,
+    Checkouts,
+    PendingBuilds,
+    PendingTest,
+    SimplifiedStatusChoices,
+    StatusChoices,
+    Tests,
 )
 from kernelCI_app.utils import is_boot
 

--- a/backend/kernelCI_app/management/commands/helpers/common.py
+++ b/backend/kernelCI_app/management/commands/helpers/common.py
@@ -2,13 +2,12 @@ import os
 from typing import Optional
 
 from django.conf import settings
+from jinja2 import Environment, FileSystemLoader, Template
 
 from kernelCI_app.helpers.email import smtp_send_email
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.management.commands.helpers.summary import SIGNUP_FOLDER
 from kernelCI_app.utils import read_yaml_file
-from jinja2 import Environment, FileSystemLoader, Template
-
 
 KERNELCI_RESULTS = "kernelci-results@groups.io"
 KERNELCI_REPLYTO = "kernelci@lists.linux.dev"

--- a/backend/kernelCI_app/management/commands/helpers/file_utils.py
+++ b/backend/kernelCI_app/management/commands/helpers/file_utils.py
@@ -1,9 +1,9 @@
+import logging
 import os
 from typing import Optional
-import logging
+
 from kernelCI_app.constants.ingester import INGESTER_TREES_FILEPATH
 from kernelCI_app.management.commands.treeproof import Command as TreeproofCommand
-
 
 logger = logging.getLogger("ingester")
 

--- a/backend/kernelCI_app/management/commands/helpers/healthcheck.py
+++ b/backend/kernelCI_app/management/commands/helpers/healthcheck.py
@@ -4,7 +4,6 @@ from typing import Any, Literal
 from django.conf import settings
 
 import requests
-
 from kernelCI_app.helpers.logger import log_message
 
 MONITORING_ID_PARAM_HELP_TEXT = (

--- a/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
+++ b/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
@@ -418,7 +418,7 @@ def process_batch(
             counter_lock=counter_lock,
         )
 
-    if any(len(instances_dict[table]) for table in instances_dict):  # type: ignore
+    if any(len(instances_dict[table]) for table in instances_dict):
         out("Process finished, flushing remaining buffers")
         flush_buffers(
             issues_buf=instances_dict["issues"],

--- a/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
+++ b/backend/kernelCI_app/management/commands/helpers/kcidbng_ingester.py
@@ -1,11 +1,19 @@
-import multiprocessing
-from multiprocessing.sharedctypes import Synchronized
-from multiprocessing.synchronize import Lock as ProcessLock
 import json
 import logging
+import multiprocessing
 import os
+import time
+import traceback
+from multiprocessing.sharedctypes import Synchronized
+from multiprocessing.synchronize import Lock as ProcessLock
 from queue import Queue
+from typing import Any, Optional, TypedDict
+
+import kcidb_io
+from django.db import connections, transaction
+from prometheus_client import Counter
 from typing_extensions import Literal
+
 from kernelCI_app.constants.ingester import (
     AUTOMATIC_LAB_FIELD,
     AUTOMATIC_LABS,
@@ -16,29 +24,21 @@ from kernelCI_app.constants.ingester import (
     INGESTER_GRAFANA_LABEL,
     VERBOSE,
 )
-import time
-import traceback
-from typing import Any, Optional, TypedDict
 from kernelCI_app.helpers.logger import out
 from kernelCI_app.management.commands.generated.insert_queries import INSERT_QUERIES
+from kernelCI_app.management.commands.helpers.aggregation_helpers import (
+    aggregate_checkouts_and_pendings,
+)
 from kernelCI_app.management.commands.helpers.file_utils import move_file_to_failed_dir
 from kernelCI_app.management.commands.helpers.log_excerpt_utils import (
     extract_log_excerpt,
 )
-import kcidb_io
-from kernelCI_app.management.commands.helpers.aggregation_helpers import (
-    aggregate_checkouts_and_pendings,
-)
-from django.db import connections, transaction
-from kernelCI_app.models import Issues, Checkouts, Builds, Tests, Incidents
-
 from kernelCI_app.management.commands.helpers.process_submissions import (
     TableNames,
     build_instances_from_submission,
 )
+from kernelCI_app.models import Builds, Checkouts, Incidents, Issues, Tests
 from kernelCI_app.typeModels.modelTypes import TableModels
-
-from prometheus_client import Counter
 
 type INGESTER_DIRS = Literal["archive", "failed", "pending_retry"]
 

--- a/backend/kernelCI_app/management/commands/helpers/log_excerpt_utils.py
+++ b/backend/kernelCI_app/management/commands/helpers/log_excerpt_utils.py
@@ -2,19 +2,19 @@ import gzip
 import hashlib
 import logging
 import os
-import requests
 import tempfile
 import threading
 from typing import Any, Literal, Optional
+
+import requests
 from kernelCI_app.constants.ingester import (
     CACHE_LOGS_SIZE_LIMIT,
     LOGEXCERPT_THRESHOLD,
-    STORAGE_TOKEN,
     STORAGE_BASE_URL,
+    STORAGE_TOKEN,
     UPLOAD_URL,
     VERBOSE,
 )
-
 
 CACHE_LOGS = {}
 cache_logs_lock = threading.Lock()

--- a/backend/kernelCI_app/management/commands/helpers/process_pending_helpers.py
+++ b/backend/kernelCI_app/management/commands/helpers/process_pending_helpers.py
@@ -1,9 +1,9 @@
 from typing import NamedTuple, Optional, Sequence, TypedDict
-from kernelCI_app.helpers.logger import logger
+
 from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.constants.process_pending import ROLLUP_STATUS_FIELDS
+from kernelCI_app.helpers.logger import logger
 from kernelCI_app.models import Builds, Checkouts, PendingTest, StatusChoices
-
 
 EMPTY_PATH_GROUP = "-"
 

--- a/backend/kernelCI_app/management/commands/helpers/process_submissions.py
+++ b/backend/kernelCI_app/management/commands/helpers/process_submissions.py
@@ -1,15 +1,14 @@
 import logging
-from django.utils import timezone
 from typing import Any, TypedDict
 
 from django.db import IntegrityError
-
-from kernelCI_app.constants.ingester import INGESTER_GRAFANA_LABEL
+from django.utils import timezone
+from prometheus_client import Counter
 from pydantic import ValidationError
 
+from kernelCI_app.constants.ingester import INGESTER_GRAFANA_LABEL
 from kernelCI_app.models import Builds, Checkouts, Incidents, Issues, Tests
 from kernelCI_app.typeModels.modelTypes import TableNames
-from prometheus_client import Counter
 
 
 class ProcessedSubmission(TypedDict):

--- a/backend/kernelCI_app/management/commands/helpers/summary.py
+++ b/backend/kernelCI_app/management/commands/helpers/summary.py
@@ -1,17 +1,17 @@
 import os
+from collections import defaultdict
 from typing import Any, Literal, Optional
 
 from django.conf import settings
+
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
+from kernelCI_app.helpers.issueExtras import assign_issue_first_seen
 from kernelCI_app.helpers.logger import log_message
-from kernelCI_app.utils import read_yaml_file
-from collections import defaultdict
-from kernelCI_app.typeModels.issues import CheckoutIssue
 from kernelCI_app.queries.notifications import (
     get_issues_summary_data,
 )
-from kernelCI_app.helpers.issueExtras import assign_issue_first_seen
-from kernelCI_app.typeModels.issues import ProcessedExtraDetailedIssues
+from kernelCI_app.typeModels.issues import CheckoutIssue, ProcessedExtraDetailedIssues
+from kernelCI_app.utils import read_yaml_file
 
 type PossibleReportOptions = Literal["ignore_default_recipients"]
 """The expected possible options in a report. If a new option is added, add it here too."""

--- a/backend/kernelCI_app/management/commands/monitor_submissions.py
+++ b/backend/kernelCI_app/management/commands/monitor_submissions.py
@@ -1,14 +1,13 @@
 import argparse
+import logging
+import os
 import shutil
 import signal
-from django.core.management.base import BaseCommand
-import logging
 import time
-import os
-from kernelCI_app.management.commands.helpers.kcidbng_ingester import (
-    INGESTER_DIRS,
-    ingest_submissions_parallel,
-)
+
+from django.core.management.base import BaseCommand
+from prometheus_client import CollectorRegistry, Gauge, multiprocess, start_http_server
+
 from kernelCI_app.constants.ingester import (
     INGEST_CYCLE_BATCH_SIZE,
     INGESTER_GRAFANA_LABEL,
@@ -19,10 +18,13 @@ from kernelCI_app.management.commands.helpers.file_utils import (
     load_tree_names,
     verify_spool_dirs,
 )
+from kernelCI_app.management.commands.helpers.kcidbng_ingester import (
+    INGESTER_DIRS,
+    ingest_submissions_parallel,
+)
 from kernelCI_app.management.commands.helpers.log_excerpt_utils import (
     cache_logs_maintenance,
 )
-from prometheus_client import CollectorRegistry, Gauge, start_http_server, multiprocess
 
 logger = logging.getLogger(__name__)
 

--- a/backend/kernelCI_app/management/commands/monitor_submissions.py
+++ b/backend/kernelCI_app/management/commands/monitor_submissions.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
                 ]
             ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
             self.stdout.write(
-                f"[{ts}] Spool scan: {len(cached_paths)}" " .json files pending"
+                f"[{ts}] Spool scan: {len(cached_paths)} .json files pending"
             )
             return cached_paths
         except PermissionError:

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -1,49 +1,56 @@
-from typing import Optional
 import json
 import sys
-
 from collections import defaultdict
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Optional
 from urllib.parse import quote_plus
 
 from django.core.management.base import BaseCommand
 
+from kernelCI_app.helpers.email import smtp_setup_connection
+from kernelCI_app.helpers.hardwares import sanitize_hardware
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.helpers.system import get_running_instance
-
-from kernelCI_app.helpers.email import smtp_setup_connection
 from kernelCI_app.helpers.trees import sanitize_tree
 from kernelCI_app.management.commands.helpers.common import (
-    setup_jinja_template,
     send_email_report,
+    setup_jinja_template,
 )
 from kernelCI_app.management.commands.helpers.healthcheck import (
     MONITORING_ID_PARAM_HELP_TEXT,
     run_with_healthcheck_monitoring,
 )
-
 from kernelCI_app.management.commands.helpers.summary import (
     SIGNUP_FOLDER,
     PossibleReportOptions,
     ReportConfigs,
     TreeKey,
     get_build_issues_from_checkout,
-    process_submissions_files,
     process_hardware_submissions_files,
+    process_submissions_files,
+)
+from kernelCI_app.queries.hardware import (
+    get_hardware_listing_data_bulk,
+    get_hardware_summary_data,
 )
 from kernelCI_app.queries.notifications import (
     get_checkout_summary_data,
     get_metrics_data,
-    kcidb_new_issues,
-    kcidb_issue_details,
     kcidb_build_incidents,
-    kcidb_test_incidents,
+    kcidb_issue_details,
     kcidb_last_test_without_issue,
+    kcidb_new_issues,
+    kcidb_test_incidents,
     kcidb_tests_results,
 )
 from kernelCI_app.queries.test import get_test_details_data, get_test_status_history
 from kernelCI_app.typeModels.metrics_notifications import MetricsReportData
+from kernelCI_app.utils import group_status, is_boot
+from kernelCI_cache.queries.issues import (
+    get_all_issue_keys,
+    get_unsent_issues,
+)
 from kernelCI_cache.queries.notifications import (
     RESEND_INTERVAL,
     check_sent_notifications,
@@ -51,19 +58,7 @@ from kernelCI_cache.queries.notifications import (
     mark_issue_notification_not_sent,
     mark_issue_notification_sent,
 )
-from kernelCI_app.utils import is_boot
-from kernelCI_cache.queries.issues import (
-    get_all_issue_keys,
-    get_unsent_issues,
-)
 from kernelCI_cache.typeModels.databases import PossibleIssueType
-from kernelCI_app.utils import group_status
-
-from kernelCI_app.queries.hardware import (
-    get_hardware_summary_data,
-    get_hardware_listing_data_bulk,
-)
-from kernelCI_app.helpers.hardwares import sanitize_hardware
 
 
 def exclude_already_found_and_store(issues: list[dict]) -> list[dict]:

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -126,7 +126,7 @@ def look_for_new_issues(*, service, signup_folder, email_args):
     report["content"] = template.render(
         build_issues=new_build_issues, boot_issues=new_boot_issues
     )
-    report["title"] = f"new issues summary - {now.strftime("%Y-%m-%d %H:%M %Z")}"
+    report["title"] = f"new issues summary - {now.strftime('%Y-%m-%d %H:%M %Z')}"
 
     send_email_report(
         service=service,
@@ -168,7 +168,7 @@ def generate_build_issue_report(issue, incidents):
         else issue["comment"][:67] + "..."
     )
     report["title"] = (
-        f"[REGRESSION] {issue["tree_name"]}/{issue["git_repository_branch"]}: (build){snippet}"
+        f"[REGRESSION] {issue['tree_name']}/{issue['git_repository_branch']}: (build){snippet}"
     )
     return report
 
@@ -183,7 +183,7 @@ def generate_boot_issue_report(issue, incidents):
         else issue["comment"][:67] + "..."
     )
     report["title"] = (
-        f"[REGRESSION] {issue["tree_name"]}/{issue["git_repository_branch"]}: (boot){snippet}"
+        f"[REGRESSION] {issue['tree_name']}/{issue['git_repository_branch']}: (boot){snippet}"
     )
     return report
 
@@ -208,7 +208,7 @@ def generate_issue_report(
     issue_tree_name = issue["tree_name"]
 
     print("=====================")
-    print(f"# {issue_tree_name}/{issue["git_repository_branch"]} - {timestamp}")
+    print(f"# {issue_tree_name}/{issue['git_repository_branch']} - {timestamp}")
     print(f"  comment: {comment}")
     print(f"  dashboard: https://d.kernelci.org/issue/{issue_id}")
 
@@ -347,17 +347,17 @@ def evaluate_test_results(
                     category = categorize_test_history(test_group)
 
                     if category == "regression":
-                        new_issues[platform][config_name][arch_compiler][
-                            path
-                        ] = test_group
+                        new_issues[platform][config_name][arch_compiler][path] = (
+                            test_group
+                        )
                     elif category == "fixed":
-                        fixed_issues[platform][config_name][arch_compiler][
-                            path
-                        ] = test_group
+                        fixed_issues[platform][config_name][arch_compiler][path] = (
+                            test_group
+                        )
                     else:
-                        unstable_tests[platform][config_name][arch_compiler][
-                            path
-                        ] = test_group
+                        unstable_tests[platform][config_name][arch_compiler][path] = (
+                            test_group
+                        )
 
     return new_issues, fixed_issues, unstable_tests
 
@@ -499,7 +499,7 @@ def run_checkout_summary(
             )
             origin_tag = f"[{origin.upper()}]" if origin != "maestro" else ""
             report["title"] = (
-                f"[STATUS]{origin_tag} {tree_name}/{branch} - {record["git_commit_hash"]}"
+                f"[STATUS]{origin_tag} {tree_name}/{branch} - {record['git_commit_hash']}"
             )
 
             recipients = process_submission_options(
@@ -672,7 +672,7 @@ def generate_hardware_summary_report(
             environment_misc = json.loads(raw.get("environment_misc", "{}"))
             misc = json.loads(raw.get("misc", "{}"))
         except json.JSONDecodeError:
-            print(f'Error decoding JSON for key: {raw.get("environment_misc")}')
+            print(f"Error decoding JSON for key: {raw.get('environment_misc')}")
             continue
         hardware_id = environment_misc.get("platform")
         raw["job_id"] = environment_misc.get("job_id")
@@ -730,7 +730,7 @@ def generate_hardware_summary_report(
             test_status_group_all=test_status_group_all,
         )
         report["title"] = (
-            f"hardware {hardware_id} summary - {now.strftime("%Y-%m-%d %H:%M %Z")}"
+            f"hardware {hardware_id} summary - {now.strftime('%Y-%m-%d %H:%M %Z')}"
         )
 
         # Extract recipient

--- a/backend/kernelCI_app/management/commands/process_pending_aggregations.py
+++ b/backend/kernelCI_app/management/commands/process_pending_aggregations.py
@@ -5,32 +5,32 @@ import signal
 import time
 from datetime import datetime
 from typing import Literal, Optional, Sequence, TypedDict, Union
-from kernelCI_app.management.commands.helpers.process_pending_helpers import (
-    aggregate_tests_rollup,
-)
+
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import connection, transaction
+from prometheus_client import Counter, start_http_server
+
 from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
+from kernelCI_app.constants.ingester import PROMETHEUS_MULTIPROC_DIR
 from kernelCI_app.helpers.logger import out
 from kernelCI_app.management.commands.helpers.aggregation_helpers import simplify_status
+from kernelCI_app.management.commands.helpers.process_pending_helpers import (
+    aggregate_tests_rollup,
+)
 from kernelCI_app.management.commands.helpers.tree_listing import (
     TreeListingRow,
     tree_listing_sort_key,
 )
-from kernelCI_app.constants.ingester import PROMETHEUS_MULTIPROC_DIR
-from prometheus_client import start_http_server
 from kernelCI_app.models import (
     Builds,
     Checkouts,
     Incidents,
-    PendingTest,
     PendingBuilds,
+    PendingTest,
     ProcessedListingItems,
     SimplifiedStatusChoices,
 )
-
-from prometheus_client import Counter
 
 AGGREGATION_RECORDS_WRITTEN = Counter(
     "aggregation_records_written_total",

--- a/backend/kernelCI_app/management/commands/refresh_metrics_email_example.py
+++ b/backend/kernelCI_app/management/commands/refresh_metrics_email_example.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+
 from kernelCI_app.tests.unitTests.commands.fixtures.metrics_notifications_data import (
     METRICS_NOTIFICATIONS_EXAMPLE_FILEPATH,
 )

--- a/backend/kernelCI_app/management/commands/seed_test_data.py
+++ b/backend/kernelCI_app/management/commands/seed_test_data.py
@@ -3,31 +3,33 @@ Management command to seed test database with realistic data.
 """
 
 import sys
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
 from kernelCI_app.constants.general import UNKNOWN_STRING
+from kernelCI_app.helpers.system import get_running_instance
 from kernelCI_app.management.commands.helpers.process_pending_helpers import (
     accumulate_rollup_entry,
     extract_path_group,
 )
-from django.core.management.base import BaseCommand
-from django.db import transaction
-from kernelCI_app.tests.factories import (
-    CheckoutFactory,
-    BuildFactory,
-    TestFactory,
-    IssueFactory,
-    IncidentFactory,
-)
 from kernelCI_app.models import (
-    Issues,
-    Tests,
     Builds,
     Checkouts,
     Incidents,
-    TreeTestsRollup,
+    Issues,
     StatusChoices,
+    Tests,
+    TreeTestsRollup,
+)
+from kernelCI_app.tests.factories import (
+    BuildFactory,
+    CheckoutFactory,
+    IncidentFactory,
+    IssueFactory,
+    TestFactory,
 )
 from kernelCI_app.tests.factories.mocks import Build, Issue, Test
-from kernelCI_app.helpers.system import get_running_instance
 
 
 class Command(BaseCommand):

--- a/backend/kernelCI_app/management/commands/treeproof.py
+++ b/backend/kernelCI_app/management/commands/treeproof.py
@@ -1,12 +1,14 @@
 import logging
+import os
+import re
 from typing import Optional
+
+import yaml
+from django.conf import settings
 from django.core.management.base import BaseCommand
+
 from kernelCI_app.constants.tree_names import TREE_NAMES_FILENAME
 from kernelCI_app.models import Checkouts
-import re
-import yaml
-import os
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 

--- a/backend/kernelCI_app/management/commands/treeproof.py
+++ b/backend/kernelCI_app/management/commands/treeproof.py
@@ -76,8 +76,8 @@ class Command(BaseCommand):
 
             origin_trees[tree_name] = git_url
 
-    def _merge_trees(self, default_trees: dict = {}):
-        merged_trees = default_trees
+    def _merge_trees(self, default_trees: dict | None = None):
+        merged_trees = default_trees if default_trees is not None else {}
 
         for tree, git_url in self.maestro_trees.items():
             tree_in_dict = tree in merged_trees

--- a/backend/kernelCI_app/management/commands/update_db.py
+++ b/backend/kernelCI_app/management/commands/update_db.py
@@ -179,7 +179,7 @@ class Command(BaseCommand):
         related_ids = set(values)
 
         related_condition = (
-            f"AND {field_name} IN ({",".join(["%s"] * len(related_ids))})"
+            f"AND {field_name} IN ({','.join(['%s'] * len(related_ids))})"
         )
 
         return related_ids, related_condition

--- a/backend/kernelCI_app/management/commands/update_db.py
+++ b/backend/kernelCI_app/management/commands/update_db.py
@@ -1,12 +1,14 @@
 import json
+import logging
+from datetime import datetime, timedelta
 from typing import Generator
+
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connections, models
-import logging
-from django.conf import settings
-from kernelCI_app.models import Issues, Checkouts, Builds, Tests, Incidents
-from datetime import datetime, timedelta
 from django.utils import timezone
+
+from kernelCI_app.models import Builds, Checkouts, Incidents, Issues, Tests
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +89,7 @@ class Command(BaseCommand):
             "--origins",
             type=lambda s: [origin.strip() for origin in s.split(",")],
             help="Limit database changes to specific origins (comma-separated list)."
-            + " If not provided, any origin will be considered",
+             " If not provided, any origin will be considered",
             default=[],
         )
 

--- a/backend/kernelCI_app/management/commands/update_db.py
+++ b/backend/kernelCI_app/management/commands/update_db.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
             "--origins",
             type=lambda s: [origin.strip() for origin in s.split(",")],
             help="Limit database changes to specific origins (comma-separated list)."
-             " If not provided, any origin will be considered",
+            " If not provided, any origin will be considered",
             default=[],
         )
 

--- a/backend/kernelCI_app/management/commands/verify_env.py
+++ b/backend/kernelCI_app/management/commands/verify_env.py
@@ -13,12 +13,10 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connections
 from django.db.utils import OperationalError
-
 from redis import Redis
 from redis.exceptions import RedisError
 
 from kernelCI_app.helpers.email import smtp_send_email, smtp_setup_connection
-
 
 DEFAULT_REDIS_TIMEOUT_SECONDS = 5
 

--- a/backend/kernelCI_app/middleware/logServerErrorMiddleware.py
+++ b/backend/kernelCI_app/middleware/logServerErrorMiddleware.py
@@ -1,7 +1,8 @@
 import json
 from http import HTTPStatus
-from kernelCI_app.helpers.logger import create_endpoint_notification
+
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
+from kernelCI_app.helpers.logger import create_endpoint_notification
 
 REASON_MAX_LEN = 500
 

--- a/backend/kernelCI_app/migrations/0001_initial.py
+++ b/backend/kernelCI_app/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/backend/kernelCI_app/migrations/0002_remove_fk_constraint.py
+++ b/backend/kernelCI_app/migrations/0002_remove_fk_constraint.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0001_initial"),
     ]

--- a/backend/kernelCI_app/migrations/0003_add_build_series_field.py
+++ b/backend/kernelCI_app/migrations/0003_add_build_series_field.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0002_remove_fk_constraint"),
     ]

--- a/backend/kernelCI_app/migrations/0010_add_hardware_denormalization_models.py
+++ b/backend/kernelCI_app/migrations/0010_add_hardware_denormalization_models.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0009_add_test_origin_start_time_platform_index"),
     ]

--- a/backend/kernelCI_app/migrations/0011_modify_latest_checkout_primary_key.py
+++ b/backend/kernelCI_app/migrations/0011_modify_latest_checkout_primary_key.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0010_add_hardware_denormalization_models"),
     ]

--- a/backend/kernelCI_app/migrations/0012_rename_processedhardwarestatus.py
+++ b/backend/kernelCI_app/migrations/0012_rename_processedhardwarestatus.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0011_modify_latest_checkout_primary_key"),
     ]

--- a/backend/kernelCI_app/migrations/0013_pendingbuilds_treelisting.py
+++ b/backend/kernelCI_app/migrations/0013_pendingbuilds_treelisting.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0012_rename_processedhardwarestatus"),
     ]

--- a/backend/kernelCI_app/migrations/0014_add_processed_and_pending_status.py
+++ b/backend/kernelCI_app/migrations/0014_add_processed_and_pending_status.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0013_pendingbuilds_treelisting"),
     ]

--- a/backend/kernelCI_app/migrations/0015_alter_pendingtest_platform.py
+++ b/backend/kernelCI_app/migrations/0015_alter_pendingtest_platform.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0014_add_processed_and_pending_status"),
     ]

--- a/backend/kernelCI_app/migrations/0016_alter_treelisting_unique_constraint.py
+++ b/backend/kernelCI_app/migrations/0016_alter_treelisting_unique_constraint.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0015_alter_pendingtest_platform"),
     ]

--- a/backend/kernelCI_app/migrations/0017_add_tree_tests_rollup_table.py
+++ b/backend/kernelCI_app/migrations/0017_add_tree_tests_rollup_table.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_app", "0016_alter_treelisting_unique_constraint"),
     ]

--- a/backend/kernelCI_app/models.py
+++ b/backend/kernelCI_app/models.py
@@ -1,12 +1,12 @@
 """Defines the models used in the main database.
 All models should have explicit id column for the ingester to work properly."""
 
-from django.db import models
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
+from django.db import models
 from django.db.models import F, Q
-from django.db.models.functions import Concat, MD5
 from django.db.models.expressions import RawSQL
+from django.db.models.functions import MD5, Concat
 
 
 class StatusChoices(models.TextChoices):

--- a/backend/kernelCI_app/queries/build.py
+++ b/backend/kernelCI_app/queries/build.py
@@ -1,7 +1,9 @@
 from typing import Optional
-from querybuilder.query import Query
-from kernelCI_app.models import Builds, Tests
+
 from django.db.models.expressions import F
+from querybuilder.query import Query
+
+from kernelCI_app.models import Builds, Tests
 
 
 def get_build_details(build_id: str) -> Optional[list[dict]]:

--- a/backend/kernelCI_app/queries/checkout.py
+++ b/backend/kernelCI_app/queries/checkout.py
@@ -1,4 +1,5 @@
 from django.db import connection
+
 from kernelCI_app.cache import get_query_cache, set_query_cache
 from kernelCI_app.helpers.database import dict_fetchall
 

--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -1,9 +1,10 @@
-from typing import Optional, TypedDict
 from datetime import datetime
+from typing import Optional, TypedDict
+
 from django.db import connection
 
-from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.cache import get_query_cache, set_query_cache
+from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.typeModels.hardwareDetails import CommitHead, Tree
 
 

--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -340,7 +340,7 @@ def get_hardware_details_data(
 
 
 def _get_build_duration_clause(
-    builds_duration: tuple[Optional[int], Optional[int]]
+    builds_duration: tuple[Optional[int], Optional[int]],
 ) -> str:
     clause = ""
 
@@ -615,9 +615,7 @@ def query_records(
                 AND checkouts.git_commit_hash IN ({0})
             ORDER BY
                 issues."_timestamp" DESC
-            """.format(
-        ",".join(["%s"] * len(commit_hashes))
-    )
+            """.format(",".join(["%s"] * len(commit_hashes)))
 
     params = [
         hardware_id,
@@ -971,7 +969,7 @@ def get_hardware_commit_history(
                     c.git_repository_url,
                     c.git_repository_branch,
                     c.git_commit_hash
-                ) IN {commit_heads_params['tuple_str']}
+                ) IN {commit_heads_params["tuple_str"]}
                 AND c.origin = %(origin)s
             ORDER BY
                 tree_name,

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Any, Optional
+
 from django.db import connection, connections
+
 from kernelCI_app.cache import get_query_cache, set_query_cache
 from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.models import Issues

--- a/backend/kernelCI_app/queries/notifications.py
+++ b/backend/kernelCI_app/queries/notifications.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 import sys
 
 from django.db import connection, connections
@@ -29,7 +26,7 @@ def kcidb_execute_query(query, params=None):
             col_names = [desc[0] for desc in cur.description]
             result = []
             for row in rows:
-                row_dict = dict(zip(col_names, row))
+                row_dict = dict(zip(col_names, row, strict=False))
                 result.append(row_dict)
 
             return result

--- a/backend/kernelCI_app/queries/notifications.py
+++ b/backend/kernelCI_app/queries/notifications.py
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import sys
+
 from django.db import connection, connections
+from pydantic import ValidationError
 
 from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.logger import out
@@ -13,7 +15,6 @@ from kernelCI_app.typeModels.metrics_notifications import (
     MetricsReportData,
     TopIssue,
 )
-from pydantic import ValidationError
 
 
 def kcidb_execute_query(query, params=None):

--- a/backend/kernelCI_app/queries/test.py
+++ b/backend/kernelCI_app/queries/test.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from django.db import connection
+
 from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.models import Tests
 from kernelCI_app.typeModels.databases import (

--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -1,12 +1,13 @@
 from typing import Literal, Optional
+
 from django.db import connection
 from django.db.models import Q
 
+from kernelCI_app.cache import get_query_cache, set_query_cache
 from kernelCI_app.helpers.database import dict_fetchall
+from kernelCI_app.helpers.treeDetails import create_checkouts_where_clauses
 from kernelCI_app.models import Checkouts
 from kernelCI_app.utils import get_query_time_interval
-from kernelCI_app.cache import get_query_cache, set_query_cache
-from kernelCI_app.helpers.treeDetails import create_checkouts_where_clauses
 
 
 def _get_tree_listing_count_clause() -> str:

--- a/backend/kernelCI_app/tasks.py
+++ b/backend/kernelCI_app/tasks.py
@@ -1,4 +1,8 @@
+from datetime import timedelta
+
 from django.conf import settings
+from django.utils.timezone import is_aware, make_aware, now
+
 from kernelCI_app.helpers.logger import out
 from kernelCI_app.models import Checkouts
 from kernelCI_app.queries.tree import (
@@ -8,8 +12,6 @@ from kernelCI_app.queries.tree import (
 from kernelCI_cache.checkouts import populate_checkouts_cache_db
 from kernelCI_cache.constants import NO_CACHE_ORIGINS, UNSTABLE_CHECKOUT_THRESHOLD
 from kernelCI_cache.queries.checkouts import get_cached_tree_listing_fast
-from datetime import timedelta
-from django.utils.timezone import now, make_aware, is_aware
 
 UPDATE_INTERVAL_IN_DAYS = 90
 

--- a/backend/kernelCI_app/tests/factories/__init__.py
+++ b/backend/kernelCI_app/tests/factories/__init__.py
@@ -2,14 +2,13 @@
 Factories for generating test data using factory-boy.
 """
 
-from .checkout_factory import CheckoutFactory
 from .build_factory import BuildFactory
-from .test_factory import TestFactory
-from .issue_factory import IssueFactory
+from .checkout_factory import CheckoutFactory
 from .incident_factory import IncidentFactory
+from .issue_factory import IssueFactory
+from .mocks import Build, Checkout, Issue, Test
+from .test_factory import TestFactory
 from .tree_tests_rollup_factory import TreeTestsRollupFactory
-
-from .mocks import Checkout, Build, Test, Issue
 
 __all__ = [
     "CheckoutFactory",

--- a/backend/kernelCI_app/tests/factories/build_factory.py
+++ b/backend/kernelCI_app/tests/factories/build_factory.py
@@ -3,9 +3,11 @@ Factory for generating Build test data.
 """
 
 import factory
-from factory.django import DjangoModelFactory
 from django.utils import timezone
+from factory.django import DjangoModelFactory
+
 from kernelCI_app.models import Builds, StatusChoices
+
 from .checkout_factory import CheckoutFactory
 from .mocks import Build, Checkout
 

--- a/backend/kernelCI_app/tests/factories/build_factory.py
+++ b/backend/kernelCI_app/tests/factories/build_factory.py
@@ -28,7 +28,7 @@ class BuildFactory(DjangoModelFactory):
 
     duration = factory.Faker("pyfloat", min_value=300.0, max_value=3600.0)
 
-    architecture = factory.LazyAttribute(lambda obj: ("x86_64"))
+    architecture = factory.LazyAttribute(lambda obj: "x86_64")
 
     command = factory.LazyAttribute(
         lambda obj: f"make ARCH={obj.architecture} defconfig all"
@@ -57,13 +57,15 @@ class BuildFactory(DjangoModelFactory):
         ]
     )
 
-    config_name = factory.LazyAttribute(lambda obj: ("defconfig"))
+    config_name = factory.LazyAttribute(lambda obj: "defconfig")
 
     config_url = factory.LazyAttribute(
         lambda obj: f"https://configs.kernelci.org/{obj.origin}/{obj.config_name}"
     )
     log_url = factory.LazyAttribute(
-        lambda obj: f"https://logs.kernelci.org/{obj.origin}/{obj.checkout.git_commit_hash[:8]}/{obj.id}.log"
+        lambda obj: (
+            f"https://logs.kernelci.org/{obj.origin}/{obj.checkout.git_commit_hash[:8]}/{obj.id}.log"
+        )
     )
     log_excerpt = factory.Faker("text", max_nb_chars=2000)
 

--- a/backend/kernelCI_app/tests/factories/checkout_factory.py
+++ b/backend/kernelCI_app/tests/factories/checkout_factory.py
@@ -106,7 +106,9 @@ class CheckoutFactory(DjangoModelFactory):
     )
 
     log_url = factory.LazyAttribute(
-        lambda obj: f"https://logs.kernelci.org/{obj.origin}/{obj.git_commit_hash[:8]}.log"
+        lambda obj: (
+            f"https://logs.kernelci.org/{obj.origin}/{obj.git_commit_hash[:8]}.log"
+        )
     )
 
     log_excerpt = factory.Faker("text", max_nb_chars=1000)

--- a/backend/kernelCI_app/tests/factories/checkout_factory.py
+++ b/backend/kernelCI_app/tests/factories/checkout_factory.py
@@ -3,9 +3,11 @@ Factory for generating Checkout test data.
 """
 
 import factory
-from factory.django import DjangoModelFactory
 from django.utils import timezone
+from factory.django import DjangoModelFactory
+
 from kernelCI_app.models import Checkouts
+
 from .mocks import Checkout
 
 

--- a/backend/kernelCI_app/tests/factories/incident_factory.py
+++ b/backend/kernelCI_app/tests/factories/incident_factory.py
@@ -3,11 +3,13 @@ Factory for generating Incident test data.
 """
 
 import factory
-from factory.django import DjangoModelFactory
 from django.utils import timezone
+from factory.django import DjangoModelFactory
+
 from kernelCI_app.models import Incidents
-from .issue_factory import IssueFactory
+
 from .build_factory import BuildFactory
+from .issue_factory import IssueFactory
 from .test_factory import TestFactory
 
 

--- a/backend/kernelCI_app/tests/factories/issue_factory.py
+++ b/backend/kernelCI_app/tests/factories/issue_factory.py
@@ -31,7 +31,7 @@ class IssueFactory(DjangoModelFactory):
         )
     )
 
-    origin = factory.Sequence(lambda n: (f"origin-fake-{n:08x}"))
+    origin = factory.Sequence(lambda n: f"origin-fake-{n:08x}")
 
     report_url = factory.LazyAttribute(
         lambda obj: f"https://reports.kernelci.org/{obj.origin}/{obj.id}.html"

--- a/backend/kernelCI_app/tests/factories/issue_factory.py
+++ b/backend/kernelCI_app/tests/factories/issue_factory.py
@@ -3,9 +3,11 @@ Factory for generating Issue test data.
 """
 
 import factory
-from factory.django import DjangoModelFactory
 from django.utils import timezone
+from factory.django import DjangoModelFactory
+
 from kernelCI_app.models import Issues
+
 from .mocks import Issue
 
 

--- a/backend/kernelCI_app/tests/factories/mocks/__init__.py
+++ b/backend/kernelCI_app/tests/factories/mocks/__init__.py
@@ -3,20 +3,19 @@ Mock data for test factories.
 This module contains all the test data classes used by the factories.
 """
 
-from .checkout import Checkout
 from .build import Build
-from .test import Test
-from .issue import Issue
-
+from .checkout import Checkout
 from .fixtures import (
-    TREE_DATA,
-    EXPECTED_BUILD_IDS,
+    BUILD_TEST_STATUS_RULES,
     CHECKOUT_BUILD_STATUS_RULES,
+    CHECKOUT_TEST_STATUS_RULES,
+    EXPECTED_BUILD_IDS,
     ISSUE_TEST_DATA,
     TEST_DATA,
-    BUILD_TEST_STATUS_RULES,
-    CHECKOUT_TEST_STATUS_RULES,
+    TREE_DATA,
 )
+from .issue import Issue
+from .test import Test
 
 __all__ = [
     "Checkout",

--- a/backend/kernelCI_app/tests/factories/mocks/build.py
+++ b/backend/kernelCI_app/tests/factories/mocks/build.py
@@ -2,7 +2,7 @@
 Build data management class.
 """
 
-from .fixtures import EXPECTED_BUILD_IDS, CHECKOUT_BUILD_STATUS_RULES
+from .fixtures import CHECKOUT_BUILD_STATUS_RULES, EXPECTED_BUILD_IDS
 
 
 class Build:

--- a/backend/kernelCI_app/tests/factories/mocks/fixtures/__init__.py
+++ b/backend/kernelCI_app/tests/factories/mocks/fixtures/__init__.py
@@ -3,10 +3,10 @@ Fixtures for test data.
 This module contains all the raw data used by the mock classes.
 """
 
-from .tree_data import TREE_DATA
-from .build_data import EXPECTED_BUILD_IDS, CHECKOUT_BUILD_STATUS_RULES
-from .test_data import TEST_DATA, BUILD_TEST_STATUS_RULES, CHECKOUT_TEST_STATUS_RULES
+from .build_data import CHECKOUT_BUILD_STATUS_RULES, EXPECTED_BUILD_IDS
 from .issue_data import ISSUE_TEST_DATA
+from .test_data import BUILD_TEST_STATUS_RULES, CHECKOUT_TEST_STATUS_RULES, TEST_DATA
+from .tree_data import TREE_DATA
 
 __all__ = [
     "TREE_DATA",

--- a/backend/kernelCI_app/tests/factories/mocks/fixtures/build_data.py
+++ b/backend/kernelCI_app/tests/factories/mocks/fixtures/build_data.py
@@ -135,7 +135,7 @@ EXPECTED_BUILD_IDS = {
         "architecture": "arm64",
         "status": "PASS",
         "config_name": "defconfig+lab-setup+arm64-chromebook"
-         "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
+        "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
     },
     "failed_tests_build": {
         "checkout_id": "failed_tests_checkout",

--- a/backend/kernelCI_app/tests/factories/mocks/fixtures/build_data.py
+++ b/backend/kernelCI_app/tests/factories/mocks/fixtures/build_data.py
@@ -135,7 +135,7 @@ EXPECTED_BUILD_IDS = {
         "architecture": "arm64",
         "status": "PASS",
         "config_name": "defconfig+lab-setup+arm64-chromebook"
-        + "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
+         "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
     },
     "failed_tests_build": {
         "checkout_id": "failed_tests_checkout",

--- a/backend/kernelCI_app/tests/factories/mocks/test.py
+++ b/backend/kernelCI_app/tests/factories/mocks/test.py
@@ -2,7 +2,7 @@
 Test data management class.
 """
 
-from .fixtures import TEST_DATA, BUILD_TEST_STATUS_RULES, CHECKOUT_TEST_STATUS_RULES
+from .fixtures import BUILD_TEST_STATUS_RULES, CHECKOUT_TEST_STATUS_RULES, TEST_DATA
 
 
 class Test:

--- a/backend/kernelCI_app/tests/factories/test_factory.py
+++ b/backend/kernelCI_app/tests/factories/test_factory.py
@@ -19,9 +19,9 @@ class TestFactory(DjangoModelFactory):
     class Meta:
         model = Tests
 
-    id = factory.Sequence(lambda n: (f"test_{n:08x}"))
+    id = factory.Sequence(lambda n: f"test_{n:08x}")
 
-    build = factory.LazyAttribute(lambda obj: (BuildFactory()))
+    build = factory.LazyAttribute(lambda obj: BuildFactory())
 
     # TODO: origin could be the origin of the test, not the build
     origin = factory.LazyAttribute(lambda obj: obj.build.origin)
@@ -70,8 +70,10 @@ class TestFactory(DjangoModelFactory):
     )
 
     log_url = factory.LazyAttribute(
-        lambda obj: "https://logs.kernelci.org/"
-        + f"{obj.origin}/{obj.build.checkout.git_commit_hash[:8]}/{obj.id}.log"
+        lambda obj: (
+            "https://logs.kernelci.org/"
+            + f"{obj.origin}/{obj.build.checkout.git_commit_hash[:8]}/{obj.id}.log"
+        )
     )
     log_excerpt = factory.Faker("text", max_nb_chars=1500)
 

--- a/backend/kernelCI_app/tests/factories/test_factory.py
+++ b/backend/kernelCI_app/tests/factories/test_factory.py
@@ -74,7 +74,7 @@ class TestFactory(DjangoModelFactory):
     log_url = factory.LazyAttribute(
         lambda obj: (
             "https://logs.kernelci.org/"
-             f"{obj.origin}/{obj.build.checkout.git_commit_hash[:8]}/{obj.id}.log"
+            f"{obj.origin}/{obj.build.checkout.git_commit_hash[:8]}/{obj.id}.log"
         )
     )
     log_excerpt = factory.Faker("text", max_nb_chars=1500)

--- a/backend/kernelCI_app/tests/factories/test_factory.py
+++ b/backend/kernelCI_app/tests/factories/test_factory.py
@@ -3,11 +3,13 @@ Factory for generating Test test data.
 """
 
 import factory
-from factory.django import DjangoModelFactory
 from django.utils import timezone
-from kernelCI_app.models import Tests, StatusChoices
+from factory.django import DjangoModelFactory
+
+from kernelCI_app.models import StatusChoices, Tests
+
 from .build_factory import BuildFactory
-from .mocks import Test, Checkout
+from .mocks import Checkout, Test
 
 
 class TestFactory(DjangoModelFactory):
@@ -72,7 +74,7 @@ class TestFactory(DjangoModelFactory):
     log_url = factory.LazyAttribute(
         lambda obj: (
             "https://logs.kernelci.org/"
-            + f"{obj.origin}/{obj.build.checkout.git_commit_hash[:8]}/{obj.id}.log"
+             f"{obj.origin}/{obj.build.checkout.git_commit_hash[:8]}/{obj.id}.log"
         )
     )
     log_excerpt = factory.Faker("text", max_nb_chars=1500)

--- a/backend/kernelCI_app/tests/factories/tree_tests_rollup_factory.py
+++ b/backend/kernelCI_app/tests/factories/tree_tests_rollup_factory.py
@@ -4,6 +4,7 @@ Factory for generating TreeTestsRollup test data.
 
 import factory
 from factory.django import DjangoModelFactory
+
 from kernelCI_app.models import TreeTestsRollup
 
 

--- a/backend/kernelCI_app/tests/integrationTests/buildDetails_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/buildDetails_test.py
@@ -1,17 +1,18 @@
-from kernelCI_app.tests.utils.client.buildClient import BuildClient
+from http import HTTPStatus
+
+import pytest
+
 from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
     assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
 )
+from kernelCI_app.tests.utils.client.buildClient import BuildClient
 from kernelCI_app.tests.utils.fields.builds import (
     build_details_expected_fields,
     build_tests_expected_fields,
 )
 from kernelCI_app.tests.utils.fields.issues import issues_resource_fields
 from kernelCI_app.utils import string_to_json
-import pytest
-from http import HTTPStatus
-
 
 client = BuildClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/hardwareDetailsCommits_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/hardwareDetailsCommits_test.py
@@ -89,7 +89,7 @@ def test_get_hardware_details_commit_history(
     if not has_error_body:
         assert "commit_history_table" in content
 
-        for _, commit_data in content["commit_history_table"].items():
+        for commit_data in content["commit_history_table"].values():
             assert_has_fields_in_response_content(
                 fields=hardware_history_checkouts, response_content=commit_data[0]
             )

--- a/backend/kernelCI_app/tests/integrationTests/hardwareDetailsCommits_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/hardwareDetailsCommits_test.py
@@ -1,17 +1,19 @@
+import copy
+from http import HTTPStatus
+
 import pytest
-from kernelCI_app.typeModels.hardwareDetails import (
-    CommitHistoryPostBody,
-    CommitHead,
+
+from kernelCI_app.tests.utils.asserts import (
+    assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
 )
 from kernelCI_app.tests.utils.client.hardwareClient import HardwareClient
-from kernelCI_app.utils import string_to_json
-from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
-    assert_has_fields_in_response_content,
-)
 from kernelCI_app.tests.utils.fields.hardware import hardware_history_checkouts
-from http import HTTPStatus
-import copy
+from kernelCI_app.typeModels.hardwareDetails import (
+    CommitHead,
+    CommitHistoryPostBody,
+)
+from kernelCI_app.utils import string_to_json
 
 client = HardwareClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/hardwareDetailsFull_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/hardwareDetailsFull_test.py
@@ -1,24 +1,24 @@
-from kernelCI_app.tests.utils.client.hardwareClient import HardwareClient
 from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
     assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
 )
+from kernelCI_app.tests.utils.client.hardwareClient import HardwareClient
 from kernelCI_app.tests.utils.fields import hardware
-from kernelCI_app.utils import string_to_json
 from kernelCI_app.tests.utils.hardwareDetailsCommonTestCases import (
     ALLWINNER_HARDWARE,
-    UNEXISTENT_HARDWARE_ID,
-    BAD_REQUEST_REQUEST_BODY,
-    GOOGLE_JUNIPER_HARDWARE_WITHOUT_FILTERS,
-    HARDWARE_WITH_UNEXISTENT_FILTER_VALUE,
-    GOOGLE_JUNIPER_HARDWARE_WITH_FILTERS,
     ARM_JUNO_HARDWARE_WITHOUT_FILTERS,
-    HARDWARE_WITH_GLOBAL_FILTER,
     BAD_REQUEST_EXPECTED_RESPONSE,
-    SUCCESS_EXPECTED_RESPONSE,
+    BAD_REQUEST_REQUEST_BODY,
     EMPTY_EXPECTED_RESPONSE,
     ERROR_EXPECTED_RESPONSE,
+    GOOGLE_JUNIPER_HARDWARE_WITH_FILTERS,
+    GOOGLE_JUNIPER_HARDWARE_WITHOUT_FILTERS,
+    HARDWARE_WITH_GLOBAL_FILTER,
+    HARDWARE_WITH_UNEXISTENT_FILTER_VALUE,
+    SUCCESS_EXPECTED_RESPONSE,
+    UNEXISTENT_HARDWARE_ID,
 )
+from kernelCI_app.utils import string_to_json
 
 client = HardwareClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/hardwareDetailsSummary_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/hardwareDetailsSummary_test.py
@@ -1,21 +1,21 @@
-import pytest
-from requests import Response
 from http import HTTPStatus
 
-from kernelCI_app.utils import string_to_json
+import pytest
+
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING
+from kernelCI_app.tests.utils.asserts import (
+    assert_error_response,
+    assert_has_fields_in_response_content,
+    assert_status_code,
+)
 from kernelCI_app.tests.utils.client.hardwareClient import HardwareClient
 from kernelCI_app.tests.utils.commonTreeAsserts import (
     assert_common_summary_status_fields,
 )
 from kernelCI_app.tests.utils.fields import hardware
-from kernelCI_app.tests.utils.asserts import (
-    assert_has_fields_in_response_content,
-    assert_status_code,
-    assert_error_response,
-)
 from kernelCI_app.typeModels.hardwareDetails import HardwareDetailsPostBody
-from kernelCI_app.constants.general import UNCATEGORIZED_STRING
-
+from kernelCI_app.utils import string_to_json
+from requests import Response
 
 INVALID_BODY_HARDWARE = {
     "id": "invalid_id",

--- a/backend/kernelCI_app/tests/integrationTests/hardwareDetails_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/hardwareDetails_test.py
@@ -1,20 +1,19 @@
-from kernelCI_app.tests.utils.client.hardwareClient import HardwareClient
 from kernelCI_app.tests.utils.asserts import assert_status_code_and_error_response
-from kernelCI_app.utils import string_to_json
+from kernelCI_app.tests.utils.client.hardwareClient import HardwareClient
 from kernelCI_app.tests.utils.hardwareDetailsCommonTestCases import (
-    BAD_REQUEST_REQUEST_BODY,
-    GOOGLE_JUNIPER_HARDWARE_WITHOUT_FILTERS,
-    HARDWARE_WITH_UNEXISTENT_FILTER_VALUE,
-    GOOGLE_JUNIPER_HARDWARE_WITH_FILTERS,
     ARM_JUNO_HARDWARE_WITHOUT_FILTERS,
-    UNEXISTENT_HARDWARE_ID,
-    HARDWARE_WITH_GLOBAL_FILTER,
     BAD_REQUEST_EXPECTED_RESPONSE,
-    SUCCESS_EXPECTED_RESPONSE,
+    BAD_REQUEST_REQUEST_BODY,
     EMPTY_EXPECTED_RESPONSE,
     ERROR_EXPECTED_RESPONSE,
+    GOOGLE_JUNIPER_HARDWARE_WITH_FILTERS,
+    GOOGLE_JUNIPER_HARDWARE_WITHOUT_FILTERS,
+    HARDWARE_WITH_GLOBAL_FILTER,
+    HARDWARE_WITH_UNEXISTENT_FILTER_VALUE,
+    SUCCESS_EXPECTED_RESPONSE,
+    UNEXISTENT_HARDWARE_ID,
 )
-
+from kernelCI_app.utils import string_to_json
 
 client = HardwareClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/hardware_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/hardware_test.py
@@ -1,16 +1,18 @@
+from http import HTTPStatus
+
 import pytest
-from kernelCI_app.typeModels.hardwareListing import HardwareQueryParamsDocumentationOnly
-from kernelCI_app.tests.utils.client.hardwareClient import HardwareClient
+
 from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
     assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
 )
+from kernelCI_app.tests.utils.client.hardwareClient import HardwareClient
 from kernelCI_app.tests.utils.fields.hardware import (
     hardware_listing_fields,
     status_summary_fields,
 )
+from kernelCI_app.typeModels.hardwareListing import HardwareQueryParamsDocumentationOnly
 from kernelCI_app.utils import string_to_json
-from http import HTTPStatus
 
 
 @pytest.mark.parametrize(

--- a/backend/kernelCI_app/tests/integrationTests/issues_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/issues_test.py
@@ -1,19 +1,20 @@
-from kernelCI_app.tests.utils.client.issueClient import IssueClient
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+
+import pytest
+
 from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
     assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
 )
+from kernelCI_app.tests.utils.client.issueClient import IssueClient
+from kernelCI_app.tests.utils.fields.builds import build_details_expected_fields
 from kernelCI_app.tests.utils.fields.issues import (
     issues_expected_fields,
     issues_listing_fields,
 )
 from kernelCI_app.tests.utils.fields.tests import issue_tests_expected_fields
-from kernelCI_app.tests.utils.fields.builds import build_details_expected_fields
 from kernelCI_app.utils import string_to_json
-import pytest
-from http import HTTPStatus
-from datetime import datetime, timezone, timedelta
-
 
 client = IssueClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/origins_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/origins_test.py
@@ -1,11 +1,12 @@
 from http import HTTPStatus
-from kernelCI_app.tests.utils.client.originClient import OriginClient
+
 from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
     assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
 )
-from kernelCI_app.utils import string_to_json
+from kernelCI_app.tests.utils.client.originClient import OriginClient
 from kernelCI_app.tests.utils.fields.origins import origins_expected_fields
+from kernelCI_app.utils import string_to_json
 
 client = OriginClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/testDetails_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/testDetails_test.py
@@ -1,14 +1,15 @@
-from kernelCI_app.tests.utils.client.testClient import TestClient
-from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
-    assert_has_fields_in_response_content,
-)
-from kernelCI_app.tests.utils.fields.tests import test_details_expected_fields
-from kernelCI_app.tests.utils.fields.issues import issues_resource_fields
-from kernelCI_app.utils import string_to_json
-import pytest
 from http import HTTPStatus
 
+import pytest
+
+from kernelCI_app.tests.utils.asserts import (
+    assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
+)
+from kernelCI_app.tests.utils.client.testClient import TestClient
+from kernelCI_app.tests.utils.fields.issues import issues_resource_fields
+from kernelCI_app.tests.utils.fields.tests import test_details_expected_fields
+from kernelCI_app.utils import string_to_json
 
 client = TestClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/testStatusHistory_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/testStatusHistory_test.py
@@ -30,7 +30,7 @@ client = TestClient()
                 platform="mt8195-cherry-tomato-r2",
                 current_test_start_time="2025-03-10T01:49:23.064000Z",
                 config_name="defconfig+lab-setup+arm64-chromebook"
-                 "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
+                "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
             ),
             HTTPStatus.OK,
             False,

--- a/backend/kernelCI_app/tests/integrationTests/testStatusHistory_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/testStatusHistory_test.py
@@ -1,17 +1,18 @@
-from kernelCI_app.typeModels.testDetails import TestStatusHistoryRequest
-from kernelCI_app.tests.utils.client.testClient import TestClient
-from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
-    assert_has_fields_in_response_content,
-)
-from kernelCI_app.tests.utils.fields.tests import (
-    status_history_response_expected_fields,
-    status_history_item_fields,
-)
-from kernelCI_app.utils import string_to_json
-import pytest
 from http import HTTPStatus
 
+import pytest
+
+from kernelCI_app.tests.utils.asserts import (
+    assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
+)
+from kernelCI_app.tests.utils.client.testClient import TestClient
+from kernelCI_app.tests.utils.fields.tests import (
+    status_history_item_fields,
+    status_history_response_expected_fields,
+)
+from kernelCI_app.typeModels.testDetails import TestStatusHistoryRequest
+from kernelCI_app.utils import string_to_json
 
 client = TestClient()
 
@@ -29,7 +30,7 @@ client = TestClient()
                 platform="mt8195-cherry-tomato-r2",
                 current_test_start_time="2025-03-10T01:49:23.064000Z",
                 config_name="defconfig+lab-setup+arm64-chromebook"
-                + "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
+                 "+CONFIG_MODULE_COMPRESS=n+CONFIG_MODULE_COMPRESS_NONE=y",
             ),
             HTTPStatus.OK,
             False,

--- a/backend/kernelCI_app/tests/integrationTests/treeCommitHistory_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeCommitHistory_test.py
@@ -1,13 +1,14 @@
-import pytest
 from http import HTTPStatus
-from requests import Response
-from kernelCI_app.tests.utils.client.treeClient import TreeClient
+
+import pytest
+
 from kernelCI_app.tests.utils.asserts import assert_status_code_and_error_response
+from kernelCI_app.tests.utils.client.treeClient import TreeClient
 from kernelCI_app.tests.utils.commonTreeAsserts import (
     assert_tree_commit_history_fields,
 )
 from kernelCI_app.utils import string_to_json
-
+from requests import Response
 
 client = TreeClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/treeDetailsBoots_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeDetailsBoots_test.py
@@ -1,19 +1,20 @@
-from kernelCI_app.tests.utils.client.treeClient import TreeClient
+from http import HTTPStatus
+
+import pytest
+
 from kernelCI_app.tests.utils.asserts import (
     assert_status_code_and_error_response,
 )
-from kernelCI_app.utils import string_to_json
+from kernelCI_app.tests.utils.client.treeClient import TreeClient
 from kernelCI_app.tests.utils.commonTreeAsserts import execute_boots_asserts
-from http import HTTPStatus
-import pytest
 from kernelCI_app.tests.utils.treeDetailsCommonTestCases import (
     ANDROID_MAESTRO_MAINLINE,
+    BROONIE_MISC_BROONIE,
+    INVALID_QUERY_PARAMS,
     NEXT_PENDING_FIXES_BROONIE,
     UNEXISTENT_TREE,
-    INVALID_QUERY_PARAMS,
-    BROONIE_MISC_BROONIE,
 )
-
+from kernelCI_app.utils import string_to_json
 
 client = TreeClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/treeDetailsBuilds_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeDetailsBuilds_test.py
@@ -1,20 +1,22 @@
-from kernelCI_app.tests.utils.client.treeClient import TreeClient
+from http import HTTPStatus
+
+import pytest
+
 from kernelCI_app.tests.utils.asserts import (
     assert_status_code_and_error_response,
 )
-from kernelCI_app.utils import string_to_json
-from http import HTTPStatus
-import pytest
-from kernelCI_app.tests.utils.treeDetailsCommonTestCases import (
-    ANDROID_MAESTRO_MAINLINE,
-    BROONIE_MISC_BROONIE,
-    NEXT_PENDING_FIXES_BROONIE,
-    UNEXISTENT_TREE,
-    INVALID_QUERY_PARAMS,
-)
+from kernelCI_app.tests.utils.client.treeClient import TreeClient
 from kernelCI_app.tests.utils.commonTreeAsserts import (
     execute_builds_asserts,
 )
+from kernelCI_app.tests.utils.treeDetailsCommonTestCases import (
+    ANDROID_MAESTRO_MAINLINE,
+    BROONIE_MISC_BROONIE,
+    INVALID_QUERY_PARAMS,
+    NEXT_PENDING_FIXES_BROONIE,
+    UNEXISTENT_TREE,
+)
+from kernelCI_app.utils import string_to_json
 
 client = TreeClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/treeDetailsFull_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeDetailsFull_test.py
@@ -1,22 +1,23 @@
-from kernelCI_app.tests.utils.client.treeClient import TreeClient
+from http import HTTPStatus
+
+import pytest
+
 from kernelCI_app.tests.utils.asserts import assert_status_code_and_error_response
-from kernelCI_app.utils import string_to_json
+from kernelCI_app.tests.utils.client.treeClient import TreeClient
 from kernelCI_app.tests.utils.commonTreeAsserts import (
     execute_boots_asserts,
     execute_builds_asserts,
     execute_summary_asserts,
     execute_tests_asserts,
 )
-from http import HTTPStatus
-import pytest
 from kernelCI_app.tests.utils.treeDetailsCommonTestCases import (
     ANDROID_MAESTRO_MAINLINE,
+    BROONIE_MISC_BROONIE,
+    INVALID_QUERY_PARAMS,
     NEXT_PENDING_FIXES_BROONIE,
     UNEXISTENT_TREE,
-    INVALID_QUERY_PARAMS,
-    BROONIE_MISC_BROONIE,
 )
-
+from kernelCI_app.utils import string_to_json
 
 client = TreeClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/treeDetailsSummary_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeDetailsSummary_test.py
@@ -1,21 +1,21 @@
-import pytest
-from requests import Response
 from http import HTTPStatus
 
-from kernelCI_app.utils import string_to_json
+import pytest
+
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING
+from kernelCI_app.tests.utils.asserts import (
+    assert_error_response,
+    assert_has_fields_in_response_content,
+    assert_status_code,
+)
 from kernelCI_app.tests.utils.client.treeClient import TreeClient
 from kernelCI_app.tests.utils.commonTreeAsserts import (
     assert_common_summary_status_fields,
 )
 from kernelCI_app.tests.utils.fields import tree
-from kernelCI_app.tests.utils.asserts import (
-    assert_has_fields_in_response_content,
-    assert_status_code,
-    assert_error_response,
-)
 from kernelCI_app.typeModels.treeDetails import TreeQueryParameters
-from kernelCI_app.constants.general import UNCATEGORIZED_STRING
-
+from kernelCI_app.utils import string_to_json
+from requests import Response
 
 INVALID_TREE = {
     "id": "invalid_id",

--- a/backend/kernelCI_app/tests/integrationTests/treeDetailsTests_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeDetailsTests_test.py
@@ -1,21 +1,22 @@
-from kernelCI_app.tests.utils.client.treeClient import TreeClient
+from http import HTTPStatus
+
+import pytest
+
 from kernelCI_app.tests.utils.asserts import (
     assert_status_code_and_error_response,
 )
-from kernelCI_app.utils import string_to_json
+from kernelCI_app.tests.utils.client.treeClient import TreeClient
 from kernelCI_app.tests.utils.commonTreeAsserts import (
     execute_tests_asserts,
 )
-from http import HTTPStatus
-import pytest
 from kernelCI_app.tests.utils.treeDetailsCommonTestCases import (
     ANDROID_MAESTRO_MAINLINE,
+    BROONIE_MISC_BROONIE,
+    INVALID_QUERY_PARAMS,
     NEXT_PENDING_FIXES_BROONIE,
     UNEXISTENT_TREE,
-    INVALID_QUERY_PARAMS,
-    BROONIE_MISC_BROONIE,
 )
-
+from kernelCI_app.utils import string_to_json
 
 client = TreeClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/treeLatest_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeLatest_test.py
@@ -1,11 +1,12 @@
-from kernelCI_app.tests.utils.client.treeClient import TreeClient
-from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
-)
-from kernelCI_app.utils import string_to_json
 from http import HTTPStatus
 
 import pytest
+
+from kernelCI_app.tests.utils.asserts import (
+    assert_status_code_and_error_response,
+)
+from kernelCI_app.tests.utils.client.treeClient import TreeClient
+from kernelCI_app.utils import string_to_json
 
 client = TreeClient()
 

--- a/backend/kernelCI_app/tests/integrationTests/treeListing_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/treeListing_test.py
@@ -1,19 +1,19 @@
 import warnings
+from http import HTTPStatus
+
 from kernelCI_app.constants.localization import ClientStrings
-from kernelCI_app.tests.utils.client.treeClient import TreeClient
 from kernelCI_app.tests.utils.asserts import (
-    assert_status_code_and_error_response,
     assert_has_fields_in_response_content,
+    assert_status_code_and_error_response,
 )
-from kernelCI_app.utils import string_to_json
+from kernelCI_app.tests.utils.client.treeClient import TreeClient
 from kernelCI_app.tests.utils.fields.tree import (
     tree_fast,
     tree_listing,
-    tree_listing_test_status,
     tree_listing_build_status,
+    tree_listing_test_status,
 )
-from http import HTTPStatus
-
+from kernelCI_app.utils import string_to_json
 
 client = TreeClient()
 

--- a/backend/kernelCI_app/tests/performanceTests/test_ingest_perf.py
+++ b/backend/kernelCI_app/tests/performanceTests/test_ingest_perf.py
@@ -112,9 +112,7 @@ def _get_file_subset(files: list[str], subset: int) -> list[str]:
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.benchmark(group="ingest-parallel-workers")
 @pytest.mark.parametrize("max_workers", WORKER_COUNTS)
-def test_ingest_perf_workers(
-    benchmark, cleanup_submission_files, max_workers
-):  # noqa: ARG001
+def test_ingest_perf_workers(benchmark, cleanup_submission_files, max_workers):  # noqa: ARG001
     """Benchmark ingestion performance with different worker counts."""
     files = _load_submission_files(SUBMISSIONS_DIR)
 
@@ -147,9 +145,7 @@ def test_ingest_perf_workers(
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.benchmark(group="ingest-parallel-file-count")
 @pytest.mark.parametrize("file_subset", FILE_SUBSETS)
-def test_ingest_perf_file_count(
-    benchmark, cleanup_submission_files, file_subset
-):  # noqa: ARG001
+def test_ingest_perf_file_count(benchmark, cleanup_submission_files, file_subset):  # noqa: ARG001
     """Benchmark ingestion performance with different file counts."""
     all_files = _load_submission_files(SUBMISSIONS_DIR)
     files = _get_file_subset(all_files, file_subset)
@@ -203,9 +199,7 @@ def test_validation_and_upgrade(benchmark, cleanup_submission_files, file_subset
 
 @pytest.mark.benchmark(group="prepare-file")
 @pytest.mark.parametrize("file_subset", FILE_SUBSETS)
-def test_prepare_file_data(
-    benchmark, cleanup_submission_files, file_subset
-):  # noqa: ARG001
+def test_prepare_file_data(benchmark, cleanup_submission_files, file_subset):  # noqa: ARG001
     """Benchmark file preparation with different file counts."""
     all_files = _load_submission_files(SUBMISSIONS_DIR)
     files = _get_file_subset(all_files, file_subset)
@@ -317,9 +311,7 @@ def test_flush_buffers_perf(benchmark, cleanup_submission_files, file_subset):
 
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 @pytest.mark.benchmark(group="ingest-parallel-batch-size")
-def test_ingest_parallel_batch_size(
-    benchmark, cleanup_submission_files, batch_size
-):  # noqa: ARG001
+def test_ingest_parallel_batch_size(benchmark, cleanup_submission_files, batch_size):  # noqa: ARG001
     all_files = _load_submission_files(SUBMISSIONS_DIR)
     files = _get_file_subset(all_files, 1000)
 

--- a/backend/kernelCI_app/tests/unitTests/cache_test.py
+++ b/backend/kernelCI_app/tests/unitTests/cache_test.py
@@ -1,13 +1,14 @@
 from unittest.mock import patch
+
 from kernelCI_app.cache import (
-    _create_cache_params_hash,
-    set_query_cache,
-    get_query_cache,
-    set_notification_cache,
-    get_notification_cache,
-    _add_to_lookup,
     DISCORD_NOTIFICATION_COOLDOWN,
     DISCORD_NOTIFICATION_KEY,
+    _add_to_lookup,
+    _create_cache_params_hash,
+    get_notification_cache,
+    get_query_cache,
+    set_notification_cache,
+    set_query_cache,
 )
 
 

--- a/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_data.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_data.py
@@ -1,6 +1,5 @@
 from kernelCI import settings
 
-
 METRICS_NOTIFICATIONS_EXAMPLE_FILEPATH = (
     settings.BASE_DIR
     / "kernelCI_app"

--- a/backend/kernelCI_app/tests/unitTests/commands/healthcheck_helper_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/healthcheck_helper_test.py
@@ -1,5 +1,6 @@
-from django.test import SimpleTestCase, override_settings
 from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase, override_settings
 
 from kernelCI_app.management.commands.helpers.healthcheck import (
     _resolve_monitoring_url,

--- a/backend/kernelCI_app/tests/unitTests/commands/metrics_notifications_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/metrics_notifications_test.py
@@ -1,6 +1,5 @@
 import re
-from unittest import TestCase
-from unittest import mock
+from unittest import TestCase, mock
 from unittest.mock import MagicMock, patch
 
 from kernelCI_app.management.commands.notifications import (

--- a/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/file_utils_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/file_utils_test.py
@@ -1,8 +1,10 @@
 import os
-from kernelCI_app.constants.ingester import INGESTER_TREES_FILEPATH
-import yaml
-import pytest
 from unittest.mock import patch
+
+import pytest
+import yaml
+
+from kernelCI_app.constants.ingester import INGESTER_TREES_FILEPATH
 from kernelCI_app.management.commands.helpers.file_utils import (
     load_tree_names,
     move_file_to_failed_dir,
@@ -10,21 +12,21 @@ from kernelCI_app.management.commands.helpers.file_utils import (
     verify_spool_dirs,
 )
 from kernelCI_app.tests.unitTests.helpers.fixtures.file_utils_data import (
-    PENDING_RETRY_SPOOL_SUBDIR,
-    TREES_PATH_TESTING,
-    BASE_TREES_FILE,
-    EXPECTED_PARSED_TREES_FILE,
-    BASE_FILE_NAME,
-    NONEXISTING_FILE_NAME,
-    TESTING_FAILED_DIR,
-    EXISTING_DIRECTORY,
-    MISSING_DIRECTORY,
-    DENIED_DIRECTORY,
-    NOT_A_DIRECTORY,
-    INACCESSIBLE_DIRECTORY,
-    SPOOL_DIR_TESTING,
-    FAIL_SPOOL_SUBDIR,
     ARCHIVE_SPOOL_SUBDIR,
+    BASE_FILE_NAME,
+    BASE_TREES_FILE,
+    DENIED_DIRECTORY,
+    EXISTING_DIRECTORY,
+    EXPECTED_PARSED_TREES_FILE,
+    FAIL_SPOOL_SUBDIR,
+    INACCESSIBLE_DIRECTORY,
+    MISSING_DIRECTORY,
+    NONEXISTING_FILE_NAME,
+    NOT_A_DIRECTORY,
+    PENDING_RETRY_SPOOL_SUBDIR,
+    SPOOL_DIR_TESTING,
+    TESTING_FAILED_DIR,
+    TREES_PATH_TESTING,
 )
 
 

--- a/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py
@@ -1,31 +1,31 @@
-from unittest.mock import patch, MagicMock, mock_open, call
+from unittest.mock import MagicMock, call, mock_open, patch
 
+import pytest
+
+from kernelCI_app.constants.ingester import AUTOMATIC_LAB_FIELD
+from kernelCI_app.management.commands.helpers.kcidbng_ingester import (
+    SubmissionFileMetadata,
+    _extract_origins_info,
+    _standardize_lab_field,
+    consume_buffer,
+    flush_buffers,
+    ingest_submissions_parallel,
+    prepare_file_data,
+    standardize_labs,
+    standardize_tree_names,
+)
 from kernelCI_app.tests.unitTests.helpers.fixtures.kcidbng_ingester_data import (
     ARCHIVE_SUBMISSIONS_DIR,
     INGEST_BATCH_SIZE_MOCK,
     MAINLINE_URL,
     SUBMISSION_DIRS_MOCK,
+    SUBMISSION_FILE_DATA_MOCK,
+    SUBMISSION_FILE_MOCK,
+    SUBMISSION_FILENAME_MOCK,
     SUBMISSION_FILEPATH_MOCK,
+    SUBMISSION_PATH_MOCK,
     TIME_MOCK,
     TREE_NAMES_MOCK,
-    SUBMISSION_PATH_MOCK,
-    SUBMISSION_FILE_MOCK,
-    SUBMISSION_FILE_DATA_MOCK,
-    SUBMISSION_FILENAME_MOCK,
-)
-from kernelCI_app.constants.ingester import AUTOMATIC_LAB_FIELD
-import pytest
-
-from kernelCI_app.management.commands.helpers.kcidbng_ingester import (
-    SubmissionFileMetadata,
-    standardize_tree_names,
-    standardize_labs,
-    _standardize_lab_field,
-    prepare_file_data,
-    consume_buffer,
-    flush_buffers,
-    ingest_submissions_parallel,
-    _extract_origins_info,
 )
 
 

--- a/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/kcidbng_ingester_test.py
@@ -527,9 +527,9 @@ class TestConsumeBuffer:
         # TODO: test with a real example
         mock_buffer = [MagicMock(), MagicMock()]
         mock_cursor = MagicMock()
-        mock_connections["default"].cursor.return_value.__enter__.return_value = (
-            mock_cursor
-        )
+        mock_connections[
+            "default"
+        ].cursor.return_value.__enter__.return_value = mock_cursor
 
         consume_buffer(mock_buffer, table_name)
 

--- a/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/log_excerpt_utils_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/monitorSubmissions/log_excerpt_utils_test.py
@@ -1,12 +1,13 @@
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import MagicMock, mock_open, patch
+
 from kernelCI_app.management.commands.helpers.log_excerpt_utils import (
-    upload_logexcerpt,
+    cache_logs_maintenance,
+    extract_log_excerpt,
     get_from_cache,
+    process_log_excerpt_from_item,
     set_in_cache,
     set_log_excerpt_ofile,
-    process_log_excerpt_from_item,
-    extract_log_excerpt,
-    cache_logs_maintenance,
+    upload_logexcerpt,
 )
 from kernelCI_app.tests.unitTests.helpers.fixtures.log_excerpt_data import (
     COMPRESSED_LOGEXCERPT,

--- a/backend/kernelCI_app/tests/unitTests/commands/process_pending_helpers_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/process_pending_helpers_test.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
+
 from django.test import SimpleTestCase
 
+from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.management.commands.helpers.process_pending_helpers import (
     EMPTY_PATH_GROUP,
     RollupEntryData,
@@ -9,7 +11,6 @@ from kernelCI_app.management.commands.helpers.process_pending_helpers import (
     aggregate_tests_rollup,
     extract_path_group,
 )
-from kernelCI_app.constants.general import UNKNOWN_STRING
 from kernelCI_app.models import StatusChoices
 
 

--- a/backend/kernelCI_app/tests/unitTests/filters_test.py
+++ b/backend/kernelCI_app/tests/unitTests/filters_test.py
@@ -1,5 +1,5 @@
-from kernelCI_app.helpers.filters import should_filter_test_issue
 from kernelCI_app.constants.general import UNCATEGORIZED_STRING
+from kernelCI_app.helpers.filters import should_filter_test_issue
 
 
 class TestShouldFilterTestIssue:

--- a/backend/kernelCI_app/tests/unitTests/helpers/database_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/database_test.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+
 from kernelCI_app.helpers.database import dict_fetchall
 
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/dateRange_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/dateRange_test.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta, timezone as dt_timezone
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
 from unittest.mock import patch
 
 import pytest

--- a/backend/kernelCI_app/tests/unitTests/helpers/detailsIssues_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/detailsIssues_test.py
@@ -1,11 +1,12 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from kernelCI_app.helpers.detailsIssues import sanitize_details_issues_rows
-from kernelCI_app.typeModels.issues import Issue
 from kernelCI_app.tests.unitTests.helpers.fixtures.issue_data import (
+    create_issue_dict,
     issue1_dict,
     issue2_dict,
-    create_issue_dict,
 )
+from kernelCI_app.typeModels.issues import Issue
 
 
 class TestSanitizeDetailsIssuesRows:

--- a/backend/kernelCI_app/tests/unitTests/helpers/detailsIssues_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/detailsIssues_test.py
@@ -9,7 +9,6 @@ from kernelCI_app.tests.unitTests.helpers.fixtures.issue_data import (
 
 
 class TestSanitizeDetailsIssuesRows:
-
     @patch("kernelCI_app.helpers.detailsIssues.create_issue_typed")
     @patch("kernelCI_app.helpers.detailsIssues.convert_issues_dict_to_list_typed")
     def test_sanitize_details_issues_rows_with_single_issue(

--- a/backend/kernelCI_app/tests/unitTests/helpers/discordWebhook_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/discordWebhook_test.py
@@ -1,10 +1,11 @@
 from unittest.mock import patch
+
 import requests
 from kernelCI_app.helpers.discordWebhook import (
-    validate_notification,
-    send_discord_notification,
     AVATAR_URL,
     WEBHOOK_NAME,
+    send_discord_notification,
+    validate_notification,
 )
 
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/email_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/email_test.py
@@ -1,8 +1,10 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 from kernelCI_app.helpers.email import (
-    smtp_setup_connection,
     smtp_send_email,
+    smtp_setup_connection,
 )
 
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/errorHandling_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/errorHandling_test.py
@@ -1,5 +1,7 @@
 from http import HTTPStatus
+
 from rest_framework.response import Response
+
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/filters_helpers_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/filters_helpers_test.py
@@ -1,39 +1,41 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
+from kernelCI_app.constants.general import UNCATEGORIZED_STRING
 from kernelCI_app.helpers.filters import (
-    is_status_failure,
-    is_known_issue,
-    is_unknown_build_issue,
-    is_exclusively_build_issue,
-    is_exclusively_test_issue,
-    is_issue_from_test,
-    is_issue_from_build,
-    verify_issue_in_filter,
-    is_issue_filtered_out,
-    should_filter_test_issue,
-    should_filter_build_issue,
-    should_increment_test_issue,
-    should_increment_build_issue,
-    to_int_or_default,
     FilterParams,
     InvalidComparisonOPError,
+    is_exclusively_build_issue,
+    is_exclusively_test_issue,
+    is_issue_filtered_out,
+    is_issue_from_build,
+    is_issue_from_test,
+    is_known_issue,
+    is_status_failure,
+    is_unknown_build_issue,
+    should_filter_build_issue,
+    should_filter_test_issue,
+    should_increment_build_issue,
+    should_increment_test_issue,
+    to_int_or_default,
+    verify_issue_in_filter,
 )
-from kernelCI_app.constants.general import UNCATEGORIZED_STRING
 from kernelCI_app.tests.unitTests.helpers.fixtures.filter_fixtures import (
     BOOT_FILTER_DATA_SCENARIOS,
+    FILTER_BODY_DATA,
     FILTER_DATA_SCENARIOS,
     FILTER_OBJECTS,
-    FILTER_BODY_DATA,
+    MATCHING_ISSUE_FILTERS,
     filter_params_with_exact_filter,
     filter_params_with_filters,
     filter_params_with_invalid_op,
-    MATCHING_ISSUE_FILTERS,
     mock_request,
     mock_request_with_filters,
-    mock_request_with_multiple_filters,
-    mock_request_with_string_filter,
-    mock_request_with_regex_filter,
     mock_request_with_invalid_param,
+    mock_request_with_multiple_filters,
+    mock_request_with_regex_filter,
+    mock_request_with_string_filter,
 )
 
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/fixtures/filter_fixtures.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/fixtures/filter_fixtures.py
@@ -3,7 +3,9 @@ Fixtures for filter tests.
 """
 
 from unittest.mock import MagicMock
+
 from django.http import HttpRequest, QueryDict
+
 from kernelCI_app.constants.general import UNCATEGORIZED_STRING
 from kernelCI_app.helpers.filters import FilterParams
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/fixtures/hardware_details_data.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/fixtures/hardware_details_data.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
-from kernelCI_app.typeModels.hardwareDetails import Tree
+
+from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.commonDetails import (
     TestArchSummaryItem,
     TestSummary,
 )
-from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.hardwareDetails import Tree
 
 
 def create_tree(**overrides):

--- a/backend/kernelCI_app/tests/unitTests/helpers/hardwareDetails_helpers_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/hardwareDetails_helpers_test.py
@@ -1089,7 +1089,6 @@ class TestDecideIfIsFullRecordFilteredOut:
 
 
 class TestDecideIfIsBuildInFilter:
-
     def test_decide_if_is_build_in_filter(self):
         """Test decide_if_is_build_in_filter function."""
         instance = MagicMock()

--- a/backend/kernelCI_app/tests/unitTests/helpers/hardwareDetails_helpers_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/hardwareDetails_helpers_test.py
@@ -1,68 +1,69 @@
-from kernelCI_app.typeModels.common import StatusCount
-from unittest.mock import patch, MagicMock
-from datetime import datetime
 from collections import defaultdict
-from kernelCI_app.helpers.hardwareDetails import (
-    unstable_parse_post_body,
-    set_trees_status_summary,
-    get_displayed_commit,
-    get_trees_with_selected_commit,
-    get_arch_summary_typed,
-    get_build_typed,
-    get_tree_key,
-    get_validated_current_tree,
-    get_current_record_tree_in_selection,
-    generate_test_dict,
-    generate_build_summary_typed,
-    generate_test_summary_typed,
-    generate_tree_status_summary_dict,
-    handle_tree_status_summary,
-    create_record_test_platform,
-    handle_test_history,
-    handle_test_summary,
-    handle_build_history,
-    handle_build_summary,
-    process_issue,
-    update_issues,
-    decide_if_is_full_record_filtered_out,
-    decide_if_is_build_in_filter,
-    get_processed_issue_key,
-    is_issue_processed,
-    is_test_processed,
-    decide_if_is_test_in_filter,
-    is_record_tree_selected,
-    mutate_properties_to_list,
-    assign_default_record_values,
-    format_issue_summary_for_response,
-    handle_build,
-    process_filters,
-    get_filter_options,
-)
-from kernelCI_app.typeModels.hardwareDetails import Tree
-from kernelCI_app.typeModels.commonDetails import (
-    TestArchSummaryItem,
-    BuildSummary,
-    TestSummary,
-)
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
 from kernelCI_app.constants.general import UNCATEGORIZED_STRING, UNKNOWN_STRING
 from kernelCI_app.constants.hardwareDetails import SELECTED_HEAD_TREE_VALUE
-from kernelCI_app.typeModels.databases import (
-    build_fail_status_list,
+from kernelCI_app.helpers.hardwareDetails import (
+    assign_default_record_values,
+    create_record_test_platform,
+    decide_if_is_build_in_filter,
+    decide_if_is_full_record_filtered_out,
+    decide_if_is_test_in_filter,
+    format_issue_summary_for_response,
+    generate_build_summary_typed,
+    generate_test_dict,
+    generate_test_summary_typed,
+    generate_tree_status_summary_dict,
+    get_arch_summary_typed,
+    get_build_typed,
+    get_current_record_tree_in_selection,
+    get_displayed_commit,
+    get_filter_options,
+    get_processed_issue_key,
+    get_tree_key,
+    get_trees_with_selected_commit,
+    get_validated_current_tree,
+    handle_build,
+    handle_build_history,
+    handle_build_summary,
+    handle_test_history,
+    handle_test_summary,
+    handle_tree_status_summary,
+    is_issue_processed,
+    is_record_tree_selected,
+    is_test_processed,
+    mutate_properties_to_list,
+    process_filters,
+    process_issue,
+    set_trees_status_summary,
+    unstable_parse_post_body,
+    update_issues,
 )
 from kernelCI_app.tests.unitTests.helpers.fixtures.hardware_details_data import (
     base_tree,
-    tree_with_different_commit,
     base_tree_status_summary,
     create_test_summary,
+    handle_test_summary_record_new_config,
+    handle_test_summary_record_new_origin,
+    handle_test_summary_record_new_platform,
     process_filters_instance,
     process_filters_instance_without_build,
+    process_filters_record_boot,
     process_filters_record_with_build,
     process_filters_record_without_build,
-    process_filters_record_boot,
-    handle_test_summary_record_new_config,
-    handle_test_summary_record_new_platform,
-    handle_test_summary_record_new_origin,
+    tree_with_different_commit,
 )
+from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.commonDetails import (
+    BuildSummary,
+    TestArchSummaryItem,
+    TestSummary,
+)
+from kernelCI_app.typeModels.databases import (
+    build_fail_status_list,
+)
+from kernelCI_app.typeModels.hardwareDetails import Tree
 
 
 class TestUnstableParsePostBody:

--- a/backend/kernelCI_app/tests/unitTests/helpers/issueExtras_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/issueExtras_test.py
@@ -1,15 +1,16 @@
-from unittest.mock import patch
 from datetime import datetime
+from unittest.mock import patch
+
 from kernelCI_app.helpers.issueExtras import (
-    process_issues_extra_details,
+    TagUrls,
     assign_issue_first_seen,
     assign_issue_trees,
-    TagUrls,
+    process_issues_extra_details,
 )
 from kernelCI_app.typeModels.issues import (
     ExtraIssuesData,
-    IssueWithExtraInfo,
     FirstIncident,
+    IssueWithExtraInfo,
 )
 
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/issueListing_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/issueListing_test.py
@@ -1,11 +1,11 @@
+from kernelCI_app.helpers.filters import FilterParams
 from kernelCI_app.helpers.issueListing import (
-    should_discard_issue_by_culprit,
-    should_discard_issue_by_origin,
-    should_discard_issue_by_options,
     should_discard_issue_by_category,
+    should_discard_issue_by_culprit,
+    should_discard_issue_by_options,
+    should_discard_issue_by_origin,
     should_discard_issue_record,
 )
-from kernelCI_app.helpers.filters import FilterParams
 from kernelCI_app.typeModels.issues import (
     CULPRIT_CODE,
     CULPRIT_HARNESS,

--- a/backend/kernelCI_app/tests/unitTests/helpers/logger_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/logger_test.py
@@ -1,7 +1,9 @@
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import MagicMock, call, patch
+
 from django.http import HttpRequest
+
 from kernelCI_app.constants.general import PRODUCTION_HOST, STAGING_HOST
-from kernelCI_app.helpers.logger import log_message, create_endpoint_notification
+from kernelCI_app.helpers.logger import create_endpoint_notification, log_message
 
 
 class TestLogMessage:

--- a/backend/kernelCI_app/tests/unitTests/helpers/misc_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/misc_test.py
@@ -1,9 +1,9 @@
+from kernelCI_app.helpers.filters import UNKNOWN_STRING
 from kernelCI_app.helpers.misc import (
+    Misc,
     handle_misc,
     misc_value_or_default,
-    Misc,
 )
-from kernelCI_app.helpers.filters import UNKNOWN_STRING
 
 
 class TestHandleMisc:

--- a/backend/kernelCI_app/tests/unitTests/helpers/process_submissions_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/process_submissions_test.py
@@ -1,26 +1,26 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from django.db import IntegrityError
 from django.test import SimpleTestCase
 from django.utils import timezone
+from pydantic import ValidationError
+
 from kernelCI_app.management.commands.helpers.kcidbng_ingester import (
     MAP_TABLENAMES_TO_COUNTER,
 )
-from pydantic import ValidationError
-
 from kernelCI_app.management.commands.helpers.process_submissions import (
-    get_model_fields,
-    flatten_dict_specific,
-    make_issue_instance,
-    make_checkout_instance,
-    make_build_instance,
-    make_test_instance,
-    make_incident_instance,
     build_instances_from_submission,
+    flatten_dict_specific,
+    get_model_fields,
     insert_items,
     insert_submission_data,
+    make_build_instance,
+    make_checkout_instance,
+    make_incident_instance,
+    make_issue_instance,
+    make_test_instance,
 )
-from kernelCI_app.models import Issues, Checkouts, Builds, Tests, Incidents
-
+from kernelCI_app.models import Builds, Checkouts, Incidents, Issues, Tests
 
 MOCK_TIME = timezone.datetime(2025, 10, 11, 12, 0, 0)
 

--- a/backend/kernelCI_app/tests/unitTests/helpers/system_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/system_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
-from kernelCI_app.helpers.system import get_running_instance
+
 from kernelCI_app.constants.general import PRODUCTION_HOST
+from kernelCI_app.helpers.system import get_running_instance
 
 
 class TestGetRunningInstance:

--- a/backend/kernelCI_app/tests/unitTests/helpers/treeDetails_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/treeDetails_test.py
@@ -1,39 +1,40 @@
-from unittest.mock import patch, MagicMock
-from kernelCI_app.helpers.treeDetails import (
-    create_checkouts_where_clauses,
-    get_current_row_data,
-    process_tree_url,
-    call_based_on_compatible_and_misc_platform,
-    get_hardware_filter,
-    get_build,
-    process_builds_issue,
-    process_tests_issue,
-    decide_if_is_build_filtered_out,
-    decide_if_is_boot_filtered_out,
-    decide_if_is_full_row_filtered_out,
-    decide_if_is_test_filtered_out,
-    increment_test_origin_summary,
-    process_test_summary,
-    process_boots_summary,
-    process_filters,
-)
-from kernelCI_app.typeModels.commonDetails import BuildHistoryItem
-from kernelCI_app.typeModels.common import StatusCount
+from unittest.mock import MagicMock, patch
+
 from kernelCI_app.constants.general import (
     UNCATEGORIZED_STRING,
     UNKNOWN_STRING,
 )
-from kernelCI_app.typeModels.databases import NULL_STATUS
+from kernelCI_app.helpers.treeDetails import (
+    call_based_on_compatible_and_misc_platform,
+    create_checkouts_where_clauses,
+    decide_if_is_boot_filtered_out,
+    decide_if_is_build_filtered_out,
+    decide_if_is_full_row_filtered_out,
+    decide_if_is_test_filtered_out,
+    get_build,
+    get_current_row_data,
+    get_hardware_filter,
+    increment_test_origin_summary,
+    process_boots_summary,
+    process_builds_issue,
+    process_filters,
+    process_test_summary,
+    process_tests_issue,
+    process_tree_url,
+)
 from kernelCI_app.tests.unitTests.helpers.fixtures.tree_details_data import (
     base_current_row,
-    current_row_with_none_values,
-    current_row_with_fail_status,
     base_row_data,
-    row_data_with_unknown_compatible,
     build_only_row_data,
-    test_only_row_data,
     combined_row_data,
+    current_row_with_fail_status,
+    current_row_with_none_values,
+    row_data_with_unknown_compatible,
+    test_only_row_data,
 )
+from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.commonDetails import BuildHistoryItem
+from kernelCI_app.typeModels.databases import NULL_STATUS
 
 
 class TestCreateCheckoutsWhereClauses:

--- a/backend/kernelCI_app/tests/unitTests/helpers/trees_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/trees_test.py
@@ -1,20 +1,22 @@
 from datetime import datetime
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
+
 import yaml
+
 from kernelCI_app.helpers.trees import (
-    make_tree_identifier_key,
     get_tree_file_data,
     get_tree_url_to_name_map,
+    make_tree_identifier_key,
     sanitize_tree,
+)
+from kernelCI_app.tests.unitTests.helpers.fixtures.checkout_data import (
+    checkout_data_with_invalid_json_tags,
+    checkout_data_with_list_tags,
+    checkout_data_with_non_list_json_tags,
+    checkout_data_with_string_tags,
 )
 from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.treeListing import Checkout
-from kernelCI_app.tests.unitTests.helpers.fixtures.checkout_data import (
-    checkout_data_with_list_tags,
-    checkout_data_with_string_tags,
-    checkout_data_with_invalid_json_tags,
-    checkout_data_with_non_list_json_tags,
-)
 
 
 class TestMakeTreeIdentifierKey:

--- a/backend/kernelCI_app/tests/unitTests/queries/build_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/build_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from kernelCI_app.queries.build import get_build_details, get_build_tests
-
 from kernelCI_app.tests.unitTests.queries.conftest import (
     setup_mock_filter_values_queryset,
     setup_mock_query_builder,

--- a/backend/kernelCI_app/tests/unitTests/queries/checkout_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/checkout_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from kernelCI_app.queries.checkout import get_origins
-
 from kernelCI_app.tests.unitTests.queries.conftest import setup_mock_cursor
 
 

--- a/backend/kernelCI_app/tests/unitTests/queries/hardware_queries_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/hardware_queries_test.py
@@ -2,19 +2,18 @@ from datetime import datetime
 from unittest.mock import patch
 
 from kernelCI_app.queries.hardware import (
-    get_hardware_listing_data,
-    get_hardware_details_data,
-    get_hardware_trees_data,
-    get_hardware_commit_history,
     _generate_query_params,
+    get_hardware_commit_history,
+    get_hardware_details_data,
+    get_hardware_listing_data,
+    get_hardware_trees_data,
     query_records,
 )
-from kernelCI_app.typeModels.hardwareDetails import CommitHead
-
 from kernelCI_app.tests.unitTests.queries.conftest import (
     TEST_TREE,
     setup_mock_cursor,
 )
+from kernelCI_app.typeModels.hardwareDetails import CommitHead
 
 START_DATE = datetime(2025, 11, 11)
 END_DATE = datetime(2025, 11, 12)

--- a/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
@@ -2,17 +2,16 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 from kernelCI_app.queries.issues import (
-    get_issue_builds,
-    get_issue_tests,
-    get_issue_listing_data,
-    get_latest_issue_version,
-    get_issue_details,
     get_build_issues,
-    get_test_issues,
+    get_issue_builds,
+    get_issue_details,
     get_issue_first_seen_data,
+    get_issue_listing_data,
+    get_issue_tests,
     get_issue_trees_data,
+    get_latest_issue_version,
+    get_test_issues,
 )
-
 from kernelCI_app.tests.unitTests.queries.conftest import (
     setup_mock_cursor,
     setup_mock_queryset,

--- a/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
@@ -239,9 +239,7 @@ class TestGetIssueTreesData:
         expected_result = [{"issue_id": "issue_1", "issue_version": 1}]
         mock_dict_fetchall.return_value = expected_result
         mock_cursor = MagicMock()
-        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = (
-            mock_cursor
-        )
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
         result = get_issue_trees_data(issue_key_list=[("issue_1", 1), ("issue_2", 2)])
 
@@ -281,9 +279,7 @@ class TestGetIssueTreesData:
         ]
         mock_dict_fetchall.return_value = expected_result
         mock_cursor = MagicMock()
-        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = (
-            mock_cursor
-        )
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
         result = get_issue_trees_data(
             issue_key_list=[("issue_1", 1), ("issue_2", 2), ("issue_3", 3)]
@@ -317,9 +313,7 @@ class TestGetIssueTreesData:
         ]
         mock_dict_fetchall.return_value = expected_result
         mock_cursor = MagicMock()
-        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = (
-            mock_cursor
-        )
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
         result = get_issue_trees_data(issue_key_list=[("issue_1", 1)])
 

--- a/backend/kernelCI_app/tests/unitTests/queries/notifications_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/notifications_test.py
@@ -1,17 +1,16 @@
 from unittest.mock import MagicMock, patch
 
 from kernelCI_app.queries.notifications import (
-    kcidb_new_issues,
-    kcidb_issue_details,
-    kcidb_build_incidents,
-    kcidb_test_incidents,
-    kcidb_last_test_without_issue,
     get_checkout_summary_data,
-    kcidb_tests_results,
     get_issues_summary_data,
+    kcidb_build_incidents,
     kcidb_execute_query,
+    kcidb_issue_details,
+    kcidb_last_test_without_issue,
+    kcidb_new_issues,
+    kcidb_test_incidents,
+    kcidb_tests_results,
 )
-
 from kernelCI_app.tests.unitTests.queries.conftest import setup_mock_cursor
 
 

--- a/backend/kernelCI_app/tests/unitTests/queries/notifications_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/notifications_test.py
@@ -243,9 +243,7 @@ class TestGetIssuesSummaryData:
         expected_result = [{"checkout_id": "checkout_1", "issue_id": "issue_1"}]
         mock_dict_fetchall.return_value = expected_result
         mock_cursor = MagicMock()
-        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = (
-            mock_cursor
-        )
+        mock_connections.__getitem__.return_value.cursor.return_value.__enter__.return_value = mock_cursor
 
         result = get_issues_summary_data(checkout_ids=["checkout_1", "checkout_2"])
 

--- a/backend/kernelCI_app/tests/unitTests/queries/test_queries_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/test_queries_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from kernelCI_app.queries.test import get_test_details_data, get_test_status_history
-
 from kernelCI_app.tests.unitTests.queries.conftest import (
     setup_mock_cursor,
     setup_mock_test_queryset,

--- a/backend/kernelCI_app/tests/unitTests/queries/tree_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/tree_test.py
@@ -1,14 +1,13 @@
 from unittest.mock import Mock, patch
 
 from kernelCI_app.queries.tree import (
-    get_tree_listing_data,
-    get_tree_listing_fast,
-    get_tree_listing_data_by_checkout_id,
-    get_tree_details_data,
-    get_tree_commit_history,
     get_latest_tree,
+    get_tree_commit_history,
+    get_tree_details_data,
+    get_tree_listing_data,
+    get_tree_listing_data_by_checkout_id,
+    get_tree_listing_fast,
 )
-
 from kernelCI_app.tests.unitTests.queries.conftest import (
     setup_mock_cursor,
     setup_mock_queryset,

--- a/backend/kernelCI_app/tests/unitTests/tasks_test.py
+++ b/backend/kernelCI_app/tests/unitTests/tasks_test.py
@@ -1,14 +1,15 @@
-from unittest.mock import patch, MagicMock
 from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from kernelCI_app.models import Checkouts
 from kernelCI_app.tasks import (
+    UPDATE_INTERVAL_IN_DAYS,
     _is_checkout_done,
-    _is_checkout_unstable,
     _is_checkout_newer,
+    _is_checkout_unstable,
     get_checkout_ids_for_update,
     update_checkout_cache,
-    UPDATE_INTERVAL_IN_DAYS,
 )
-from kernelCI_app.models import Checkouts
 
 
 class TestIsCheckoutDone:

--- a/backend/kernelCI_app/tests/unitTests/typeModels/commonDetails_test.py
+++ b/backend/kernelCI_app/tests/unitTests/typeModels/commonDetails_test.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from kernelCI_app.typeModels.commonDetails import (
     BuildHistoryItem,
 )

--- a/backend/kernelCI_app/tests/unitTests/typeModels/common_test.py
+++ b/backend/kernelCI_app/tests/unitTests/typeModels/common_test.py
@@ -1,6 +1,6 @@
 from kernelCI_app.typeModels.common import (
-    StatusCount,
     GroupedStatus,
+    StatusCount,
     make_default_validator,
 )
 

--- a/backend/kernelCI_app/tests/unitTests/typeModels/treeListing_unit_test.py
+++ b/backend/kernelCI_app/tests/unitTests/typeModels/treeListing_unit_test.py
@@ -1,9 +1,10 @@
 from datetime import datetime
-from kernelCI_app.typeModels.treeListing import (
-    TestStatusCount,
-    Checkout,
-)
+
 from kernelCI_app.typeModels.common import StatusCount
+from kernelCI_app.typeModels.treeListing import (
+    Checkout,
+    TestStatusCount,
+)
 
 
 class TestCheckout:

--- a/backend/kernelCI_app/tests/unitTests/url_patterns_test.py
+++ b/backend/kernelCI_app/tests/unitTests/url_patterns_test.py
@@ -1,4 +1,4 @@
-from django.urls import reverse, resolve
+from django.urls import resolve, reverse
 
 
 class TestURLPatterns:

--- a/backend/kernelCI_app/tests/unitTests/utils_test.py
+++ b/backend/kernelCI_app/tests/unitTests/utils_test.py
@@ -1,25 +1,27 @@
 import json
-import yaml
-from unittest.mock import patch, mock_open
 from datetime import timedelta
+from unittest.mock import mock_open, patch
+
+import yaml
 from django.utils import timezone
+
+from kernelCI_app.typeModels.common import GroupedStatus, StatusCount
+from kernelCI_app.typeModels.issues import Issue
+from kernelCI_app.typeModels.treeListing import TestStatusCount
 from kernelCI_app.utils import (
-    create_issue_typed,
+    DEFAULT_QUERY_TIME_INTERVAL,
     convert_issues_dict_to_list_typed,
+    create_issue_typed,
     extract_error_message,
-    get_query_time_interval,
     get_error_body_response,
+    get_query_time_interval,
+    group_status,
+    is_boot,
+    read_yaml_file,
     sanitize_dict,
     string_to_json,
-    is_boot,
     validate_str_to_dict,
-    group_status,
-    read_yaml_file,
-    DEFAULT_QUERY_TIME_INTERVAL,
 )
-from kernelCI_app.typeModels.issues import Issue
-from kernelCI_app.typeModels.common import StatusCount, GroupedStatus
-from kernelCI_app.typeModels.treeListing import TestStatusCount
 
 
 class TestCreateIssueTyped:

--- a/backend/kernelCI_app/tests/unitTests/viewCommon_test.py
+++ b/backend/kernelCI_app/tests/unitTests/viewCommon_test.py
@@ -1,11 +1,11 @@
-from kernelCI_app.viewCommon import (
-    _increment_status,
-    create_details_build_summary,
-)
 from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.commonDetails import (
     BaseBuildSummary,
     BuildHistoryItem,
+)
+from kernelCI_app.viewCommon import (
+    _increment_status,
+    create_details_build_summary,
 )
 
 

--- a/backend/kernelCI_app/tests/unitTests/views/buildDetailsView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/buildDetailsView_test.py
@@ -1,8 +1,10 @@
 from unittest.mock import patch
+
 from django.test import SimpleTestCase
 from rest_framework.test import APIRequestFactory
-from kernelCI_app.views.buildDetailsView import BuildDetails
+
 from kernelCI_app.tests.unitTests.views.fixtures.build_data import build_details_data
+from kernelCI_app.views.buildDetailsView import BuildDetails
 
 
 class TestBuildDetails(SimpleTestCase):

--- a/backend/kernelCI_app/tests/unitTests/views/buildIssuesView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/buildIssuesView_test.py
@@ -1,8 +1,10 @@
 from unittest.mock import patch
+
 from django.test import SimpleTestCase
 from rest_framework.test import APIRequestFactory
-from kernelCI_app.views.buildIssuesView import BuildIssuesView
+
 from kernelCI_app.tests.unitTests.views.fixtures.build_data import base_issue_data
+from kernelCI_app.views.buildIssuesView import BuildIssuesView
 
 
 class TestBuildIssuesView(SimpleTestCase):

--- a/backend/kernelCI_app/tests/unitTests/views/buildTestsView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/buildTestsView_test.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
+
 from django.test import SimpleTestCase
 from rest_framework.test import APIRequestFactory
-from kernelCI_app.views.buildTestsView import BuildTests
+
 from kernelCI_app.tests.unitTests.views.fixtures.build_data import (
     base_test_data,
 )
+from kernelCI_app.views.buildTestsView import BuildTests
 
 
 class TestBuildTests(SimpleTestCase):

--- a/backend/kernelCI_app/tests/unitTests/views/fixtures/build_data.py
+++ b/backend/kernelCI_app/tests/unitTests/views/fixtures/build_data.py
@@ -23,7 +23,6 @@ build_details_data = {
     "git_commit_hash": "test_git_commit_hash",
     "git_commit_name": "test_git_commit_name",
     "git_commit_tags": ["test_git_commit_tag"],
-    "origin": "test_origin",
     "log_excerpt": "test_log_excerpt",
     "input_files": None,
     "output_files": None,

--- a/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsBootsView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsBootsView_test.py
@@ -1,12 +1,14 @@
-from http import HTTPStatus
 import json
+from http import HTTPStatus
 from unittest.mock import patch
+
 from django.test import SimpleTestCase
-from rest_framework.test import APIRequestFactory
 from pydantic import ValidationError
-from kernelCI_app.views.hardwareDetailsBootsView import HardwareDetailsBoots
+from rest_framework.test import APIRequestFactory
+
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.typeModels.hardwareDetails import HardwareTestHistoryItem
+from kernelCI_app.views.hardwareDetailsBootsView import HardwareDetailsBoots
 
 
 class TestHardwareDetailsBootsView(SimpleTestCase):

--- a/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsCommitHistory_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsCommitHistory_test.py
@@ -1,13 +1,15 @@
-from http import HTTPStatus
 import json
+from datetime import datetime, timezone
+from http import HTTPStatus
 from unittest.mock import patch
+
 from django.test import SimpleTestCase
+from rest_framework.test import APIRequestFactory
+
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.views.hardwareDetailsCommitHistoryView import (
     HardwareDetailsCommitHistoryView,
 )
-from rest_framework.test import APIRequestFactory
-from datetime import datetime, timezone
 
 
 class TestHardwareDetailsCommitHistoryView(SimpleTestCase):

--- a/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsTestsView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsTestsView_test.py
@@ -158,10 +158,8 @@ class TestHardwareDetailsTestsView(SimpleTestCase):
             }
         ]
 
-        mock_sanitize_records.side_effect = (
-            lambda records, trees, is_all_selected: self.view.tests.append(
-                {"invalid": "data"}
-            )
+        mock_sanitize_records.side_effect = lambda records, trees, is_all_selected: (
+            self.view.tests.append({"invalid": "data"})
         )
 
         request = self.factory.post(

--- a/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsTestsView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsTestsView_test.py
@@ -1,11 +1,13 @@
-from http import HTTPStatus
 import json
+from http import HTTPStatus
 from unittest.mock import patch
+
 from django.test import SimpleTestCase
+from rest_framework.test import APIRequestFactory
+
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.typeModels.hardwareDetails import HardwareTestHistoryItem
 from kernelCI_app.views.hardwareDetailsTestsView import HardwareDetailsTests
-from rest_framework.test import APIRequestFactory
 
 
 class TestHardwareDetailsTestsView(SimpleTestCase):

--- a/backend/kernelCI_app/tests/unitTests/views/hardwareView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/hardwareView_test.py
@@ -1,9 +1,11 @@
 from http import HTTPStatus
 from unittest.mock import patch
+
 from django.test.testcases import SimpleTestCase
+from rest_framework.test import APIRequestFactory
+
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.views.hardwareView import HardwareView
-from rest_framework.test import APIRequestFactory
 
 
 class TestHardwareView(SimpleTestCase):

--- a/backend/kernelCI_app/tests/unitTests/views/treeCommitsHistory_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/treeCommitsHistory_test.py
@@ -226,7 +226,7 @@ class TestTreeCommitsHistory(SimpleTestCase):
     ):
         commit_hash = "6bd9ed02871f22beb0e50690b0c3caf457104f7c"
         hardware = "fsl,imx8mp-evk"
-        direct_url = "/api/tree/mainline/master/" f"{commit_hash}/commits"
+        direct_url = f"/api/tree/mainline/master/{commit_hash}/commits"
 
         mock_get_tree_commit_history.return_value = [
             (

--- a/backend/kernelCI_app/tests/unitTests/views/treeDetailsSummaryView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/treeDetailsSummaryView_test.py
@@ -1,10 +1,10 @@
 from unittest.mock import patch
+
 from django.test import SimpleTestCase
 from rest_framework.test import APIRequestFactory
 
-from kernelCI_app.views.treeDetailsSummaryView import TreeDetailsSummary
 from kernelCI_app.tests.unitTests.helpers.fixtures.tree_details_data import create_row
-
+from kernelCI_app.views.treeDetailsSummaryView import TreeDetailsSummary
 
 COMMIT_HASH = "abc123def456rollupfallback"
 

--- a/backend/kernelCI_app/tests/utils/asserts.py
+++ b/backend/kernelCI_app/tests/utils/asserts.py
@@ -3,15 +3,15 @@ from http import HTTPStatus
 
 
 def assert_status_code(*, response: requests.Response, status_code: HTTPStatus) -> None:
-    assert (
-        response.status_code == status_code
-    ), f"This call returned status code {response.status_code}, when it should be {status_code}."
+    assert response.status_code == status_code, (
+        f"This call returned status code {response.status_code}, when it should be {status_code}."
+    )
 
 
 def assert_error_response(response_content: dict) -> None:
-    assert (
-        "error" in response_content
-    ), f"This call must return an error message. {response_content}"
+    assert "error" in response_content, (
+        f"This call must return an error message. {response_content}"
+    )
 
 
 def assert_status_code_and_error_response(
@@ -30,9 +30,9 @@ def assert_has_fields_in_response_content(
     *, fields: list[str], response_content: dict
 ) -> None:
     for field in fields:
-        assert (
-            field in response_content
-        ), f"Field {field} doesn't exists on {response_content}"
+        assert field in response_content, (
+            f"Field {field} doesn't exists on {response_content}"
+        )
 
 
 def assert_build_filters(*, filters: dict, build: dict):
@@ -44,9 +44,9 @@ def assert_build_filters(*, filters: dict, build: dict):
             if filter_key.startswith("build."):
                 filter_key = filter_key.split(".")[1]
 
-            assert (
-                build[filter_key] == filter_value
-            ), f"Wrong value for filter field {filter_key}. {build[filter_key]} != {filter_value}"
+            assert build[filter_key] == filter_value, (
+                f"Wrong value for filter field {filter_key}. {build[filter_key]} != {filter_value}"
+            )
 
 
 def assert_boots_filters(*, filters: dict, boot: dict):
@@ -60,9 +60,9 @@ def assert_boots_filters(*, filters: dict, boot: dict):
             else:
                 field_key = filter_key.split(".")[1]
 
-            assert (
-                boot[field_key] == filter_value or filter_value in boot[field_key]
-            ), f"Wrong value for filter field {filter_key}. {boot[filter_key]} != {filter_value}"
+            assert boot[field_key] == filter_value or filter_value in boot[field_key], (
+                f"Wrong value for filter field {filter_key}. {boot[filter_key]} != {filter_value}"
+            )
 
 
 def assert_tests_filters(*, filters: dict, test: dict):
@@ -76,6 +76,6 @@ def assert_tests_filters(*, filters: dict, test: dict):
             else:
                 field_key = filter_key.split(".")[1]
 
-            assert (
-                test[field_key] == filter_value or filter_value in test[field_key]
-            ), f"Wrong value for filter field {filter_key}. {test[filter_key]} != {filter_value}"
+            assert test[field_key] == filter_value or filter_value in test[field_key], (
+                f"Wrong value for filter field {filter_key}. {test[filter_key]} != {filter_value}"
+            )

--- a/backend/kernelCI_app/tests/utils/asserts.py
+++ b/backend/kernelCI_app/tests/utils/asserts.py
@@ -1,5 +1,6 @@
-import requests
 from http import HTTPStatus
+
+import requests
 
 
 def assert_status_code(*, response: requests.Response, status_code: HTTPStatus) -> None:

--- a/backend/kernelCI_app/tests/utils/client/baseClient.py
+++ b/backend/kernelCI_app/tests/utils/client/baseClient.py
@@ -1,8 +1,9 @@
+import os
 from abc import ABC
 from typing import Any, Optional
-from urllib.parse import urljoin, urlencode
+from urllib.parse import urlencode, urljoin
+
 from kernelCI_app.helpers.filters import FilterFields
-import os
 
 
 class BaseClient(ABC):

--- a/backend/kernelCI_app/tests/utils/client/baseClient.py
+++ b/backend/kernelCI_app/tests/utils/client/baseClient.py
@@ -30,7 +30,7 @@ class BaseClient(ABC):
             mapped_filters = self.get_filters(filters=filters)
             string_parts.append(urlencode(mapped_filters, doseq=True))
 
-        query_string = f"?{"&".join(string_parts)}" if string_parts else ""
+        query_string = f"?{'&'.join(string_parts)}" if string_parts else ""
 
         url = f"{url}{query_string}"
         return url

--- a/backend/kernelCI_app/tests/utils/client/buildClient.py
+++ b/backend/kernelCI_app/tests/utils/client/buildClient.py
@@ -1,6 +1,6 @@
-import requests
 from django.urls import reverse
 
+import requests
 from kernelCI_app.tests.utils.client.baseClient import BaseClient
 
 

--- a/backend/kernelCI_app/tests/utils/client/hardwareClient.py
+++ b/backend/kernelCI_app/tests/utils/client/hardwareClient.py
@@ -1,9 +1,11 @@
-import requests
+import json
+
 from django.urls import reverse
+
+import requests
 from kernelCI_app.tests.utils.client.baseClient import BaseClient
 from kernelCI_app.typeModels.hardwareDetails import HardwareDetailsPostBody
 from kernelCI_app.typeModels.hardwareListing import HardwareQueryParamsDocumentationOnly
-import json
 
 
 class HardwareClient(BaseClient):

--- a/backend/kernelCI_app/tests/utils/client/issueClient.py
+++ b/backend/kernelCI_app/tests/utils/client/issueClient.py
@@ -1,7 +1,9 @@
-from typing import Any
-import requests
-from django.urls import reverse
 import json
+from typing import Any
+
+from django.urls import reverse
+
+import requests
 from kernelCI_app.helpers.filters import FilterFields
 from kernelCI_app.tests.utils.client.baseClient import BaseClient
 

--- a/backend/kernelCI_app/tests/utils/client/originClient.py
+++ b/backend/kernelCI_app/tests/utils/client/originClient.py
@@ -1,6 +1,6 @@
-import requests
 from django.urls import reverse
 
+import requests
 from kernelCI_app.tests.utils.client.baseClient import BaseClient
 
 

--- a/backend/kernelCI_app/tests/utils/client/testClient.py
+++ b/backend/kernelCI_app/tests/utils/client/testClient.py
@@ -1,6 +1,6 @@
-import requests
 from django.urls import reverse
 
+import requests
 from kernelCI_app.tests.utils.client.baseClient import BaseClient
 from kernelCI_app.typeModels.testDetails import TestStatusHistoryRequest
 

--- a/backend/kernelCI_app/tests/utils/client/treeClient.py
+++ b/backend/kernelCI_app/tests/utils/client/treeClient.py
@@ -1,13 +1,15 @@
 from typing import Any, Literal
-import requests
+
 from django.urls import reverse
+
+import requests
 from kernelCI_app.helpers.filters import FilterFields
+from kernelCI_app.tests.utils.client.baseClient import BaseClient
 from kernelCI_app.typeModels.treeDetails import (
     DirectTreePathParameters,
     DirectTreeQueryParameters,
     TreeQueryParameters,
 )
-from kernelCI_app.tests.utils.client.baseClient import BaseClient
 
 
 class TreeClient(BaseClient):

--- a/backend/kernelCI_app/tests/utils/commonTreeAsserts.py
+++ b/backend/kernelCI_app/tests/utils/commonTreeAsserts.py
@@ -1,12 +1,13 @@
 from typing import Literal
-from kernelCI_app.typeModels.databases import StatusValues
+
 from kernelCI_app.tests.utils.asserts import (
-    assert_has_fields_in_response_content,
-    assert_build_filters,
     assert_boots_filters,
+    assert_build_filters,
+    assert_has_fields_in_response_content,
     assert_tests_filters,
 )
 from kernelCI_app.tests.utils.fields import tree
+from kernelCI_app.typeModels.databases import StatusValues
 
 type SummaryFields = Literal["builds", "boots", "tests"]
 

--- a/backend/kernelCI_app/tests/utils/hardwareDetailsCommonTestCases.py
+++ b/backend/kernelCI_app/tests/utils/hardwareDetailsCommonTestCases.py
@@ -1,7 +1,7 @@
-from http import HTTPStatus
-from kernelCI_app.typeModels.hardwareDetails import HardwareDetailsPostBody
 import copy
+from http import HTTPStatus
 
+from kernelCI_app.typeModels.hardwareDetails import HardwareDetailsPostBody
 
 UNEXISTENT_HARDWARE_ID: dict = {
     "id": "no hardware id",

--- a/backend/kernelCI_app/tests/utils/treeDetailsCommonTestCases.py
+++ b/backend/kernelCI_app/tests/utils/treeDetailsCommonTestCases.py
@@ -4,7 +4,6 @@ from kernelCI_app.typeModels.treeDetails import (
     TreeQueryParameters,
 )
 
-
 UNEXISTENT_TREE = {
     "id": "invalid id",
     "params": {

--- a/backend/kernelCI_app/typeModels/buildDetails.py
+++ b/backend/kernelCI_app/typeModels/buildDetails.py
@@ -1,30 +1,31 @@
 from typing import List, Optional
-from typing_extensions import Annotated
+
 from pydantic import BaseModel, RootModel
+from typing_extensions import Annotated
 
 from kernelCI_app.typeModels.common import make_default_validator
 from kernelCI_app.typeModels.commonDetails import BuildHistoryItem
 from kernelCI_app.typeModels.databases import (
     NULL_STATUS,
-    Origin,
-    StatusValues,
-    Timestamp,
-    Checkout__Id,
-    Checkout__TreeName,
+    Build__Command,
+    Build__Comment,
+    Build__InputFiles,
+    Build__LogExcerpt,
+    Build__OutputFiles,
     Checkout__GitCommitHash,
     Checkout__GitCommitName,
     Checkout__GitCommitTags,
-    Build__Command,
-    Build__Comment,
-    Build__LogExcerpt,
-    Build__InputFiles,
-    Build__OutputFiles,
-    Test__Id,
+    Checkout__Id,
+    Checkout__TreeName,
+    Origin,
+    StatusValues,
     Test__Duration,
-    Test__Path,
-    Test__StartTime,
     Test__EnvironmentCompatible,
     Test__EnvironmentMisc,
+    Test__Id,
+    Test__Path,
+    Test__StartTime,
+    Timestamp,
 )
 
 

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -1,7 +1,7 @@
 import json
 from collections import defaultdict
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional, Self, Union
 
 from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Annotated
@@ -40,7 +40,7 @@ class TestArchSummaryItem(BaseModel):
 class BuildArchitectures(StatusCount):
     compilers: Optional[list[str]] = []
 
-    def __iadd__(self, other: StatusCount) -> "BuildArchitectures":
+    def __iadd__(self, other: StatusCount) -> Self:
         self.PASS += other.PASS
         self.ERROR += other.ERROR
         self.FAIL += other.FAIL

--- a/backend/kernelCI_app/typeModels/commonDetails.py
+++ b/backend/kernelCI_app/typeModels/commonDetails.py
@@ -2,29 +2,30 @@ import json
 from collections import defaultdict
 from datetime import datetime
 from typing import Optional, Union
+
+from pydantic import BaseModel, Field, field_validator
 from typing_extensions import Annotated
 
-from pydantic import BaseModel, field_validator, Field
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.typeModels.common import StatusCount, make_default_validator
-from kernelCI_app.typeModels.issues import Issue
 from kernelCI_app.typeModels.databases import (
     NULL_STATUS,
-    EnvironmentMisc,
-    Build__Id,
     Build__Architecture,
-    Build__ConfigName,
-    Build__Misc,
-    Build__ConfigUrl,
     Build__Compiler,
-    Build__Status,
-    Build__LogUrl,
-    Build__StartTime,
+    Build__ConfigName,
+    Build__ConfigUrl,
     Build__Duration,
-    Checkout__GitRepositoryUrl,
+    Build__Id,
+    Build__LogUrl,
+    Build__Misc,
+    Build__StartTime,
+    Build__Status,
     Checkout__GitRepositoryBranch,
+    Checkout__GitRepositoryUrl,
+    EnvironmentMisc,
     Origin,
 )
+from kernelCI_app.typeModels.issues import Issue
 
 
 class TestArchSummaryItem(BaseModel):

--- a/backend/kernelCI_app/typeModels/commonListing.py
+++ b/backend/kernelCI_app/typeModels/commonListing.py
@@ -1,4 +1,5 @@
 from typing import Annotated, Optional
+
 from pydantic import BaseModel, Field
 
 from kernelCI_app.constants.general import DEFAULT_INTERVAL_IN_DAYS, DEFAULT_ORIGIN

--- a/backend/kernelCI_app/typeModels/commonOpenApiParameters.py
+++ b/backend/kernelCI_app/typeModels/commonOpenApiParameters.py
@@ -1,4 +1,5 @@
 from drf_spectacular.utils import OpenApiParameter
+
 from kernelCI_app.constants.localization import DocStrings
 
 COMMIT_HASH_PATH_PARAM = OpenApiParameter(

--- a/backend/kernelCI_app/typeModels/databases.py
+++ b/backend/kernelCI_app/typeModels/databases.py
@@ -1,5 +1,6 @@
-from typing import List, Optional, Dict, Literal, Any, Union, Annotated
 from datetime import datetime
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+
 from pydantic import BaseModel, ConfigDict
 
 # TODO: remove these status types in favor of the StatusChoices enum class

--- a/backend/kernelCI_app/typeModels/detailsIssuesView.py
+++ b/backend/kernelCI_app/typeModels/detailsIssuesView.py
@@ -1,4 +1,5 @@
 from pydantic import RootModel
+
 from kernelCI_app.typeModels.issues import Issue
 
 

--- a/backend/kernelCI_app/typeModels/hardwareDetails.py
+++ b/backend/kernelCI_app/typeModels/hardwareDetails.py
@@ -1,8 +1,10 @@
 from datetime import datetime
 from typing import Annotated, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, Field
+
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
-
 from kernelCI_app.typeModels.common import make_default_validator
 from kernelCI_app.typeModels.commonDetails import (
     BuildHistoryItem,
@@ -11,17 +13,15 @@ from kernelCI_app.typeModels.commonDetails import (
     Summary,
     TestHistoryItem,
 )
-
 from kernelCI_app.typeModels.databases import (
     NULL_STATUS,
+    Checkout__GitRepositoryBranch,
+    Checkout__TreeName,
     Issue__Id,
+    Issue__Version,
     Origin,
     StatusValues,
-    Checkout__TreeName,
-    Checkout__GitRepositoryBranch,
-    Issue__Version,
 )
-from pydantic import BaseModel, Field
 
 
 class HardwareDetailsQueryParameters(BaseModel):

--- a/backend/kernelCI_app/typeModels/hardwareListing.py
+++ b/backend/kernelCI_app/typeModels/hardwareListing.py
@@ -1,10 +1,11 @@
 from datetime import datetime
-from pydantic import BaseModel, BeforeValidator, Field
 from typing import Annotated, Optional, Union
 
+from pydantic import BaseModel, BeforeValidator, Field
+
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
-from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.constants.localization import DocStrings
+from kernelCI_app.typeModels.common import StatusCount
 
 
 class HardwareItem(BaseModel):

--- a/backend/kernelCI_app/typeModels/hardwareListingV2.py
+++ b/backend/kernelCI_app/typeModels/hardwareListingV2.py
@@ -1,10 +1,11 @@
 from datetime import datetime
-from kernelCI_app.typeModels.commonListing import StatusCountV2
-from pydantic import BaseModel, BeforeValidator, Field
 from typing import Annotated, Optional, Union
+
+from pydantic import BaseModel, BeforeValidator, Field
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
+from kernelCI_app.typeModels.commonListing import StatusCountV2
 
 
 class HardwareItemV2(BaseModel):

--- a/backend/kernelCI_app/typeModels/issueDetails.py
+++ b/backend/kernelCI_app/typeModels/issueDetails.py
@@ -1,44 +1,44 @@
 from typing import List, Optional
-from typing_extensions import Annotated
-from pydantic import BaseModel, BeforeValidator, RootModel, Field
-from kernelCI_app.constants.localization import DocStrings
 
+from pydantic import BaseModel, BeforeValidator, Field, RootModel
+from typing_extensions import Annotated
+
+from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.common import make_default_validator
 from kernelCI_app.typeModels.databases import (
     NULL_STATUS,
-    Build__Id,
     Build__Architecture,
-    Build__ConfigName,
-    Build__Misc,
-    Build__Status,
-    Build__StartTime,
-    Build__Duration,
     Build__Compiler,
+    Build__ConfigName,
+    Build__Duration,
+    Build__Id,
     Build__LogUrl,
+    Build__Misc,
+    Build__StartTime,
+    Build__Status,
+    Checkout__GitRepositoryBranch,
+    Checkout__TreeName,
     Issue__Categories,
-    Issue__Id,
-    Issue__Version,
-    Issue__ReportUrl,
-    Issue__ReportSubject,
-    Issue__CulpritCode,
-    Issue__CulpritTool,
-    Issue__CulpritHarness,
     Issue__Comment,
+    Issue__CulpritCode,
+    Issue__CulpritHarness,
+    Issue__CulpritTool,
+    Issue__Id,
     Issue__Misc,
+    Issue__ReportSubject,
+    Issue__ReportUrl,
+    Issue__Version,
     Origin,
     StatusValues,
-    Test__Id,
     Test__Duration,
-    Test__Path,
-    Test__StartTime,
     Test__EnvironmentCompatible,
     Test__EnvironmentMisc,
+    Test__Id,
+    Test__Path,
+    Test__StartTime,
     Timestamp,
-    Checkout__TreeName,
-    Checkout__GitRepositoryBranch,
 )
 from kernelCI_app.typeModels.issues import ProcessedExtraDetailedIssues
-
 from kernelCI_app.utils import validate_str_to_dict
 
 

--- a/backend/kernelCI_app/typeModels/issueListing.py
+++ b/backend/kernelCI_app/typeModels/issueListing.py
@@ -1,7 +1,8 @@
 from typing import Optional
-from pydantic import BaseModel, Field
-from kernelCI_app.constants.localization import DocStrings
 
+from pydantic import BaseModel, Field
+
+from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.commonListing import ListingInterval
 from kernelCI_app.typeModels.databases import (
     Issue__Categories,
@@ -11,8 +12,8 @@ from kernelCI_app.typeModels.databases import (
     Issue__CulpritTool,
     Issue__Id,
     Issue__Version,
-    Timestamp,
     Origin,
+    Timestamp,
 )
 from kernelCI_app.typeModels.issues import FirstIncident
 

--- a/backend/kernelCI_app/typeModels/issues.py
+++ b/backend/kernelCI_app/typeModels/issues.py
@@ -1,16 +1,17 @@
-from typing import Literal, Optional, Annotated
+from typing import Annotated, Literal, Optional
+
 from pydantic import BaseModel, Field
 
 from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.databases import (
+    Checkout__GitCommitHash,
+    Checkout__GitCommitName,
+    Checkout__GitRepositoryBranch,
+    Checkout__GitRepositoryUrl,
+    Checkout__TreeName,
     Issue__Version,
     Timestamp,
-    Checkout__GitCommitHash,
-    Checkout__GitRepositoryUrl,
-    Checkout__GitRepositoryBranch,
-    Checkout__GitCommitName,
-    Checkout__TreeName,
 )
 
 

--- a/backend/kernelCI_app/typeModels/logDownloader.py
+++ b/backend/kernelCI_app/typeModels/logDownloader.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+
 from pydantic import BaseModel, Field
 
 from kernelCI_app.constants.localization import DocStrings

--- a/backend/kernelCI_app/typeModels/modelTypes.py
+++ b/backend/kernelCI_app/typeModels/modelTypes.py
@@ -3,9 +3,9 @@ from kernelCI_app.models import Builds, Checkouts, Incidents, Issues, Tests
 
 type TableNames = Literal["issues", "checkouts", "builds", "tests", "incidents"]
 type TableModels = Issues | Checkouts | Builds | Tests | Incidents
-type TableModelsClass = Type[Issues] | Type[Checkouts] | Type[Builds] | Type[
-    Tests
-] | Type[Incidents]
+type TableModelsClass = (
+    Type[Issues] | Type[Checkouts] | Type[Builds] | Type[Tests] | Type[Incidents]
+)
 
 MODEL_MAP: dict[TableNames, TableModelsClass] = {
     "issues": Issues,

--- a/backend/kernelCI_app/typeModels/modelTypes.py
+++ b/backend/kernelCI_app/typeModels/modelTypes.py
@@ -1,4 +1,5 @@
 from typing import Literal, Type
+
 from kernelCI_app.models import Builds, Checkouts, Incidents, Issues, Tests
 
 type TableNames = Literal["issues", "checkouts", "builds", "tests", "incidents"]

--- a/backend/kernelCI_app/typeModels/testDetails.py
+++ b/backend/kernelCI_app/typeModels/testDetails.py
@@ -1,34 +1,35 @@
 from typing import Literal, Optional
-from typing_extensions import Annotated
+
 from pydantic import BaseModel, BeforeValidator, Field
+from typing_extensions import Annotated
+
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
-
 from kernelCI_app.typeModels.common import make_default_validator
 from kernelCI_app.typeModels.databases import (
     NULL_STATUS,
+    Build__Architecture,
+    Build__Compiler,
+    Build__ConfigName,
+    Build__Id,
+    Checkout__GitCommitHash,
+    Checkout__GitCommitTags,
+    Checkout__GitRepositoryBranch,
+    Checkout__GitRepositoryUrl,
+    Checkout__TreeName,
     Origin,
     StatusValues,
+    Test__EnvironmentCompatible,
+    Test__EnvironmentMisc,
     Test__Id,
-    Build__Id,
-    Test__Status,
-    Test__Path,
+    Test__InputFiles,
     Test__LogExcerpt,
     Test__LogUrl,
     Test__Misc,
-    Test__EnvironmentMisc,
-    Test__StartTime,
-    Test__EnvironmentCompatible,
     Test__OutputFiles,
-    Test__InputFiles,
-    Build__Compiler,
-    Build__Architecture,
-    Build__ConfigName,
-    Checkout__GitCommitHash,
-    Checkout__GitRepositoryBranch,
-    Checkout__GitRepositoryUrl,
-    Checkout__GitCommitTags,
-    Checkout__TreeName,
+    Test__Path,
+    Test__StartTime,
+    Test__Status,
     Timestamp,
 )
 from kernelCI_app.utils import validate_str_to_dict

--- a/backend/kernelCI_app/typeModels/treeCommits.py
+++ b/backend/kernelCI_app/typeModels/treeCommits.py
@@ -1,18 +1,18 @@
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional
-from pydantic import BaseModel, RootModel, field_validator
+
+from pydantic import BaseModel, Field, RootModel, field_validator
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.common import StatusCount
-from kernelCI_app.typeModels.treeListing import TestStatusCount
-from pydantic import Field
 from kernelCI_app.typeModels.databases import (
     Checkout__GitCommitHash,
     Checkout__GitCommitName,
     Checkout__GitCommitTags,
 )
+from kernelCI_app.typeModels.treeListing import TestStatusCount
 
 
 class TreeEntityTypes(str, Enum):

--- a/backend/kernelCI_app/typeModels/treeDetails.py
+++ b/backend/kernelCI_app/typeModels/treeDetails.py
@@ -1,16 +1,17 @@
 from typing import List, Optional
 
+from pydantic import BaseModel, Field
+
+from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.commonDetails import (
     BuildHistoryItem,
-    DetailsFilters,
-    Summary,
     CommonDetailsBootsResponse,
     CommonDetailsTestsResponse,
+    DetailsFilters,
+    Summary,
 )
 from kernelCI_app.typeModels.treeListing import BaseCheckouts
-from pydantic import BaseModel, Field
-from kernelCI_app.constants.general import DEFAULT_ORIGIN
 
 
 class TreeLatestPathParameters(BaseModel):

--- a/backend/kernelCI_app/typeModels/treeListing.py
+++ b/backend/kernelCI_app/typeModels/treeListing.py
@@ -1,21 +1,23 @@
 from typing import List
+
+from pydantic import BaseModel, Field, RootModel
+
 from kernelCI_app.typeModels.common import StatusCount
 from kernelCI_app.typeModels.commonListing import StatusCountV2
 from kernelCI_app.typeModels.databases import (
     Checkout__GitCommitHash,
     Checkout__GitCommitName,
     Checkout__GitCommitTags,
-    Checkout__TreeName,
-    Checkout__Id,
-    Checkout__PatchsetHash,
     Checkout__GitRepositoryBranch,
     Checkout__GitRepositoryUrl,
+    Checkout__Id,
     Checkout__OriginBuildsFinishTime,
     Checkout__OriginTestsFinishTime,
+    Checkout__PatchsetHash,
+    Checkout__TreeName,
     Origin,
     Timestamp,
 )
-from pydantic import BaseModel, Field, RootModel
 
 
 class TestStatusCount(BaseModel):

--- a/backend/kernelCI_app/typeModels/treeReport.py
+++ b/backend/kernelCI_app/typeModels/treeReport.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 from typing import TypedDict
-from kernelCI_app.typeModels.issues import CheckoutIssue
-from typing_extensions import Annotated
+
 from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
 from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.common import StatusCount, make_default_validator
 from kernelCI_app.typeModels.databases import Test__Id, Test__StartTime, Test__Status
+from kernelCI_app.typeModels.issues import CheckoutIssue
 from kernelCI_app.typeModels.treeListing import TestStatusCount
 
 DEFAULT_PATH_SEARCH = ["%"]

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -1,12 +1,13 @@
+from django.conf import settings
 from django.urls import path
 from django.views.decorators.cache import cache_page
-from django.conf import settings
-from kernelCI_app import views
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
     SpectacularSwaggerView,
 )
+
+from kernelCI_app import views
 
 timeout = settings.CACHE_TIMEOUT
 cache = cache_page(timeout)

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -1,10 +1,10 @@
 import json
 import os
-from typing import Union, List, Optional
-from django.utils import timezone
 from datetime import timedelta
+from typing import List, Optional, Union
 
 import yaml
+from django.utils import timezone
 
 from kernelCI_app.constants.general import DEFAULT_INTERVAL_IN_DAYS
 from kernelCI_app.helpers.logger import log_message

--- a/backend/kernelCI_app/views/__init__.py
+++ b/backend/kernelCI_app/views/__init__.py
@@ -1,8 +1,7 @@
-import os
 import glob
 import importlib
+import os
 import sys
-
 
 current_dir = os.path.dirname(__file__)
 modules = glob.glob(os.path.join(current_dir, "*.py"))

--- a/backend/kernelCI_app/views/buildDetailsView.py
+++ b/backend/kernelCI_app/views/buildDetailsView.py
@@ -1,13 +1,15 @@
 from http import HTTPStatus
-from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.typeModels.buildDetails import BuildDetailsResponse
+
 from drf_spectacular.utils import extend_schema
-from rest_framework.views import APIView
-from rest_framework.response import Response
 from pydantic import ValidationError
-from kernelCI_app.queries.build import get_build_details
-from kernelCI_app.typeModels.commonOpenApiParameters import BUILD_ID_PATH_PARAM
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.queries.build import get_build_details
+from kernelCI_app.typeModels.buildDetails import BuildDetailsResponse
+from kernelCI_app.typeModels.commonOpenApiParameters import BUILD_ID_PATH_PARAM
 
 
 class BuildDetails(APIView):

--- a/backend/kernelCI_app/views/buildIssuesView.py
+++ b/backend/kernelCI_app/views/buildIssuesView.py
@@ -1,15 +1,16 @@
-from rest_framework.views import APIView
-from rest_framework.response import Response
+from http import HTTPStatus
+
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.detailsIssues import sanitize_details_issues_rows
 from kernelCI_app.helpers.errorHandling import create_api_error_response
-from http import HTTPStatus
 from kernelCI_app.queries.issues import get_build_issues
-from kernelCI_app.typeModels.detailsIssuesView import DetailsIssuesResponse
 from kernelCI_app.typeModels.commonOpenApiParameters import BUILD_ID_PATH_PARAM
-from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.typeModels.detailsIssuesView import DetailsIssuesResponse
 
 
 class BuildIssuesView(APIView):

--- a/backend/kernelCI_app/views/buildTestsView.py
+++ b/backend/kernelCI_app/views/buildTestsView.py
@@ -1,16 +1,18 @@
 from http import HTTPStatus
+
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.logger import create_endpoint_notification
 from kernelCI_app.queries.build import get_build_tests
 from kernelCI_app.typeModels.buildDetails import BuildTestsResponse
-from drf_spectacular.utils import extend_schema
-from kernelCI_app.typeModels.databases import FAIL_STATUS
 from kernelCI_app.typeModels.commonOpenApiParameters import BUILD_ID_PATH_PARAM
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from pydantic import ValidationError
-from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.typeModels.databases import FAIL_STATUS
 
 
 class BuildTests(APIView):

--- a/backend/kernelCI_app/views/hardwareDetailsBootsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBootsView.py
@@ -1,9 +1,17 @@
+import json
 from datetime import datetime
+from http import HTTPStatus
+from typing import Dict, List, Optional
+
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.utils import extend_schema
-from http import HTTPStatus
-import json
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.hardwareDetails import (
     assign_default_record_values,
     decide_if_is_full_record_filtered_out,
@@ -18,23 +26,17 @@ from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
     get_hardware_trees_data,
 )
-from kernelCI_app.typeModels.hardwareDetails import (
-    HardwareDetailsPostBody,
-    HardwareDetailsQueryParameters,
-    HardwareTestHistoryItem,
-    HardwareDetailsBootsResponse,
-    Tree,
-)
-from kernelCI_app.utils import is_boot
-from pydantic import ValidationError
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from typing import Dict, List, Optional
-from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.typeModels.commonOpenApiParameters import (
     HARDWARE_ID_PATH_PARAM,
 )
-from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.typeModels.hardwareDetails import (
+    HardwareDetailsBootsResponse,
+    HardwareDetailsPostBody,
+    HardwareDetailsQueryParameters,
+    HardwareTestHistoryItem,
+    Tree,
+)
+from kernelCI_app.utils import is_boot
 
 
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/

--- a/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsBuildsView.py
@@ -10,6 +10,8 @@ from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import FilterParams
 from kernelCI_app.helpers.hardwareDetails import (
     assign_default_record_values,
@@ -34,8 +36,6 @@ from kernelCI_app.typeModels.hardwareDetails import (
     HardwareDetailsPostBody,
     Tree,
 )
-from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.constants.localization import ClientStrings
 
 
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/

--- a/backend/kernelCI_app/views/hardwareDetailsCommitHistoryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsCommitHistoryView.py
@@ -1,10 +1,18 @@
-from collections import defaultdict
 import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from http import HTTPStatus
+
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.logger import log_message
-from django.utils.decorators import method_decorator
-from datetime import datetime, timezone
-from django.views.decorators.csrf import csrf_exempt
 from kernelCI_app.helpers.trees import make_tree_identifier_key
 from kernelCI_app.queries.hardware import get_hardware_commit_history
 from kernelCI_app.typeModels.commonOpenApiParameters import (
@@ -15,12 +23,6 @@ from kernelCI_app.typeModels.hardwareDetails import (
     CommitHistoryValidCheckout,
     HardwareCommitHistoryResponse,
 )
-from pydantic import ValidationError
-from http import HTTPStatus
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from drf_spectacular.utils import extend_schema
-from kernelCI_app.constants.localization import ClientStrings
 
 
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -1,14 +1,19 @@
+import json
 from collections import defaultdict
 from datetime import datetime
+from http import HTTPStatus
 from itertools import chain
 from typing import Dict, Optional
+
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.utils import extend_schema
-from http import HTTPStatus
-import json
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from kernelCI_app.constants.general import UNKNOWN_STRING
-from kernelCI_app.helpers.issueExtras import parse_issue
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
@@ -20,6 +25,7 @@ from kernelCI_app.helpers.hardwareDetails import (
     generate_test_summary_typed,
     unstable_parse_post_body,
 )
+from kernelCI_app.helpers.issueExtras import parse_issue
 from kernelCI_app.queries.hardware import (
     get_hardware_details_summary,
     get_hardware_trees_head_commits,
@@ -45,10 +51,6 @@ from kernelCI_app.typeModels.hardwareDetails import (
     HardwareTestLocalFilters,
     Tree,
 )
-from pydantic import ValidationError
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from kernelCI_app.constants.localization import ClientStrings
 
 
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/
@@ -328,7 +330,7 @@ class HardwareDetailsSummary(APIView):
             status_count = StatusCount()
             status_count.increment(status, count)
 
-            if not (tree_name, git_repository_url, git_repository_branch) in all_trees:
+            if (tree_name, git_repository_url, git_repository_branch) not in all_trees:
                 all_trees[(tree_name, git_repository_url, git_repository_branch)] = (
                     Tree(
                         index="",  # if we dont mind to sort, we can just use len(all_trees)

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -58,7 +58,6 @@ from kernelCI_app.constants.localization import ClientStrings
 # supported in this project
 @method_decorator(csrf_exempt, name="dispatch")
 class HardwareDetailsSummary(APIView):
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.origin: str = None
@@ -531,7 +530,6 @@ class HardwareDetailsSummary(APIView):
             return validation_error
 
         try:
-
             tree_heads = get_hardware_trees_head_commits(
                 hardware_id=hardware_id,
                 origin=self.origin,

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -158,7 +158,7 @@ class HardwareDetailsSummary(APIView):
             is_test = instance["is_test"]
             is_boot = instance["is_boot"]
             (compiler, architecture) = [
-                (val or UNKNOWN_STRING).strip(" []''")
+                (val or UNKNOWN_STRING).strip(" []''")  # noqa: B005
                 for val in (instance["compiler_arch"] or [None, None])
             ]
 

--- a/backend/kernelCI_app/views/hardwareDetailsTestsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsTestsView.py
@@ -1,9 +1,17 @@
+import json
 from datetime import datetime
+from http import HTTPStatus
+from typing import Dict, List, Optional
+
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.utils import extend_schema
-from http import HTTPStatus
-import json
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.hardwareDetails import (
     assign_default_record_values,
     decide_if_is_full_record_filtered_out,
@@ -24,17 +32,11 @@ from kernelCI_app.typeModels.commonOpenApiParameters import (
 from kernelCI_app.typeModels.hardwareDetails import (
     HardwareDetailsPostBody,
     HardwareDetailsQueryParameters,
-    HardwareTestHistoryItem,
     HardwareDetailsTestsResponse,
+    HardwareTestHistoryItem,
     Tree,
 )
 from kernelCI_app.utils import is_boot
-from pydantic import ValidationError
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from typing import Dict, List, Optional
-from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.constants.localization import ClientStrings
 
 
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/

--- a/backend/kernelCI_app/views/hardwareDetailsView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsView.py
@@ -1,10 +1,17 @@
+import json
 from collections import defaultdict
 from datetime import datetime
-import json
+from http import HTTPStatus
+from typing import Dict, List, Literal, Set
+
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.utils import extend_schema
-from http import HTTPStatus
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import FilterParams
@@ -23,6 +30,7 @@ from kernelCI_app.helpers.hardwareDetails import (
     get_trees_with_selected_commit,
     get_validated_current_tree,
     handle_build,
+    handle_test_history,
     handle_test_summary,
     handle_tree_status_summary,
     is_issue_processed,
@@ -31,7 +39,6 @@ from kernelCI_app.helpers.hardwareDetails import (
     process_issue,
     set_trees_status_summary,
     unstable_parse_post_body,
-    handle_test_history,
 )
 from kernelCI_app.queries.hardware import (
     get_hardware_details_data,
@@ -60,11 +67,6 @@ from kernelCI_app.typeModels.hardwareDetails import (
 )
 from kernelCI_app.utils import is_boot
 from kernelCI_app.viewCommon import create_details_build_summary
-from pydantic import ValidationError
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from typing import Dict, List, Literal, Set
-from kernelCI_app.constants.localization import ClientStrings
 
 
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/

--- a/backend/kernelCI_app/views/hardwareView.py
+++ b/backend/kernelCI_app/views/hardwareView.py
@@ -6,17 +6,18 @@ from pydantic import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
+from kernelCI_app.queries.hardware import get_hardware_listing_data
 from kernelCI_app.typeModels.hardwareListing import (
     HardwareItem,
+    HardwareListingResponse,
     HardwareQueryParams,
     HardwareQueryParamsDocumentationOnly,
-    HardwareListingResponse,
 )
-from kernelCI_app.queries.hardware import get_hardware_listing_data
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class HardwareView(APIView):

--- a/backend/kernelCI_app/views/hardwareViewV2.py
+++ b/backend/kernelCI_app/views/hardwareViewV2.py
@@ -7,20 +7,20 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
-)
-from kernelCI_app.typeModels.hardwareListingV2 import (
-    HardwareItemV2,
-    HardwareQueryParamsV2,
-    HardwareQueryParamsV2DocumentationOnly,
-    HardwareListingResponseV2,
-    StatusCountV2,
 )
 from kernelCI_app.queries.hardware import (
     get_hardware_listing_data_from_status_table,
 )
-from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.typeModels.hardwareListingV2 import (
+    HardwareItemV2,
+    HardwareListingResponseV2,
+    HardwareQueryParamsV2,
+    HardwareQueryParamsV2DocumentationOnly,
+    StatusCountV2,
+)
 
 
 class HardwareViewV2(APIView):

--- a/backend/kernelCI_app/views/issueDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/issueDetailsBuildsView.py
@@ -1,21 +1,23 @@
 from http import HTTPStatus
 from typing import Optional
+
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
 from kernelCI_app.helpers.misc import handle_misc
+from kernelCI_app.queries.issues import get_issue_builds
 from kernelCI_app.typeModels.commonOpenApiParameters import ISSUE_ID_PATH_PARAM
 from kernelCI_app.typeModels.issueDetails import (
     IssueBuildsResponse,
     IssueDetailsPathParameters,
     IssueDetailsQueryParameters,
 )
-from kernelCI_app.queries.issues import get_issue_builds
-from drf_spectacular.utils import extend_schema
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from pydantic import ValidationError
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class IssueDetailsBuilds(APIView):

--- a/backend/kernelCI_app/views/issueDetailsTestsView.py
+++ b/backend/kernelCI_app/views/issueDetailsTestsView.py
@@ -2,6 +2,12 @@ from http import HTTPStatus
 from typing import Optional
 
 from django.http import HttpRequest
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.queries.issues import get_issue_tests
 from kernelCI_app.typeModels.commonOpenApiParameters import ISSUE_ID_PATH_PARAM
@@ -10,11 +16,6 @@ from kernelCI_app.typeModels.issueDetails import (
     IssueDetailsQueryParameters,
     IssueTestsResponse,
 )
-from drf_spectacular.utils import extend_schema
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from pydantic import ValidationError
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class IssueDetailsTests(APIView):

--- a/backend/kernelCI_app/views/issueDetailsView.py
+++ b/backend/kernelCI_app/views/issueDetailsView.py
@@ -1,6 +1,14 @@
 from http import HTTPStatus
 from typing import Optional
+
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.helpers.issueExtras import process_issues_extra_details
 from kernelCI_app.queries.issues import get_issue_details, get_latest_issue_version
 from kernelCI_app.typeModels.commonOpenApiParameters import ISSUE_ID_PATH_PARAM
 from kernelCI_app.typeModels.issueDetails import (
@@ -8,12 +16,6 @@ from kernelCI_app.typeModels.issueDetails import (
     IssueDetailsQueryParameters,
     IssueDetailsResponse,
 )
-from kernelCI_app.helpers.issueExtras import process_issues_extra_details
-from drf_spectacular.utils import extend_schema
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from pydantic import ValidationError
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class IssueDetails(APIView):

--- a/backend/kernelCI_app/views/issueExtrasView.py
+++ b/backend/kernelCI_app/views/issueExtrasView.py
@@ -1,8 +1,14 @@
-from http import HTTPStatus
 import json
+from http import HTTPStatus
 
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.issueExtras import (
     process_issues_extra_details,
@@ -12,11 +18,6 @@ from kernelCI_app.typeModels.issues import (
     IssueExtraDetailsResponse,
     ProcessedExtraDetailedIssues,
 )
-from drf_spectacular.utils import extend_schema
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from pydantic import ValidationError
-from kernelCI_app.constants.localization import ClientStrings
 
 
 # disable django csrf protection https://docs.djangoproject.com/en/5.0/ref/csrf/

--- a/backend/kernelCI_app/views/issueView.py
+++ b/backend/kernelCI_app/views/issueView.py
@@ -1,12 +1,14 @@
 from datetime import datetime
 from http import HTTPStatus
 from typing import Optional
+
 from django.http import HttpRequest
 from drf_spectacular.utils import extend_schema
-from rest_framework.views import APIView
-from rest_framework.response import Response
 from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.dateRange import resolve_date_range
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
@@ -17,8 +19,8 @@ from kernelCI_app.helpers.issueListing import should_discard_issue_record
 from kernelCI_app.queries.issues import get_issue_listing_data
 from kernelCI_app.typeModels.issueListing import (
     IssueListingFilters,
-    IssueListingResponse,
     IssueListingQueryParameters,
+    IssueListingResponse,
 )
 from kernelCI_app.typeModels.issues import (
     CULPRIT_CODE,
@@ -28,7 +30,6 @@ from kernelCI_app.typeModels.issues import (
     PossibleIssueCulprits,
     ProcessedExtraDetailedIssues,
 )
-from kernelCI_app.constants.localization import ClientStrings
 
 
 def _resolve_issue_date_wrapper(

--- a/backend/kernelCI_app/views/logDownloaderView.py
+++ b/backend/kernelCI_app/views/logDownloaderView.py
@@ -1,16 +1,18 @@
-from bs4 import BeautifulSoup, Tag
-import requests
 from http import HTTPStatus
-from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.typeModels.logDownloader import (
-    LogDownloaderResponse,
-    LogDownloaderQueryParameters,
-)
-from rest_framework.views import APIView
-from rest_framework.response import Response
+
+from bs4 import BeautifulSoup, Tag
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+import requests
 from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.typeModels.logDownloader import (
+    LogDownloaderQueryParameters,
+    LogDownloaderResponse,
+)
 
 
 def scrape_log_data(url):

--- a/backend/kernelCI_app/views/originsView.py
+++ b/backend/kernelCI_app/views/originsView.py
@@ -1,16 +1,15 @@
 from http import HTTPStatus
 
+from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
-from kernelCI_app.helpers.errorHandling import create_api_error_response
-from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.queries.checkout import get_origins
-from drf_spectacular.utils import extend_schema
-
 from kernelCI_app.typeModels.origins import OriginsQueryParameters, OriginsResponse
-from kernelCI_app.constants.localization import ClientStrings
-
 
 # For now we are hardcoding test origins since fetching them dynamically in a query is taking
 # around 8 minutes to finish. That time will result in a timeout every request, so this is a

--- a/backend/kernelCI_app/views/proxyView.py
+++ b/backend/kernelCI_app/views/proxyView.py
@@ -1,13 +1,15 @@
-from urllib.parse import ParseResult, urlparse
-import requests
 from fnmatch import fnmatch
-from rest_framework.views import APIView
-from django.http import HttpResponse
 from http import HTTPStatus
+from urllib.parse import ParseResult, urlparse
+
+from django.http import HttpResponse
 from drf_spectacular.utils import extend_schema
+from rest_framework.views import APIView
+
+import requests
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.typeModels.commonOpenApiParameters import URL_QUERY_PARAM
-from kernelCI_app.constants.localization import ClientStrings
 
 # TIMEOUT to avoid people sending very large files through the proxy
 TIMEOUT_TIME_IN_SECONDS = 45

--- a/backend/kernelCI_app/views/testDetailsView.py
+++ b/backend/kernelCI_app/views/testDetailsView.py
@@ -1,15 +1,17 @@
 from http import HTTPStatus
+
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.queries.test import get_test_details_data
 from kernelCI_app.typeModels.commonOpenApiParameters import TEST_ID_PATH_PARAM
 from kernelCI_app.typeModels.testDetails import (
     TestDetailsResponse,
 )
-from drf_spectacular.utils import extend_schema
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from pydantic import ValidationError
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class TestDetails(APIView):

--- a/backend/kernelCI_app/views/testIssuesView.py
+++ b/backend/kernelCI_app/views/testIssuesView.py
@@ -1,15 +1,16 @@
-from rest_framework.views import APIView
-from rest_framework.response import Response
+from http import HTTPStatus
+
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.detailsIssues import sanitize_details_issues_rows
 from kernelCI_app.helpers.errorHandling import create_api_error_response
-from http import HTTPStatus
 from kernelCI_app.queries.issues import get_test_issues
 from kernelCI_app.typeModels.commonOpenApiParameters import TEST_ID_PATH_PARAM
 from kernelCI_app.typeModels.detailsIssuesView import DetailsIssuesResponse
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class TestIssuesView(APIView):

--- a/backend/kernelCI_app/views/testStatusHistoryView.py
+++ b/backend/kernelCI_app/views/testStatusHistoryView.py
@@ -1,6 +1,12 @@
 from http import HTTPStatus
 
 from django.http import HttpRequest
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.queries.test import get_test_status_history
 from kernelCI_app.typeModels.databases import FAIL_STATUS, PASS_STATUS
@@ -9,11 +15,6 @@ from kernelCI_app.typeModels.testDetails import (
     TestStatusHistoryRequest,
     TestStatusHistoryResponse,
 )
-from drf_spectacular.utils import extend_schema
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from pydantic import ValidationError
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class TestStatusHistory(APIView):

--- a/backend/kernelCI_app/views/treeCommitsHistory.py
+++ b/backend/kernelCI_app/views/treeCommitsHistory.py
@@ -1,39 +1,43 @@
 from datetime import datetime, timezone
 from http import HTTPStatus
+from typing import Optional
 
 from django.http import HttpRequest
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.general import (
+    MAESTRO_DUMMY_BUILD_PREFIX,
+    UNCATEGORIZED_STRING,
+    UNKNOWN_STRING,
+)
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
     InvalidComparisonOPError,
 )
-from kernelCI_app.constants.general import UNCATEGORIZED_STRING, UNKNOWN_STRING
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.helpers.misc import (
     handle_misc,
     misc_value_or_default,
 )
+from kernelCI_app.queries.tree import get_tree_commit_history
 from kernelCI_app.typeModels.commonOpenApiParameters import (
     COMMIT_HASH_PATH_PARAM,
     GIT_BRANCH_PATH_PARAM,
     TREE_NAME_PATH_PARAM,
 )
 from kernelCI_app.typeModels.databases import FAIL_STATUS, NULL_STATUS, StatusValues
-from kernelCI_app.utils import is_boot, sanitize_dict
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from drf_spectacular.utils import extend_schema
-from typing import Optional
 from kernelCI_app.typeModels.treeCommits import (
     DirectTreeCommitsQueryParameters,
     TreeCommitsQueryParameters,
     TreeCommitsResponse,
     TreeEntityTypes,
 )
-from pydantic import ValidationError
-from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
-from kernelCI_app.queries.tree import get_tree_commit_history
-from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.utils import is_boot, sanitize_dict
 
 
 # TODO Move this endpoint to a function so it doesn't

--- a/backend/kernelCI_app/views/treeDetailsBootsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBootsView.py
@@ -4,19 +4,24 @@ from typing import Optional
 from django.http import HttpRequest
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
     FilterParams,
 )
-from rest_framework.views import APIView
-from rest_framework.response import Response
 from kernelCI_app.helpers.treeDetails import (
     decide_if_is_boot_filtered_out,
     decide_if_is_full_row_filtered_out,
     get_current_row_data,
 )
 from kernelCI_app.queries.tree import get_tree_data
+from kernelCI_app.typeModels.commonDetails import (
+    CommonDetailsBootsResponse,
+    TestHistoryItem,
+)
 from kernelCI_app.typeModels.commonOpenApiParameters import (
     COMMIT_HASH_PATH_PARAM,
     GIT_BRANCH_PATH_PARAM,
@@ -25,10 +30,6 @@ from kernelCI_app.typeModels.commonOpenApiParameters import (
 from kernelCI_app.typeModels.treeDetails import (
     DirectTreeDetailsQueryParameters,
     TreeDetailsQueryParameters,
-)
-from kernelCI_app.typeModels.commonDetails import (
-    CommonDetailsBootsResponse,
-    TestHistoryItem,
 )
 from kernelCI_app.utils import is_boot
 

--- a/backend/kernelCI_app/views/treeDetailsBuildsView.py
+++ b/backend/kernelCI_app/views/treeDetailsBuildsView.py
@@ -1,10 +1,13 @@
 from http import HTTPStatus
 from typing import Dict, List, Optional
+
 from django.http import HttpRequest
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
 from kernelCI_app.helpers.errorHandling import create_api_error_response
@@ -29,7 +32,6 @@ from kernelCI_app.typeModels.treeDetails import (
     TreeDetailsBuildsResponse,
     TreeQueryParameters,
 )
-from kernelCI_app.constants.general import MAESTRO_DUMMY_BUILD_PREFIX
 
 
 class BaseTreeDetailsBuilds(APIView):

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -1,14 +1,25 @@
+from collections import defaultdict
+from http import HTTPStatus
 from typing import Any, Dict, Optional
+
 from django.http import HttpRequest
-from kernelCI_app.helpers.hardwareDetails import generate_test_summary_typed
+from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.general import (
+    DEFAULT_ORIGIN,
+    MAESTRO_DUMMY_BUILD_PREFIX,
+    UNKNOWN_STRING,
+)
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import FilterParams
-from kernelCI_app.helpers.logger import create_endpoint_notification
-from kernelCI_app.helpers.logger import out
+from kernelCI_app.helpers.hardwareDetails import generate_test_summary_typed
+from kernelCI_app.helpers.logger import create_endpoint_notification, out
 from kernelCI_app.helpers.treeDetails import (
     call_based_on_compatible_and_misc_platform,
     decide_if_is_boot_filtered_out,
@@ -37,7 +48,6 @@ from kernelCI_app.queries.tree import (
     get_tree_details_data,
     get_tree_details_rollup,
 )
-from kernelCI_app.utils import is_boot
 from kernelCI_app.typeModels.commonDetails import (
     BaseBuildSummary,
     BuildSummary,
@@ -59,20 +69,8 @@ from kernelCI_app.typeModels.treeDetails import (
     TreeCommon,
     TreeQueryParameters,
 )
-from kernelCI_app.utils import convert_issues_dict_to_list_typed
-
-from collections import defaultdict
-
-from drf_spectacular.utils import extend_schema
-from rest_framework.views import APIView
+from kernelCI_app.utils import convert_issues_dict_to_list_typed, is_boot
 from kernelCI_app.viewCommon import create_details_build_summary
-from kernelCI_app.helpers.errorHandling import create_api_error_response
-from http import HTTPStatus
-from kernelCI_app.constants.general import (
-    DEFAULT_ORIGIN,
-    MAESTRO_DUMMY_BUILD_PREFIX,
-    UNKNOWN_STRING,
-)
 
 
 class BaseTreeDetailsSummary(APIView):

--- a/backend/kernelCI_app/views/treeDetailsTestsView.py
+++ b/backend/kernelCI_app/views/treeDetailsTestsView.py
@@ -1,10 +1,12 @@
+from http import HTTPStatus
 from typing import Optional
+
 from django.http import HttpRequest
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from http import HTTPStatus
+
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
@@ -16,6 +18,10 @@ from kernelCI_app.helpers.treeDetails import (
     get_current_row_data,
 )
 from kernelCI_app.queries.tree import get_tree_data
+from kernelCI_app.typeModels.commonDetails import (
+    CommonDetailsTestsResponse,
+    TestHistoryItem,
+)
 from kernelCI_app.typeModels.commonOpenApiParameters import (
     COMMIT_HASH_PATH_PARAM,
     GIT_BRANCH_PATH_PARAM,
@@ -24,10 +30,6 @@ from kernelCI_app.typeModels.commonOpenApiParameters import (
 from kernelCI_app.typeModels.treeDetails import (
     DirectTreeDetailsQueryParameters,
     TreeDetailsQueryParameters,
-)
-from kernelCI_app.typeModels.commonDetails import (
-    CommonDetailsTestsResponse,
-    TestHistoryItem,
 )
 from kernelCI_app.utils import is_boot
 

--- a/backend/kernelCI_app/views/treeDetailsView.py
+++ b/backend/kernelCI_app/views/treeDetailsView.py
@@ -1,16 +1,20 @@
-from typing import Any, Dict, List, Optional
+from collections import defaultdict
 from http import HTTPStatus
+from typing import Any, Dict, List, Optional
+
 from django.http import HttpRequest
-from kernelCI_app.helpers.hardwareDetails import generate_test_summary_typed
-from rest_framework.views import APIView
+from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
 from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.general import DEFAULT_ORIGIN, MAESTRO_DUMMY_BUILD_PREFIX
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.commonDetails import PossibleTabs
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
-from kernelCI_app.helpers.filters import FilterParams
-from drf_spectacular.utils import extend_schema
-from pydantic import ValidationError
 from kernelCI_app.helpers.errorHandling import create_api_error_response
+from kernelCI_app.helpers.filters import FilterParams
+from kernelCI_app.helpers.hardwareDetails import generate_test_summary_typed
 from kernelCI_app.helpers.logger import create_endpoint_notification
 from kernelCI_app.helpers.treeDetails import (
     call_based_on_compatible_and_misc_platform,
@@ -20,12 +24,12 @@ from kernelCI_app.helpers.treeDetails import (
     decide_if_is_test_filtered_out,
     get_build,
     get_current_row_data,
-    process_tree_url,
     process_boots_summary,
     process_builds_issue,
+    process_filters,
     process_test_summary,
     process_tests_issue,
-    process_filters,
+    process_tree_url,
 )
 from kernelCI_app.queries.tree import get_tree_details_data
 from kernelCI_app.typeModels.commonDetails import (
@@ -42,12 +46,6 @@ from kernelCI_app.typeModels.commonOpenApiParameters import (
     GIT_BRANCH_PATH_PARAM,
     TREE_NAME_PATH_PARAM,
 )
-from kernelCI_app.utils import convert_issues_dict_to_list_typed, is_boot
-
-from collections import defaultdict
-
-from kernelCI_app.viewCommon import create_details_build_summary
-
 from kernelCI_app.typeModels.issues import Issue, IssueDict
 from kernelCI_app.typeModels.treeDetails import (
     DirectTreeQueryParameters,
@@ -55,7 +53,8 @@ from kernelCI_app.typeModels.treeDetails import (
     TreeDetailsFullResponse,
     TreeQueryParameters,
 )
-from kernelCI_app.constants.general import DEFAULT_ORIGIN, MAESTRO_DUMMY_BUILD_PREFIX
+from kernelCI_app.utils import convert_issues_dict_to_list_typed, is_boot
+from kernelCI_app.viewCommon import create_details_build_summary
 
 
 class BaseTreeDetails(APIView):

--- a/backend/kernelCI_app/views/treeLatestView.py
+++ b/backend/kernelCI_app/views/treeLatestView.py
@@ -1,14 +1,15 @@
 from http import HTTPStatus
 from urllib.parse import urlencode
-from drf_spectacular.utils import extend_schema
-from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from django.http import HttpRequest, JsonResponse
 from django.urls import reverse
+from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.queries.tree import get_latest_tree
 from kernelCI_app.typeModels.commonOpenApiParameters import (
     GIT_BRANCH_PATH_PARAM,
@@ -16,10 +17,9 @@ from kernelCI_app.typeModels.commonOpenApiParameters import (
 )
 from kernelCI_app.typeModels.treeDetails import (
     TreeLatestPathParameters,
-    TreeLatestResponse,
     TreeLatestQueryParameters,
+    TreeLatestResponse,
 )
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class TreeLatest(APIView):

--- a/backend/kernelCI_app/views/treeReportView.py
+++ b/backend/kernelCI_app/views/treeReportView.py
@@ -3,10 +3,11 @@ from urllib.parse import quote_plus
 
 from django.http import HttpRequest
 from drf_spectacular.utils import extend_schema
-from rest_framework.views import APIView
-from rest_framework.response import Response
 from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.trees import sanitize_tree
 from kernelCI_app.management.commands.helpers.summary import (
@@ -16,11 +17,10 @@ from kernelCI_app.management.commands.helpers.summary import (
 from kernelCI_app.management.commands.notifications import evaluate_test_results
 from kernelCI_app.queries.notifications import get_checkout_summary_data
 from kernelCI_app.typeModels.treeReport import (
+    TreeReportIssues,
     TreeReportQueryParameters,
     TreeReportResponse,
-    TreeReportIssues,
 )
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class TreeReport(APIView):

--- a/backend/kernelCI_app/views/treeView.py
+++ b/backend/kernelCI_app/views/treeView.py
@@ -1,24 +1,25 @@
+from http import HTTPStatus
+
 from django.http import HttpRequest
+from django.utils.timezone import make_aware, now
 from drf_spectacular.utils import extend_schema
-from rest_framework.views import APIView
+from pydantic import ValidationError
 from rest_framework.response import Response
-from kernelCI_app.helpers.trees import sanitize_tree
-from kernelCI_app.queries.tree import get_tree_listing_data
-from kernelCI_app.typeModels.commonListing import ListingQueryParameters
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import (
     create_api_error_response,
 )
-from http import HTTPStatus
+from kernelCI_app.helpers.trees import sanitize_tree
+from kernelCI_app.queries.tree import get_tree_listing_data
+from kernelCI_app.typeModels.commonListing import ListingQueryParameters
 from kernelCI_app.typeModels.treeListing import (
     Checkout,
     TreeListingResponse,
 )
-from pydantic import ValidationError
-
 from kernelCI_cache.constants import UNSTABLE_CHECKOUT_THRESHOLD
 from kernelCI_cache.queries.tree import get_cached_tree_listing_data
-from kernelCI_app.constants.localization import ClientStrings
-from django.utils.timezone import now, make_aware
 
 
 class TreeView(APIView):

--- a/backend/kernelCI_app/views/treeViewFast.py
+++ b/backend/kernelCI_app/views/treeViewFast.py
@@ -1,17 +1,19 @@
+from http import HTTPStatus
+
 from django.http import HttpRequest
-from rest_framework.views import APIView
-from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema
+from pydantic import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.queries.tree import get_tree_listing_fast
 from kernelCI_app.typeModels.commonListing import ListingQueryParameters
-from http import HTTPStatus
-from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.typeModels.treeListing import (
     CheckoutFast,
     TreeListingFastResponse,
 )
-from pydantic import ValidationError
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class TreeViewFast(APIView):

--- a/backend/kernelCI_app/views/treeViewV2.py
+++ b/backend/kernelCI_app/views/treeViewV2.py
@@ -1,14 +1,16 @@
 from http import HTTPStatus
+
 from django.http import HttpRequest
 from drf_spectacular.utils import extend_schema
 from pydantic import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.queries.tree import get_tree_listing_data_denormalized
 from kernelCI_app.typeModels.commonListing import ListingQueryParameters, StatusCountV2
 from kernelCI_app.typeModels.treeListing import TreeListingItem, TreeListingResponseV2
-from kernelCI_app.helpers.errorHandling import create_api_error_response
-from kernelCI_app.constants.localization import ClientStrings
 
 
 class TreeViewV2(APIView):

--- a/backend/kernelCI_cache/checkouts.py
+++ b/backend/kernelCI_cache/checkouts.py
@@ -1,5 +1,6 @@
 import json
 from typing import Optional
+
 from kernelCI_app.typeModels.databases import Origin
 from kernelCI_cache.models import CheckoutsCache
 from kernelCI_cache.utils import get_current_timestamp_kcidb_format

--- a/backend/kernelCI_cache/migrations/0001_initial.py
+++ b/backend/kernelCI_cache/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/backend/kernelCI_cache/migrations/0002_drop_old_table.py
+++ b/backend/kernelCI_cache/migrations/0002_drop_old_table.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0001_initial"),
     ]

--- a/backend/kernelCI_cache/migrations/0003_recreate_model.py
+++ b/backend/kernelCI_cache/migrations/0003_recreate_model.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/backend/kernelCI_cache/migrations/0004_rename_count_fields.py
+++ b/backend/kernelCI_cache/migrations/0004_rename_count_fields.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0003_recreate_model"),
     ]

--- a/backend/kernelCI_cache/migrations/0005_checkoutscache_origin_finish_time.py
+++ b/backend/kernelCI_cache/migrations/0005_checkoutscache_origin_finish_time.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0004_rename_count_fields"),
     ]

--- a/backend/kernelCI_cache/migrations/0006_drop_table_for_refresh.py
+++ b/backend/kernelCI_cache/migrations/0006_drop_table_for_refresh.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0005_checkoutscache_origin_finish_time"),
     ]

--- a/backend/kernelCI_cache/migrations/0007_refresh_table.py
+++ b/backend/kernelCI_cache/migrations/0007_refresh_table.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/backend/kernelCI_cache/migrations/0008_notificationscheckout.py
+++ b/backend/kernelCI_cache/migrations/0008_notificationscheckout.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0007_refresh_table"),
     ]

--- a/backend/kernelCI_cache/migrations/0009_rename_notification_id_to_notification_message_id.py
+++ b/backend/kernelCI_cache/migrations/0009_rename_notification_id_to_notification_message_id.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0008_notificationscheckout"),
     ]

--- a/backend/kernelCI_cache/migrations/0010_notificationsissue.py
+++ b/backend/kernelCI_cache/migrations/0010_notificationsissue.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0009_rename_notification_id_to_notification_message_id"),
     ]

--- a/backend/kernelCI_cache/migrations/0011_copy_data_from_cache_if_exists.py
+++ b/backend/kernelCI_cache/migrations/0011_copy_data_from_cache_if_exists.py
@@ -37,7 +37,10 @@ def copy_from_cache_to_notification_tables(apps, schema_editor):
     cache_conn = connections["cache"]
     notification_conn = connections["notifications"]
 
-    with cache_conn.cursor() as cache_cursor, notification_conn.cursor() as notif_cursor:
+    with (
+        cache_conn.cursor() as cache_cursor,
+        notification_conn.cursor() as notif_cursor,
+    ):
         try:
             print("\nRUNNING DATA TRANSFER MIGRATION")
             # Check if tables exist in databases
@@ -113,7 +116,6 @@ def copy_from_cache_to_notification_tables(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0010_notificationsissue"),
     ]

--- a/backend/kernelCI_cache/migrations/0011_copy_data_from_cache_if_exists.py
+++ b/backend/kernelCI_cache/migrations/0011_copy_data_from_cache_if_exists.py
@@ -1,6 +1,7 @@
+from django.db import connections, migrations
+
 from kernelCI.settings import DATABASES
 from kernelCI_app.helpers.discordWebhook import send_discord_notification
-from django.db import migrations, connections
 
 cache_path = DATABASES["cache"]["NAME"]
 

--- a/backend/kernelCI_cache/migrations/0012_add_checkout_report_identification_fields.py
+++ b/backend/kernelCI_cache/migrations/0012_add_checkout_report_identification_fields.py
@@ -87,7 +87,6 @@ def populate_checkout_fields(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("kernelCI_cache", "0011_copy_data_from_cache_if_exists"),
     ]

--- a/backend/kernelCI_cache/migrations/0012_add_checkout_report_identification_fields.py
+++ b/backend/kernelCI_cache/migrations/0012_add_checkout_report_identification_fields.py
@@ -1,4 +1,5 @@
 from django.db import connections, migrations, models
+
 from kernelCI import settings
 
 _TEMP_DEFAULT = "none"

--- a/backend/kernelCI_cache/queries/checkouts.py
+++ b/backend/kernelCI_cache/queries/checkouts.py
@@ -1,4 +1,5 @@
 from django.db import connections
+
 from kernelCI_app.helpers.database import dict_fetchall
 
 

--- a/backend/kernelCI_cache/queries/issues.py
+++ b/backend/kernelCI_cache/queries/issues.py
@@ -1,6 +1,6 @@
-from kernelCI_app.helpers.database import dict_fetchall
 from django.db import connections
 
+from kernelCI_app.helpers.database import dict_fetchall
 from kernelCI_app.helpers.logger import log_message
 from kernelCI_cache.typeModels.issues import IssueKeyTuple, UnsentIssueKeys
 

--- a/backend/kernelCI_cache/queries/notifications.py
+++ b/backend/kernelCI_cache/queries/notifications.py
@@ -1,13 +1,13 @@
 import json
 
 from django.db import connections
+
 from kernelCI_app.constants.general import DEFAULT_ORIGIN
+from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.management.commands.helpers.summary import ReportConfigs, TreeKey
+from kernelCI_cache.models import NotificationsCheckout, NotificationsIssue
 from kernelCI_cache.typeModels.databases import PossibleIssueType
 from kernelCI_cache.utils import get_current_timestamp_kcidb_format
-from kernelCI_cache.models import NotificationsCheckout, NotificationsIssue
-from kernelCI_app.helpers.logger import log_message
-
 
 RESEND_INTERVAL = "12 hours"
 """The time interval where a report can be resent.

--- a/backend/kernelCI_cache/queries/tree.py
+++ b/backend/kernelCI_cache/queries/tree.py
@@ -1,7 +1,8 @@
-from typing import Optional
 from datetime import timedelta
-from django.utils.timezone import now
+from typing import Optional
+
 from django.db import connections
+from django.utils.timezone import now
 
 from kernelCI_app.helpers.database import dict_fetchall
 

--- a/backend/kernelCI_cache/typeModels/databases.py
+++ b/backend/kernelCI_cache/typeModels/databases.py
@@ -1,4 +1,3 @@
 from typing import Literal, Optional
 
-
 type PossibleIssueType = Optional[Literal["build", "boot", "test"]]

--- a/backend/kernelCI_cache/typeModels/issues.py
+++ b/backend/kernelCI_cache/typeModels/issues.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+
 from kernelCI_app.typeModels.databases import Issue__Id, Issue__Version
 from kernelCI_cache.typeModels.databases import PossibleIssueType
 

--- a/backend/kernelCI_cache/utils.py
+++ b/backend/kernelCI_cache/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 def get_timestamp_kcidb_format(timestamp: datetime) -> str:

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/backend/utils/development_metrics.py
+++ b/backend/utils/development_metrics.py
@@ -1,4 +1,5 @@
 import os
+
 from django_prometheus import exports
 
 

--- a/backend/utils/prometheus_aggregator.py
+++ b/backend/utils/prometheus_aggregator.py
@@ -1,6 +1,7 @@
 import os
 import time
-from prometheus_client import start_http_server, REGISTRY
+
+from prometheus_client import REGISTRY, start_http_server
 from prometheus_client.multiprocess import MultiProcessCollector
 
 metrics_dir = os.environ.get(

--- a/backend/utils/validation.py
+++ b/backend/utils/validation.py
@@ -1,5 +1,7 @@
 from typing import Union
+
 from django.http import HttpResponseBadRequest
+
 from kernelCI_app.utils import get_error_body_response
 
 


### PR DESCRIPTION
This PR is only meant for applying all the ruff styling changes, so that we can later ignore the single squash-merge commit from the blame history using the [.git-blame-ignore-revs file](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-filefile)

If we had included these changes with the configuration, the squash-merge would combine everything (refactor and configs) into a single commit, and ignoring the revisions from that commit would ignore the config changes, which is not correct.

## Changes
- Applied auto-formatting
- Applied auto-linting
- Applied manual linting changes for lint rules with unsafe fixes

## How to test
This is just a refactor, the entire dashboard should still be working normally. There was no change to the frontend.

Since this PR doesn't include the ruff configs, it's going to fail all CI, but you can check that everything is right by going to the ruff config PR and running the ruff commands there.

Part of #1845 