### PR TITLE
fix: include builds from all matching checkouts in tree details queries

### DIFF
--- a/backend/kernelCI_app/queries/tree.py
+++ b/backend/kernelCI_app/queries/tree.py
@@ -801,7 +801,6 @@ def get_tree_details_builds(
                 AND c.origin = %(origin_param)s
             ORDER BY
                 c._timestamp DESC
-            LIMIT 1
         )
         SELECT
             b.id AS build_id,
@@ -831,7 +830,7 @@ def get_tree_details_builds(
             iss.report_url AS issue_report_url
         FROM
             builds b
-        INNER JOIN RELEVANT_CHECKOUTS rc ON b.checkout_id = rc.checkout_id
+        INNER JOIN RELEVANT_CHECKOUTS rc ON b.checkout_id IN (SELECT checkout_id FROM RELEVANT_CHECKOUTS)
         LEFT JOIN incidents inc
             ON inc.build_id = b.id AND inc.test_id IS NULL
         LEFT JOIN issues iss


### PR DESCRIPTION
Fixes an issue where the tree details page returns empty results when multiple checkout rows exist for the same commit hash. The query was previously limited to only the most recent checkout (`LIMIT 1`), potentially missing builds associated with other checkout rows.

## Changes

- Removed `LIMIT 1` from the `RELEVANT_CHECKOUTS` CTE to return all matching checkouts
- Changed the build join from `b.checkout_id = rc.checkout_id` to `b.checkout_id IN (SELECT checkout_id FROM RELEVANT_CHECKOUTS)` to aggregate builds from all matching checkout rows

## Related Issue

Closes #1869 