### PR TITLE
feat: enable django gzip middleware

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -80,6 +80,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "corsheaders.middleware.CorsMiddleware",
+    "django.middleware.gzip.GZipMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",


### PR DESCRIPTION
## Description

Enable Django's built-in GZipMiddleware to compress API responses for browsers that support gzip encoding. This reduces bandwidth usage and improves response times for large JSON payloads returned by the dashboard's API endpoints.

## Changes

- Added `django.middleware.gzip.GZipMiddleware` to the `MIDDLEWARE` list in `backend/kernelCI/settings.py`

## How to test

1. Start the backend server: `cd backend && poetry run python manage.py runserver`
2. Make a request to any API endpoint with gzip support: `curl -H "Accept-Encoding: gzip" -I http://localhost:8000/api/...`
3. Verify the response headers include `Content-Encoding: gzip` and `Vary: Accept-Encoding` for responses >= 200 bytes
4. Verify requests without `Accept-Encoding: gzip` header return uncompressed responses

Closes #1876 
