### PR TITLE
Fix: path search on treeDetails

### DIFF
--- a/backend/kernelCI_app/tests/unitTests/views/treeDetailsSummaryView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/treeDetailsSummaryView_test.py
@@ -36,6 +36,36 @@ BASE_BUILD_ROW: dict[str, object] = {
     "issue_report_url": None,
 }
 
+BASE_ROLLUP_ROW: dict[str, object] = {
+    "origin": "maestro",
+    "tree_name": "mainline",
+    "git_repository_branch": "for-kernelci",
+    "git_repository_url": "https://git.kernel.org",
+    "git_commit_hash": COMMIT_HASH,
+    "path_group": "test",
+    "build_config_name": "defconfig",
+    "build_architecture": "x86_64",
+    "build_compiler": "gcc-12",
+    "hardware_key": "qemu",
+    "test_platform": "qemu",
+    "test_lab": "lab-a",
+    "test_origin": "maestro",
+    "issue_id": None,
+    "issue_version": None,
+    "issue_uncategorized": False,
+    "is_boot": False,
+    "pass_tests": 1,
+    "fail_tests": 0,
+    "skip_tests": 0,
+    "error_tests": 0,
+    "miss_tests": 0,
+    "done_tests": 0,
+    "null_tests": 0,
+    "total_tests": 1,
+    "issue_comment": None,
+    "issue_report_url": None,
+}
+
 # Legacy row representing a boot test (PASS, no issue)
 LEGACY_BOOT_ROW = create_row(
     test_id="legacy_boot_001",
@@ -70,8 +100,11 @@ class TestTreeDetailsSummaryRollupFallback(SimpleTestCase):
             "git_branch": "for-kernelci",
         }
 
-    def _make_request(self):
-        return self.factory.get(self.url, self.base_query)
+    def _make_request(self, query_overrides: dict | None = None):
+        query = dict(self.base_query)
+        if query_overrides:
+            query.update(query_overrides)
+        return self.factory.get(self.url, query)
 
     @patch("kernelCI_app.views.treeDetailsSummaryView.out")
     @patch("kernelCI_app.views.treeDetailsSummaryView.get_tree_details_data")
@@ -164,3 +197,34 @@ class TestTreeDetailsSummaryRollupFallback(SimpleTestCase):
 
         mock_get_legacy_data.assert_not_called()
         mock_out.assert_not_called()
+
+    @patch("kernelCI_app.views.treeDetailsSummaryView.out")
+    @patch("kernelCI_app.views.treeDetailsSummaryView.get_tree_details_data")
+    @patch("kernelCI_app.views.treeDetailsSummaryView.get_tree_details_builds")
+    @patch("kernelCI_app.views.treeDetailsSummaryView.get_tree_details_rollup")
+    def test_path_filter_forces_legacy_even_with_rollup_rows(
+        self,
+        mock_get_rollup,
+        mock_get_builds,
+        mock_get_legacy_data,
+        mock_out,
+    ):
+        """Path filters must use legacy test rows because rollup only has path_group."""
+        mock_get_rollup.return_value = [BASE_ROLLUP_ROW]
+        mock_get_builds.return_value = [BASE_BUILD_ROW]
+        mock_get_legacy_data.return_value = [LEGACY_TEST_ROW]
+
+        response = self.view.get(
+            self._make_request({"filter_test.path": "test.something"}),
+            commit_hash=COMMIT_HASH,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("error", response.data)
+        mock_get_legacy_data.assert_called_once()
+        mock_out.assert_called_once()
+
+        # Value comes from legacy row (FAIL), not from rollup row (PASS).
+        test_status = response.data["summary"]["tests"]["status"]
+        self.assertEqual(test_status.get("FAIL"), 1)
+        self.assertEqual(test_status.get("PASS"), 0)

--- a/backend/kernelCI_app/views/treeDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/treeDetailsSummaryView.py
@@ -265,6 +265,14 @@ class BaseTreeDetailsSummary(APIView):
             issues_dict=self.test_issues_dict
         )
 
+    def _should_fallback_to_legacy_tests(self) -> bool:
+        """Rollup rows cannot evaluate path filters with test-level precision.
+
+        tree_tests_rollup stores only `path_group` (first path segment). When a
+        path filter is present, summary correctness requires raw test rows.
+        """
+        return bool(self.filters.filterTestPath or self.filters.filterBootPath)
+
     def get(
         self,
         request: HttpRequest,
@@ -308,14 +316,24 @@ class BaseTreeDetailsSummary(APIView):
 
         self._sanitize_builds_rows(builds_rows)
 
-        if rollup_rows:
+        should_fallback_to_legacy = self._should_fallback_to_legacy_tests()
+
+        # We only use the rollup rows if they exist and we have no other constraints
+        if rollup_rows and not should_fallback_to_legacy:
             self._sanitize_rollup_rows(rollup_rows)
         else:
-            out(
-                f"Rollup data empty for commit {commit_hash} "
-                f"(origin={origin_param}, tree={tree_name}, git_url={git_url_param}), "
-                f"falling back to legacy query"
-            )
+            if should_fallback_to_legacy:
+                out(
+                    f"Path filter detected for commit {commit_hash} "
+                    f"(origin={origin_param}, tree={tree_name}, git_url={git_url_param}), "
+                    "falling back to legacy query for accurate test/boot summary"
+                )
+            else:
+                out(
+                    f"Rollup data empty for commit {commit_hash} "
+                    f"(origin={origin_param}, tree={tree_name}, git_url={git_url_param}), "
+                    f"falling back to legacy query"
+                )
             legacy_rows = get_tree_details_data(
                 origin_param=origin_param,
                 git_url_param=git_url_param,

--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -28,10 +28,7 @@ import type { TestHistory } from '@/types/general';
 
 import BaseTable, { TableHead } from '@/components/Table/BaseTable';
 
-import TableStatusFilter from '@/components/Table/TableStatusFilter';
-
 import { PaginationInfo } from '@/components/Table/PaginationInfo';
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import { useTestIssues } from '@/api/testDetails';
 import { useLogData } from '@/hooks/useLogData';
 import WrapperTableWithLogSheet from '@/pages/TreeDetails/Tabs/WrapperTableWithLogSheet';
@@ -54,6 +51,8 @@ import { TooltipDateTime } from '@/components/TooltipDateTime';
 import TooltipHardware from '@/components/Table/TooltipHardware';
 import { EMPTY_VALUE } from '@/lib/string';
 import { UNKNOWN_STRING } from '@/utils/constants/backend';
+import { TableTopFilters } from '@/components/Table/TableTopFilters';
+import type { TStatusFilters } from '@/components/Table/TableStatusFilter';
 
 const defaultColumns: ColumnDef<TestByCommitHash>[] = [
   {
@@ -146,6 +145,9 @@ export function BootsTable({
 }: IBootsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const { pagination, paginationUpdater } = usePaginationState(tableKey);
+  const [globalFilter, setGlobalFilter] = useState<string | undefined>(
+    currentPathFilter,
+  );
 
   const intl = useIntl();
 
@@ -187,13 +189,13 @@ export function BootsTable({
     onPaginationChange: paginationUpdater,
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    onGlobalFilterChange: setGlobalFilter,
     state: {
       sorting,
       pagination,
+      globalFilter,
     },
   });
-
-  const { globalFilter } = table.getState();
 
   const filterCount: Record<PossibleTableFilters, number> = useMemo(() => {
     const count: Record<PossibleTableFilters, number> = {
@@ -222,7 +224,7 @@ export function BootsTable({
     [filter],
   );
 
-  const filters = useMemo(
+  const filters: TStatusFilters[] = useMemo(
     () => [
       {
         label: intl.formatMessage(
@@ -268,14 +270,12 @@ export function BootsTable({
 
   const onSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.value !== undefined && updatePathFilter) {
+      setGlobalFilter(e.target.value);
+      if (updatePathFilter) {
         updatePathFilter(e.target.value);
       }
-      if (updatePathFilter === undefined) {
-        table.setGlobalFilter(String(e.target.value));
-      }
     },
-    [table, updatePathFilter],
+    [updatePathFilter],
   );
 
   const groupHeaders = table.getHeaderGroups()[0]?.headers;
@@ -292,25 +292,11 @@ export function BootsTable({
           });
       return (
         <TableHead key={header.id} className="border-b px-2 font-bold">
-          {header.id === 'path' ? (
-            <div className="flex items-center">
-              {headerComponent}
-              <DebounceInput
-                key={currentPathFilter}
-                debouncedSideEffect={onSearchChange}
-                startingValue={currentPathFilter}
-                className="w-50 font-normal"
-                type="text"
-                placeholder={intl.formatMessage({ id: 'global.search' })}
-              />
-            </div>
-          ) : (
-            headerComponent
-          )}
+          {headerComponent}
         </TableHead>
       );
     });
-  }, [currentPathFilter, groupHeaders, intl, onSearchChange, sorting]);
+  }, [groupHeaders, sorting]);
 
   const modelRows = table.getRowModel().rows;
 
@@ -414,7 +400,13 @@ export function BootsTable({
       status={status}
       error={error}
     >
-      <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
+      <TableTopFilters
+        key="bootsTableSearch"
+        filters={filters}
+        onClickFilter={onClickFilter}
+        onSearchChange={onSearchChange}
+        currentPathFilter={currentPathFilter}
+      />
       <BaseTable headerComponents={tableHeaders}>
         <TableBody>{tableRows}</TableBody>
       </BaseTable>

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -14,10 +14,8 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import type { LinkProps } from '@tanstack/react-router';
 
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 import BaseTable, { TableHead } from '@/components/Table/BaseTable';
 import { PaginationInfo } from '@/components/Table/PaginationInfo';
-import TableStatusFilter from '@/components/Table/TableStatusFilter';
 import { TableBody, TableCell, TableRow } from '@/components/ui/table';
 import {
   possibleTableFilters,
@@ -37,6 +35,10 @@ import { useBuildIssues } from '@/api/buildDetails';
 import { useLogData } from '@/hooks/useLogData';
 
 import { getBuildStatusGroup } from '@/utils/status';
+
+import { TableTopFilters } from '@/components/Table/TableTopFilters';
+
+import type { TStatusFilters } from '@/components/Table/TableStatusFilter';
 
 import { defaultBuildColumns } from './DefaultBuildsColumns';
 
@@ -119,7 +121,7 @@ export function BuildsTable({
     return count;
   }, [rawData, globalFilter, table]);
 
-  const filters = useMemo(
+  const filters: TStatusFilters[] = useMemo(
     () => [
       {
         label: intl.formatMessage(
@@ -294,15 +296,12 @@ export function BuildsTable({
       status={status}
       error={error}
     >
-      <div className="flex items-center justify-between">
-        <TableStatusFilter filters={filters} onClickBuild={onClickFilter} />
-        <DebounceInput
-          debouncedSideEffect={onSearchChange}
-          className="w-50"
-          type="text"
-          placeholder={intl.formatMessage({ id: 'global.search' })}
-        />
-      </div>
+      <TableTopFilters
+        key="buildsTableSearch"
+        filters={filters}
+        onClickFilter={onClickFilter}
+        onSearchChange={onSearchChange}
+      />
       <BaseTable headerComponents={tableHeaders}>
         <TableBody>{tableBody}</TableBody>
       </BaseTable>

--- a/dashboard/src/components/Table/TableStatusFilter.tsx
+++ b/dashboard/src/components/Table/TableStatusFilter.tsx
@@ -5,14 +5,16 @@ import { FormattedMessage } from 'react-intl';
 import { Button } from '@/components/ui/button';
 import type { PossibleTableFilters } from '@/types/tree/TreeDetails';
 
+export type TStatusFilters = {
+  label: string;
+  value: PossibleTableFilters;
+  isSelected: boolean;
+};
+
 interface ITableStatusFilter {
   onClickBuild?: (value: PossibleTableFilters) => void;
   onClickTest?: (value: PossibleTableFilters) => void;
-  filters: {
-    label: string;
-    value: PossibleTableFilters;
-    isSelected: boolean;
-  }[];
+  filters: TStatusFilters[];
 }
 
 const TableStatusFilter = ({

--- a/dashboard/src/components/Table/TableTopFilters.tsx
+++ b/dashboard/src/components/Table/TableTopFilters.tsx
@@ -1,0 +1,38 @@
+import type { JSX } from 'react';
+import { useIntl } from 'react-intl';
+
+import type { PossibleTableFilters } from '@/types/tree/TreeDetails';
+
+import DebounceInput from '@/components/DebounceInput/DebounceInput';
+
+import type { TStatusFilters } from './TableStatusFilter';
+import TableStatusFilter from './TableStatusFilter';
+
+interface ITableTopFilters {
+  filters: TStatusFilters[];
+  onClickFilter: (newFilter: PossibleTableFilters) => void;
+  currentPathFilter?: string;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export function TableTopFilters({
+  filters,
+  onClickFilter,
+  currentPathFilter,
+  onSearchChange,
+}: ITableTopFilters): JSX.Element {
+  const intl = useIntl();
+
+  return (
+    <div className="flex flex-col items-center gap-4 sm:flex-row sm:gap-8">
+      <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
+      <DebounceInput
+        debouncedSideEffect={onSearchChange}
+        startingValue={currentPathFilter}
+        className="w-9/10 sm:mt-6 sm:w-50"
+        type="text"
+        placeholder={intl.formatMessage({ id: 'global.search' })}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/components/Tabs/FilterList.tsx
+++ b/dashboard/src/components/Tabs/FilterList.tsx
@@ -1,7 +1,10 @@
 import { useCallback, type JSX } from 'react';
 
 import FilterList from '@/components/FilterList/FilterList';
-import type { TFilter } from '@/types/general';
+import { isTFilterKeys } from '@/types/general';
+import type { TFilter, TFilterKeys } from '@/types/general';
+
+const IGNORED_FILTERS: TFilterKeys[] = ['testPath', 'bootPath'];
 
 interface IDetailsFilterList {
   filter: TFilter;
@@ -15,6 +18,15 @@ export const createFlatFilter = (filter: TFilter): string[] => {
   const flatFilter: string[] = [];
 
   Object.entries(filter).forEach(([field, fieldValue]) => {
+    // Type guard + don't show filters outside of the expected keys
+    if (!isTFilterKeys(field)) {
+      return;
+    }
+
+    if (IGNORED_FILTERS.includes(field)) {
+      return;
+    }
+
     if (typeof fieldValue === 'object') {
       Object.entries(fieldValue).forEach(([value, isSelected]) => {
         if (isSelected) {

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -30,11 +30,7 @@ import { TableBody, TableCell, TableRow } from '@/components/ui/table';
 
 import BaseTable, { TableHead } from '@/components/Table/BaseTable';
 
-import TableStatusFilter from '@/components/Table/TableStatusFilter';
-
 import { PaginationInfo } from '@/components/Table/PaginationInfo';
-
-import DebounceInput from '@/components/DebounceInput/DebounceInput';
 
 import { usePaginationState } from '@/hooks/usePaginationState';
 
@@ -42,6 +38,10 @@ import type { TableKeys } from '@/utils/constants/tables';
 import { buildHardwareArray, buildTreeBranch } from '@/utils/table';
 
 import { EMPTY_VALUE } from '@/lib/string';
+
+import { TableTopFilters } from '@/components/Table/TableTopFilters';
+
+import type { TStatusFilters } from '@/components/Table/TableStatusFilter';
 
 import { IndividualTestsTable } from './IndividualTestsTable';
 import { defaultColumns, defaultInnerColumns } from './DefaultTestsColumns';
@@ -110,7 +110,9 @@ export function TestsTable({
 }: ITestsTable): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
-  const [globalFilter, setGlobalFilter] = useState<string | undefined>();
+  const [globalFilter, setGlobalFilter] = useState<string | undefined>(
+    currentPathFilter,
+  );
   const { pagination, paginationUpdater } = usePaginationState(tableKey);
 
   const intl = useIntl();
@@ -292,7 +294,7 @@ export function TestsTable({
     [globalStatusGroup],
   );
 
-  const filters = useMemo(
+  const filters: TStatusFilters[] = useMemo(
     () => [
       {
         label: intl.formatMessage(
@@ -332,14 +334,12 @@ export function TestsTable({
 
   const onSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.value !== undefined && updatePathFilter) {
+      setGlobalFilter(String(e.target.value));
+      if (updatePathFilter) {
         updatePathFilter(e.target.value);
       }
-      if (updatePathFilter === undefined) {
-        setGlobalFilter(String(e.target.value));
-      }
     },
-    [setGlobalFilter, updatePathFilter],
+    [updatePathFilter],
   );
 
   const groupHeaders = table.getHeaderGroups()[0]?.headers;
@@ -356,25 +356,11 @@ export function TestsTable({
           });
       return (
         <TableHead key={header.id} className="border-b px-2 font-bold">
-          {header.id === 'path_group' ? (
-            <div className="flex items-center">
-              {headerComponent}
-              <DebounceInput
-                key={currentPathFilter}
-                debouncedSideEffect={onSearchChange}
-                startingValue={currentPathFilter}
-                className="w-50 font-normal"
-                type="text"
-                placeholder={intl.formatMessage({ id: 'global.search' })}
-              />
-            </div>
-          ) : (
-            headerComponent
-          )}
+          {headerComponent}
         </TableHead>
       );
     });
-  }, [currentPathFilter, groupHeaders, intl, onSearchChange, sorting]);
+  }, [groupHeaders, sorting]);
 
   const modelRows = table.getRowModel().rows;
   const tableRows = useMemo((): JSX.Element[] | JSX.Element => {
@@ -420,7 +406,13 @@ export function TestsTable({
 
   return (
     <div className="flex flex-col gap-6 pb-4">
-      <TableStatusFilter filters={filters} onClickTest={onClickFilter} />
+      <TableTopFilters
+        key="testsTableSearch"
+        filters={filters}
+        onClickFilter={onClickFilter}
+        onSearchChange={onSearchChange}
+        currentPathFilter={currentPathFilter}
+      />
       <BaseTable headerComponents={tableHeaders}>
         <TableBody>{tableRows}</TableBody>
       </BaseTable>

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -235,6 +235,10 @@ export const isTFilterNumberKeys = (key: string): key is TFilterNumberKeys => {
   return zFilterNumberKeys.safeParse(key).success;
 };
 
+export const isTFilterKeys = (key: string): key is TFilterKeys => {
+  return isTFilterObjectKeys(key) || isTFilterNumberKeys(key);
+};
+
 export type SearchParamsKeys =
   | 'origin'
   | 'intervalInDays'
@@ -275,8 +279,6 @@ const requestFilters = {
     'test.duration_[gte]',
     'test.duration_[lte]',
     'test.hardware',
-    'test.path',
-    'boot.path',
     'boot.status',
     'boot.duration_[gte]',
     'boot.duration_[lte]',
@@ -324,8 +326,6 @@ export const filterFieldMap = {
   'test.duration_[gte]': 'testDurationMin',
   'test.duration_[lte]': 'testDurationMax',
   'test.hardware': 'hardware',
-  'test.path': 'testPath',
-  'boot.path': 'bootPath',
   'build.issue': 'buildIssue',
   'boot.issue': 'bootIssue',
   'test.issue': 'testIssue',


### PR DESCRIPTION
Fixes an issue where a path filter would make the rollup rows filter the entire path group instead of only filtering individual tests. ~~For the solution, legacy rows have to be used since the aggregated rows don't have information about individual tests.~~ **We opted for a solution where the test path filter only applies to the table in the frontend, without making changes in the backend so that we don't fallback to the legacy query and the path filtering becomes faster too.**

The tests were being filtered correctly, but the summary was returning empty and was causing all the frontend components to be replaced with a "no data" too.

## Changes
- Removed test path and boot path from the mapping that ultimately goes to the backend request
- Altered the frontend testsTable and bootsTable so that they use the table state for the path filtering

Since these changes are in the core component, they work in the treeDetails page, hardwareDetails page, and buildDetails page (that has a testTable).

## How to test
Check any treeDetails page and try applying a test or boot path filter that only works on a subset of a group (ex "nfs" for "boot.nfs" or "setup" for "tast.setup"). Then compare with the production state.

Closes #1872