### PR TITLE
fix: feedback URL serialization handling in SendFeedback component

### DIFF
--- a/dashboard/src/components/SideMenu/SendFeedback.tsx
+++ b/dashboard/src/components/SideMenu/SendFeedback.tsx
@@ -1,6 +1,6 @@
 import { MdOutlineFeedback } from 'react-icons/md';
 
-import { useEffect, useMemo, useState, type JSX } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import { useLocation } from '@tanstack/react-router';
 
@@ -25,27 +25,27 @@ const SendFeedback = (
 ): JSX.Element => {
   const location = useLocation();
 
-  const [fullLocation, setFullLocation] = useState(
-    `${window.location.origin}${location.pathname}${location.search}${location.hash}`,
-  );
-
-  useEffect(() => {
-    const newUrl = `${window.location.origin}${location.pathname}${location.search}${location.hash}`;
-    setFullLocation(newUrl);
+  const fullLocation = useMemo(() => {
+    const href = location.href;
+    // href is relative (starts with "/"), prepend origin
+    if (href.startsWith('/')) {
+      return `${window.location.origin}${href}`;
+    }
+    return href;
   }, [location]);
 
   const actionLinks: ActionLink[] = useMemo(() => {
     const github_body = encodeURIComponent(
       `# Feedback Description:
-  
+
 ## URL used to send feedback:
 ${fullLocation}`,
     );
 
-    const email_subject = 'Dashboard Feedback';
+    const email_subject = encodeURIComponent('Dashboard Feedback');
     const email_body = encodeURIComponent(
       `Feedback Description:
-  
+
 URL used to send feedback:
 ${fullLocation}`,
     );


### PR DESCRIPTION
## Description

Fix feedback URL construction in the side menu so the generated GitHub issue body and email body include the correct current page URL.

## Changes

- Build `fullLocation` from `useLocation().href` and prepend `window.location.origin` when needed
- URL-encode the email subject

## How to test (if needed)

1. Start the dashboard and navigate to any page
2. Open the side menu and click "Send feedback"
3. Verify the GitHub and Email actions include the current URL correctly

Closes #1848
