### PR TITLE
Fix: topbar page title

### DIFF
--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -1,11 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 
-import {
-  useSearch,
-  useNavigate,
-  useRouterState,
-  useMatches,
-} from '@tanstack/react-router';
+import { useSearch, useNavigate, useMatches } from '@tanstack/react-router';
 
 import { useCallback, useEffect, useMemo, useState, type JSX } from 'react';
 
@@ -121,9 +116,6 @@ const TitleName = ({ basePath }: { basePath: string }): JSX.Element => {
 const TopBar = (): JSX.Element => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const matches = useMatches();
-  const redirectStateFrom = useRouterState({
-    select: s => s.location.state.from,
-  });
 
   const routeInfo = useMemo(() => {
     const lastMatch = matches[matches.length - 1];
@@ -142,8 +134,6 @@ const TopBar = (): JSX.Element => {
     };
   }, [matches]);
 
-  const basePath = redirectStateFrom ?? routeInfo.firstUrlLocation;
-
   return (
     <>
       <div className="fixed top-0 z-10 flex h-20 w-full max-w-full bg-white px-6 md:max-w-[calc(100%-14rem)] md:px-16">
@@ -159,7 +149,7 @@ const TopBar = (): JSX.Element => {
               <HiMenu className="size-6" />
             </Button>
             <span className="mr-2 text-2xl sm:mr-10">
-              <TitleName basePath={basePath} />
+              <TitleName basePath={routeInfo.firstUrlLocation} />
             </span>
             {(routeInfo.isTreeListing || routeInfo.isHardwarePage) && (
               <OriginSelect isHardwarePath={routeInfo.isHardwarePage} />


### PR DESCRIPTION
Fixes the page title for the topbar, using only the route instead of the redirect state + route

## Changes
- Removes the "redirectFrom" state and uses only the route path for the page title in the topBar

## How to test
Go from treeDetails to build/test/issueDetails page and see that even though the breadcrumb is present, the title is the current page (instead of staying at "Tree" like the old behavior). The same happens for hardwareDetails. Compare with the old behavior on staging/production.

## Example
Before:
<img width="412" height="290" alt="image" src="https://github.com/user-attachments/assets/fe621167-76e9-4b65-b036-d13f2dee322d" />

After:
<img width="412" height="290" alt="image" src="https://github.com/user-attachments/assets/02229443-b8db-41b2-8728-496ff09c23d6" />

Tested on [localhost issue](http://localhost:5173/issue/maestro%3Ada694c56147298d223ee432ad8d6a8ee311b773a?iv=1) using submissions data.

Closes #1855