### PR TITLE
Fix: change frontend cache time

### DIFF
--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -24,6 +24,7 @@ import { ToastProvider } from './components/ui/toast';
 import type { RedirectFrom, RequiredStatusCount } from './types/general';
 import { parseSearch, stringifySearch } from './utils/search';
 import { retryHandler } from './utils/query';
+import { MILLISECONDS_IN_ONE_SECOND } from './utils/date';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -58,11 +59,12 @@ declare module '@tanstack/react-router' {
   }
 }
 
+const QUERY_STALE_SECONDS = 30;
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      // eslint-disable-next-line no-magic-numbers
-      staleTime: 1000 * 60 * 5, // 5 minutes,
+      staleTime: QUERY_STALE_SECONDS * MILLISECONDS_IN_ONE_SECOND,
       retry: retryHandler(),
     },
   },


### PR DESCRIPTION
The frontend query cache can stale some requests, which in turn can show outdated numbers between treeListing, treeDetails and treeCommitHistory. Lowering the cache time will technically increase the number of requests, but this can be done without much concern since we have improved endpoint performance. Besides, without this risk for outdated numbers there is less chance for confusion in users when they see trees that are receiving data in real time.

## Changes
- Changed frontend request cache from 5 minutes to 30 seconds

Also removes eslint rule ignore

## How to test
Go to any frontend page, check that if you make the same request within 30s it will get the data from cache (it won't perform the request again) and after 30s it will redo the request.

Closes #1890 