### PR TITLE
fix: Check gzip log via magic numbers

### DIFF
--- a/dashboard/src/api/logViewer.ts
+++ b/dashboard/src/api/logViewer.ts
@@ -16,33 +16,29 @@ const STALE_DURATION_MS = minutesToMilliseconds(60);
 type FetchAndDecompressLogsResponse = {
   content: string;
 };
+
+const isGzipBytes = (data: Uint8Array): boolean =>
+  // eslint-disable-next-line no-magic-numbers
+  data.length >= 2 && data[0] === 0x1f && data[1] === 0x8b;
+
 async function fetchAndDecompressLog(
   url: string,
 ): Promise<FetchAndDecompressLogsResponse> {
   const proxyUrl = `/api/proxy/?url=${encodeURIComponent(url)}`;
-  const urlPathname = new URL(url).pathname;
-  const isGzipped = urlPathname.endsWith('.gz');
 
   try {
-    if (isGzipped) {
-      const response = await RequestData.get<ArrayBuffer>(proxyUrl, {
-        responseType: 'arraybuffer',
-      });
+    const response = await RequestData.get<ArrayBuffer>(proxyUrl, {
+      responseType: 'arraybuffer',
+    });
 
-      const uint8ArrayResponse = new Uint8Array(response);
-      const decompressedData = pako.inflate(uint8ArrayResponse);
-      const textDecoder = new TextDecoder('utf-8');
-      const decompressedText = textDecoder.decode(decompressedData);
+    let byteResponse = new Uint8Array(response);
+    const textDecoder = new TextDecoder('utf-8');
 
-      return { content: decompressedText };
-    } else {
-      // For non-gzipped files, request as text
-      const response = await RequestData.get<string>(proxyUrl, {
-        responseType: 'text',
-      });
-
-      return { content: response };
+    while (isGzipBytes(byteResponse)) {
+      byteResponse = pako.inflate(byteResponse);
     }
+
+    return { content: textDecoder.decode(byteResponse) };
   } catch (error) {
     console.error(error);
 


### PR DESCRIPTION
 We are directly checking the bytes content of the log. If, for any reason, the content is not compressed, or is compressed but with wrong file extension, we are still going to properly decompress the file content.

## How to test

Check for both cases (compressed and uncompressed) of logs, and verify they behave properly (valid utf-8 characters being rendered).
Examples for both cases:
1. https://staging.dashboard.kernelci.org/log-viewer?itemId=linaro%3A3DZmXcQoam87yzdZfwJ5Wo3DrnA&o=linaro&type=build&url=https%3A%2F%2Fstorage.tuxsuite.com%2Fpublic%2Flinaro%2Flkft%2Fbuilds%2F3DZmXcQoam87yzdZfwJ5Wo3DrnA%2Fbuild.log
2. https://staging.dashboard.kernelci.org/log-viewer?itemId=ti%3Ad7378c1959574935bc056d7b&o=ti&type=test&url=http%3A%2F%2Ffiles.kernelci.org%2F%2Fti%2Fnext%2Fmaster%2Fnext-20260508%2Farm64%2Fdefconfig%2Blab-setup%2Bkselftest%2Fgcc-14%2Fbaseline-nfs-boot.nfs-j721e-idk-gw-8_132543899.txt.gz

Closes #1887