### PR TITLE
chore: update Dockerfile and package.json to pin pnpm version

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -4,7 +4,7 @@ FROM node:22.3-alpine AS builder
 WORKDIR /dashboard
 
 COPY dashboard/package.json dashboard/pnpm-lock.yaml ./
-RUN npm install -g pnpm && pnpm install --frozen-lockfile
+RUN npm install -g pnpm@10.33.3 && pnpm install --frozen-lockfile
 
 COPY dashboard/. ./
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@10.33.3",
   "scripts": {
     "dev": "rm -rf ./node_modules/.vite && vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Description

Pin the frontend pnpm version used by Docker builds to avoid CI failures caused by installing the latest pnpm release with incompatible Node.js engine requirements.

## Changes

- Add `packageManager: pnpm@10.33.3` to the dashboard package metadata.
- Replace the floating global pnpm install in the dashboard Dockerfile with `pnpm@10.33.3`.
- Keep `pnpm install --frozen-lockfile` for reproducible dependency installs.

## How to test

1. Run `docker buildx build --file ./dashboard/Dockerfile --tag dashboard-frontend:local --load .`.
2. Confirm the build reaches `pnpm install --frozen-lockfile` without installing `pnpm@latest`.
3. Confirm the frontend image builds successfully.

Closes #1892 