### PR TITLE
fix: Remove the date filter from dashboard listings

### DIFF
--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -55,7 +55,6 @@ import type { ListingTableColumnMeta } from '@/types/table';
 
 import { statusCountToRequiredStatusCount } from '@/utils/status';
 
-import { MemoizedInputTime } from '@/components/InputTime';
 import { shouldShowRelativeDate } from '@/lib/date';
 import { valueOrEmpty } from '@/lib/string';
 import { PinnedTrees } from '@/utils/constants/tables';
@@ -533,7 +532,6 @@ export function TreeTable({
           />
         </span>
         <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
-          <MemoizedInputTime navigateFrom={urlFromMap.navigate} />
           <ItemsPerPageSelector
             table={table}
             onPaginationChange={navigateWithPageSize}

--- a/dashboard/src/components/TreeListingPage/TreeTableV2.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTableV2.tsx
@@ -46,8 +46,6 @@ import {
 
 import type { ListingTableColumnMeta } from '@/types/table';
 
-import { MemoizedInputTime } from '@/components/InputTime';
-
 import QuerySwitcher from '@/components/QuerySwitcher/QuerySwitcher';
 import { MemoizedSectionError } from '@/components/DetailsPages/SectionError';
 
@@ -368,7 +366,6 @@ export function TreeTableV2({
           />
         </span>
         <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
-          <MemoizedInputTime navigateFrom={urlFromMap.navigate} />
           <ItemsPerPageSelector
             table={table}
             onPaginationChange={navigateWithPageSize}

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -49,8 +49,6 @@ import type { ListingTableColumnMeta } from '@/types/table';
 
 import { RedirectFrom, type TFilter } from '@/types/general';
 
-import { MemoizedInputTime } from '@/components/InputTime';
-import { REDUCED_TIME_SEARCH } from '@/utils/constants/general';
 import { EMPTY_VALUE } from '@/lib/string';
 import { Badge } from '@/components/ui/badge';
 
@@ -490,10 +488,6 @@ export function HardwareTable({
           />
         </span>
         <div className="flex justify-end gap-y-2 max-[700px]:flex-wrap">
-          <MemoizedInputTime
-            navigateFrom={navigateFrom}
-            defaultInterval={REDUCED_TIME_SEARCH}
-          />
           <ItemsPerPageSelector
             table={table}
             onPaginationChange={navigateWithPageSize}

--- a/dashboard/src/routes/_main/tree/route.tsx
+++ b/dashboard/src/routes/_main/tree/route.tsx
@@ -8,18 +8,18 @@ import {
   type SearchSchema,
 } from '@/types/general';
 import {
+  DEFAULT_LISTING_INTERVAL_IN_DAYS,
   DEFAULT_LISTING_ITEMS,
-  DEFAULT_TIME_SEARCH,
 } from '@/utils/constants/general';
 
 const defaultValues = {
-  intervalInDays: DEFAULT_TIME_SEARCH,
+  intervalInDays: DEFAULT_LISTING_INTERVAL_IN_DAYS,
   treeSearch: '',
   listingSize: DEFAULT_LISTING_ITEMS,
 };
 
 export const RootSearchSchema = z.object({
-  intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+  intervalInDays: makeZIntervalInDays(DEFAULT_LISTING_INTERVAL_IN_DAYS),
   treeSearch: z.string().catch(''),
   listingSize: zListingSize,
 } satisfies SearchSchema);

--- a/dashboard/src/routes/_main/tree/v1/route.tsx
+++ b/dashboard/src/routes/_main/tree/v1/route.tsx
@@ -8,18 +8,18 @@ import {
   type SearchSchema,
 } from '@/types/general';
 import {
+  DEFAULT_LISTING_INTERVAL_IN_DAYS,
   DEFAULT_LISTING_ITEMS,
-  DEFAULT_TIME_SEARCH,
 } from '@/utils/constants/general';
 
 const defaultValues = {
-  intervalInDays: DEFAULT_TIME_SEARCH,
+  intervalInDays: DEFAULT_LISTING_INTERVAL_IN_DAYS,
   treeSearch: '',
   listingSize: DEFAULT_LISTING_ITEMS,
 };
 
 export const RootSearchSchema = z.object({
-  intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+  intervalInDays: makeZIntervalInDays(DEFAULT_LISTING_INTERVAL_IN_DAYS),
   treeSearch: z.string().catch(''),
   listingSize: zListingSize,
 } satisfies SearchSchema);

--- a/dashboard/src/routes/_main/tree/v2/route.tsx
+++ b/dashboard/src/routes/_main/tree/v2/route.tsx
@@ -8,18 +8,18 @@ import {
   type SearchSchema,
 } from '@/types/general';
 import {
+  DEFAULT_LISTING_INTERVAL_IN_DAYS,
   DEFAULT_LISTING_ITEMS,
-  DEFAULT_TIME_SEARCH,
 } from '@/utils/constants/general';
 
 const defaultValues = {
-  intervalInDays: DEFAULT_TIME_SEARCH,
+  intervalInDays: DEFAULT_LISTING_INTERVAL_IN_DAYS,
   treeSearch: '',
   listingSize: DEFAULT_LISTING_ITEMS,
 };
 
 export const RootSearchSchema = z.object({
-  intervalInDays: makeZIntervalInDays(DEFAULT_TIME_SEARCH),
+  intervalInDays: makeZIntervalInDays(DEFAULT_LISTING_INTERVAL_IN_DAYS),
   treeSearch: z.string().catch(''),
   listingSize: zListingSize,
 } satisfies SearchSchema);

--- a/dashboard/src/utils/constants/general.ts
+++ b/dashboard/src/utils/constants/general.ts
@@ -9,3 +9,4 @@ export const ItemsPerPageValues = [5, 10, 20, 30, 40, 50];
 export const DEFAULT_TIME_SEARCH = 7;
 export const REDUCED_TIME_SEARCH = 5;
 export const DEFAULT_LISTING_ITEMS = 10;
+export const DEFAULT_LISTING_INTERVAL_IN_DAYS = 30;


### PR DESCRIPTION
  * Tree (and hardware) listing pages no longer render the “last N days” input.
  * intervalInDays / ?i still apply from the URL; listing default is 30 days.

How to test:
* Pages should match previous version using 30 days in the interval days filter.
* Links, in general, should point to valid instances, especially links to the listings.

Closes #1894 #1839 