### PR TITLE
feat/search commit intent filter hardware

### DIFF
--- a/backend/kernelCI_app/constants/localization.py
+++ b/backend/kernelCI_app/constants/localization.py
@@ -93,6 +93,10 @@ class DocStrings:
     )
 
     HARDWARE_LISTING_ORIGIN_DESCRIPTION = "Origin of the hardware"
+    HARDWARE_LISTING_COMMITS_LIST_DESCRIPTION = (
+        "Optional comma-separated git commit identifiers: full SHA(s) "
+        "and/or tag strings that appear in checkout.git_commit_tags."
+    )
 
     ISSUE_DETAILS_VERSION_DESCRIPTION = "Issue version"
 

--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -110,23 +110,50 @@ def _get_hardware_listing_count_clauses() -> str:
 
 
 def get_hardware_listing_data(
-    start_date: datetime, end_date: datetime, origin: str
+    *,
+    start_date: datetime,
+    end_date: datetime,
+    origin: str,
+    commits_list: Optional[list[str]] = None,
 ) -> list[dict]:
     """
     Retrieves the listing of platform, compatibles, and
     the status counts of builds, boots and tests
     for the latest checkout of every tree.
     The selected checkouts and tests are limited to the start_date/end_date interval.
+    When commits_list is set, tree heads are not used: checkouts qualify if
+    git_commit_hash is in the token list or git_commit_tags overlaps it (comma-
+    separated request values can be full SHAs or tag strings stored on checkouts).
+    Still scoped by the test start_time and origin filters below.
     """
 
     count_clauses = _get_hardware_listing_count_clauses()
-    tree_head_clause = _get_hardware_tree_heads_clause(id_only=True)
 
     params = {
         "start_date": start_date,
         "end_date": end_date,
         "origin": origin,
     }
+
+    if commits_list:
+        params["commits_list"] = commits_list
+        checkout_ids_select = """
+            SELECT C.id
+            FROM checkouts C
+            WHERE C.git_commit_hash = ANY(%(commits_list)s)
+               OR (
+                   C.git_commit_tags IS NOT NULL
+                   AND C.git_commit_tags && %(commits_list)s::text[]
+               )
+            """
+    else:
+        checkout_ids_select = _get_hardware_tree_heads_clause(id_only=True)
+
+    selected_checkouts_cte = f"""
+            selected_checkouts AS (
+                {checkout_ids_select}
+            ),
+        """
 
     # The grouping by platform and compatibles is possible because a platform
     # can dictate the array of compatibles, meaning that if the array of compatibles
@@ -137,12 +164,7 @@ def get_hardware_listing_data(
     # to the tests, not checkouts. There are no platforms being tested by multiple origins yet.
     query = f"""
         WITH
-            -- Selects the id of the latest checkout of all trees in the given period.
-            -- No checkout data is returned in the end.
-            tree_heads AS (
-                {tree_head_clause}
-            ),
-            -- Selects all tests/builds related to those checkouts.
+            {selected_checkouts_cte}
             relevant_tests AS (
                 SELECT
                     "tests"."environment_compatible" AS hardware,
@@ -155,7 +177,7 @@ def get_hardware_listing_data(
                 FROM
                     tests
                     INNER JOIN builds b ON tests.build_id = b.id
-                    JOIN tree_heads TH ON b.checkout_id = TH.id
+                    JOIN selected_checkouts AC ON b.checkout_id = AC.id
                 WHERE
                     "tests"."environment_misc" ->> 'platform' IS NOT NULL
                     AND "tests"."origin" = %(origin)s
@@ -261,7 +283,10 @@ def get_hardware_listing_data_bulk(
 
 
 def get_hardware_listing_data_from_status_table(
-    start_date: datetime, end_date: datetime, origin: str
+    start_date: datetime,
+    end_date: datetime,
+    origin: str,
+    commits_list: Optional[list[str]] = None,
 ) -> list[tuple]:
     """
     Retrieves hardware listing data from the HardwareStatus denormalized table.
@@ -273,7 +298,49 @@ def get_hardware_listing_data_from_status_table(
         "origin": origin,
     }
 
-    query = """
+    if commits_list:
+        params["commits_list"] = commits_list
+        query = """
+        SELECT
+            platform,
+            compatibles AS hardware,
+            SUM(build_pass) AS build_pass,
+            SUM(build_failed) AS build_fail,
+            SUM(build_inc) AS build_null,
+            SUM(boot_pass) AS boot_pass,
+            SUM(boot_failed) AS boot_fail,
+            SUM(boot_inc) AS boot_null,
+            SUM(test_pass) AS test_pass,
+            SUM(test_failed) AS test_fail,
+            SUM(test_inc) AS test_null
+        FROM
+            hardware_status
+        INNER JOIN
+            checkouts C
+            ON
+                hardware_status.checkout_id = C.id
+            AND
+                C.start_time >= %(start_date)s
+            AND
+                C.start_time <= %(end_date)s
+            AND (
+                C.git_commit_hash = ANY(%(commits_list)s)
+                OR (
+                    C.git_commit_tags IS NOT NULL
+                    AND C.git_commit_tags && %(commits_list)s::text[]
+                )
+            )
+        WHERE
+            hardware_status.test_origin = %(origin)s
+        GROUP BY
+            platform,
+            compatibles
+        ORDER BY
+            platform,
+            compatibles
+    """
+    else:
+        query = """
         SELECT
             platform,
             compatibles AS hardware,

--- a/backend/kernelCI_app/tests/unitTests/views/hardwareView_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/hardwareView_test.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from django.test.testcases import SimpleTestCase
 from rest_framework.test import APIRequestFactory
@@ -30,6 +30,41 @@ class TestHardwareView(SimpleTestCase):
         response = self.view.get(request)
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
+        mock_get_hardware_listing_data.assert_called_once_with(
+            origin="origin1",
+            start_date=ANY,
+            end_date=ANY,
+            commits_list=None,
+        )
+
+    @patch("kernelCI_app.views.hardwareView.get_hardware_listing_data")
+    def test_get_hardware_listing_passes_commits_list(
+        self, mock_get_hardware_listing_data
+    ):
+        mock_get_hardware_listing_data.return_value = [
+            ("platform1", "hardware1", *range(22)),
+        ]
+        h1 = "a" * 40
+        h2 = "b" * 40
+
+        request = self.factory.get(
+            self.url,
+            {
+                "startTimestampInSeconds": "1741192200",
+                "endTimestampInSeconds": "1741624200",
+                "origin": "origin1",
+                "commitsList": f"{h1},{h2}",
+            },
+        )
+        response = self.view.get(request)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        mock_get_hardware_listing_data.assert_called_once_with(
+            origin="origin1",
+            start_date=ANY,
+            end_date=ANY,
+            commits_list=[h1, h2],
+        )
 
     def test_get_hardware_listing_invalid_query_params_returns_bad_request(self):
         query_params = {"origin": "origin1"}

--- a/backend/kernelCI_app/typeModels/hardwareListing.py
+++ b/backend/kernelCI_app/typeModels/hardwareListing.py
@@ -8,6 +8,15 @@ from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.common import StatusCount
 
 
+def _normalize_commits_list(value: object) -> Optional[list[str]]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        cleaned = [part.strip() for part in value.split(",") if part.strip()]
+        return cleaned if cleaned else None
+    return None
+
+
 class HardwareItem(BaseModel):
     hardware: Optional[Union[str, set[str]]]
     platform: str
@@ -37,6 +46,10 @@ class HardwareQueryParamsDocumentationOnly(BaseModel):
     endTimestampInSeconds: str = Field(  # noqa: N815
         description=DocStrings.DEFAULT_END_TS_DESCRIPTION
     )
+    commitsList: Optional[str] = Field(  # noqa: N815
+        default=None,
+        description=DocStrings.HARDWARE_LISTING_COMMITS_LIST_DESCRIPTION,
+    )
 
 
 class HardwareQueryParams(BaseModel):
@@ -47,3 +60,7 @@ class HardwareQueryParams(BaseModel):
     ]
     start_date: datetime
     end_date: datetime
+    commits_list: Annotated[
+        Optional[list[str]],
+        BeforeValidator(_normalize_commits_list),
+    ] = Field(default=None)

--- a/backend/kernelCI_app/typeModels/hardwareListingV2.py
+++ b/backend/kernelCI_app/typeModels/hardwareListingV2.py
@@ -8,6 +8,15 @@ from kernelCI_app.constants.localization import DocStrings
 from kernelCI_app.typeModels.commonListing import StatusCountV2
 
 
+def _normalize_commits_list(value: object) -> Optional[list[str]]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        cleaned = [part.strip() for part in value.split(",") if part.strip()]
+        return cleaned if cleaned else None
+    return None
+
+
 class HardwareItemV2(BaseModel):
     hardware: Optional[Union[str, set[str]]]
     platform: str
@@ -34,6 +43,10 @@ class HardwareQueryParamsV2DocumentationOnly(BaseModel):
     endTimestampInSeconds: str = Field(  # noqa: N815
         description=DocStrings.DEFAULT_END_TS_DESCRIPTION
     )
+    commitsList: Optional[str] = Field(  # noqa: N815
+        default=None,
+        description=DocStrings.HARDWARE_LISTING_COMMITS_LIST_DESCRIPTION,
+    )
 
 
 class HardwareQueryParamsV2(BaseModel):
@@ -44,3 +57,7 @@ class HardwareQueryParamsV2(BaseModel):
     ]
     start_date: datetime
     end_date: datetime
+    commits_list: Annotated[
+        Optional[list[str]],
+        BeforeValidator(_normalize_commits_list),
+    ] = Field(default=None)

--- a/backend/kernelCI_app/views/hardwareView.py
+++ b/backend/kernelCI_app/views/hardwareView.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from http import HTTPStatus
 
 from drf_spectacular.utils import extend_schema
@@ -70,18 +69,16 @@ class HardwareView(APIView):
                 start_date=request.GET.get("startTimestampInSeconds"),
                 end_date=request.GET.get("endTimestampInSeconds"),
                 origin=request.GET.get("origin"),
+                commits_list=request.GET.get("commitsList"),
             )
-
-            start_date: datetime = query_params.start_date
-            end_date: datetime = query_params.end_date
-            origin = query_params.origin
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.BAD_REQUEST)
 
         hardwares_raw = get_hardware_listing_data(
-            origin=origin,
-            start_date=start_date,
-            end_date=end_date,
+            origin=query_params.origin,
+            start_date=query_params.start_date,
+            end_date=query_params.end_date,
+            commits_list=query_params.commits_list,
         )
 
         try:

--- a/backend/kernelCI_app/views/hardwareViewV2.py
+++ b/backend/kernelCI_app/views/hardwareViewV2.py
@@ -61,6 +61,7 @@ class HardwareViewV2(APIView):
                 start_date=request.GET.get("startTimestampInSeconds"),
                 end_date=request.GET.get("endTimestampInSeconds"),
                 origin=request.GET.get("origin"),
+                commits_list=request.GET.get("commitsList"),
             )
 
             start_date: datetime = query_params.start_date
@@ -73,6 +74,7 @@ class HardwareViewV2(APIView):
             origin=origin,
             start_date=start_date,
             end_date=end_date,
+            commits_list=query_params.commits_list,
         )
 
         try:

--- a/backend/requests/hardware-listing-v2.sh
+++ b/backend/requests/hardware-listing-v2.sh
@@ -1,3 +1,4 @@
+# http 'http://localhost:8000/api/hardware-v2/?startTimestampInSeconds=1736510400&endTimestampInSeconds=1736942400&origin=maestro&commitsList=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 http 'http://localhost:8000/api/hardware-v2/?startTimestampInSeconds=1736510400&endTimestampInSeconds=1736942400&origin=maestro'
 
 # HTTP/1.1 200 OK

--- a/backend/requests/hardware-listing.sh
+++ b/backend/requests/hardware-listing.sh
@@ -1,5 +1,8 @@
 http 'http://localhost:8000/api/hardware/?startTimestampInSeconds=1736510400&endTimestampInSeconds=1736942400&origin=maestro'
 
+# Optional: comma-separated commit identifiers — full SHA and/or git tag strings (matches hash or overlaps git_commit_tags)
+# http 'http://localhost:8000/api/hardware/?startTimestampInSeconds=1736510400&endTimestampInSeconds=1736942400&origin=maestro&commitsList=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
 # HTTP/1.1 200 OK
 # Allow: GET, HEAD, OPTIONS
 # Cache-Control: max-age=0

--- a/dashboard/src/api/hardware.ts
+++ b/dashboard/src/api/hardware.ts
@@ -61,6 +61,7 @@ const fetchHardwareListingV2 = async (
   origin: string,
   startTimestampInSeconds: number,
   endTimestampInSeconds: number,
+  commitsList?: string[],
 ): Promise<HardwareListingResponseV2> => {
   const data = await RequestData.get<HardwareListingResponseV2>(
     '/api/hardware-v2/',
@@ -69,6 +70,7 @@ const fetchHardwareListingV2 = async (
         startTimestampInSeconds,
         endTimestampInSeconds,
         origin,
+        ...(commitsList?.length ? { commitsList: commitsList.join(',') } : {}),
       },
     },
   );
@@ -80,6 +82,7 @@ export const useHardwareListingV2 = (
   startTimestampInSeconds: number,
   endTimestampInSeconds: number,
   searchFrom: HardwareListingRoutesMap['v2']['search'],
+  commitsList?: string[],
 ): UseQueryResult<HardwareListingResponseV2> => {
   const { origin } = useSearch({ from: searchFrom });
 
@@ -88,6 +91,7 @@ export const useHardwareListingV2 = (
     startTimestampInSeconds,
     endTimestampInSeconds,
     origin,
+    commitsList ?? null,
   ];
 
   return useQuery({
@@ -97,6 +101,7 @@ export const useHardwareListingV2 = (
         origin,
         startTimestampInSeconds,
         endTimestampInSeconds,
+        commitsList,
       ),
     refetchOnWindowFocus: false,
   });

--- a/dashboard/src/lib/commits.ts
+++ b/dashboard/src/lib/commits.ts
@@ -1,0 +1,12 @@
+const COMMIT_REGEX = [
+  /\b[0-9a-f]{40}\b/g,
+  /\S*v?\d+\.\d+(?:\.\d+)?(?:-rc\d+)?\S*/gi,
+  /\b([a-z][a-z0-9]*(?:-[a-z0-9]+)*)-(\d{8})\S*/gi,
+];
+
+export const listCommits = (text: string): string[] => {
+  if (typeof text !== 'string') {
+    return [];
+  }
+  return COMMIT_REGEX.flatMap(r => text.match(r) || []);
+};

--- a/dashboard/src/lib/intent.ts
+++ b/dashboard/src/lib/intent.ts
@@ -1,0 +1,22 @@
+import { listCommits } from '@/lib/commits';
+
+export type SearchIntent =
+  | { intent: 'commits'; commits: string[]; search: string }
+  | { intent: 'text'; search: string };
+
+export const parseSearchIntent = (text: string): SearchIntent => {
+  const commitList = listCommits(text);
+  if (commitList.length > 0) {
+    return {
+      intent: 'commits',
+      commits: commitList,
+      search: commitList
+        .reduce((acc, word) => acc.replace(word, ''), text)
+        .trim(),
+    };
+  }
+  return {
+    intent: 'text',
+    search: text,
+  };
+};

--- a/dashboard/src/pages/Hardware/HardwareListingPageV2.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPageV2.tsx
@@ -26,6 +26,7 @@ import { HardwareTable } from './HardwareTable';
 
 interface HardwareListingPageV2Props {
   inputFilter: string;
+  commitsList?: string[];
   urlFromMap: HardwareListingRoutesMap['v2'];
 }
 
@@ -68,6 +69,7 @@ const useHardwareListingTime = (
 
 const HardwareListingPageV2 = ({
   inputFilter,
+  commitsList,
   urlFromMap,
 }: HardwareListingPageV2Props): JSX.Element => {
   const { startTimestampInSeconds, endTimestampInSeconds } =
@@ -78,6 +80,7 @@ const HardwareListingPageV2 = ({
     startTimestampInSeconds,
     endTimestampInSeconds,
     urlFromMap.search,
+    commitsList,
   );
 
   const listItems: HardwareItem[] = useMemo(() => {

--- a/dashboard/src/pages/Hardware/HardwareV2.tsx
+++ b/dashboard/src/pages/Hardware/HardwareV2.tsx
@@ -8,6 +8,7 @@ import { MemoizedListingOGTags } from '@/components/OpenGraphTags/ListingOGTags'
 import { NewPageBanner } from '@/components/Banner/PageBanner';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import type { HardwareListingRoutesMap } from '@/utils/constants/hardwareListing';
+import { parseSearchIntent } from '@/lib/intent';
 
 export const HardwareV2 = ({
   urlFromMap,
@@ -18,6 +19,8 @@ export const HardwareV2 = ({
   const { hardwareSearch } = useSearch({
     from: urlFromMap.search,
   });
+
+  const intent = parseSearchIntent(hardwareSearch ?? '');
 
   return (
     <>
@@ -30,7 +33,8 @@ export const HardwareV2 = ({
       )}
       <div className="bg-light-gray w-full py-10">
         <HardwareListingPageV2
-          inputFilter={hardwareSearch ?? ''}
+          inputFilter={intent.search}
+          commitsList={intent.intent === 'commits' ? intent.commits : undefined}
           urlFromMap={urlFromMap}
         />
       </div>

--- a/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetails.tsx
@@ -24,10 +24,13 @@ import { useHardwareDetailsCommitHistory } from '@/api/hardwareDetails';
 
 import type {
   CommitHead,
+  CommitHistory,
   CommitHistoryTable,
   PreparedTrees,
   HardwareTrees,
 } from '@/types/hardware/hardwareDetails';
+
+import { parseSearchIntent } from '@/lib/intent';
 
 import MemoizedCompatibleHardware from '@/components/Cards/CompatibleHardware';
 
@@ -70,16 +73,44 @@ import { HardwareHeader } from './HardwareDetailsHeaderTable';
 import HardwareDetailsTabs from './Tabs/HardwareDetailsTabs';
 import HardwareDetailsFilter from './HardwareDetailsFilter';
 
+function matchesCommitToken(
+  hash: string,
+  tags: string[] | undefined,
+  selected: string,
+): boolean {
+  return (
+    hash.toLowerCase() === selected.toLowerCase() ||
+    (tags?.includes(selected) ?? false)
+  );
+}
+
+function findMatchingCheckout(
+  rows: CommitHistory[],
+  tokens: string[],
+): CommitHistory | undefined {
+  for (const token of tokens) {
+    const found = rows.find(r =>
+      matchesCommitToken(r.git_commit_hash, r.git_commit_tags, token),
+    );
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
 const prepareTreeItems = ({
   treeItems,
   commitHistoryData,
   isCommitHistoryDataLoading,
   isMainPageLoading,
+  commitIntentTokens,
 }: {
   treeItems?: HardwareTrees[];
   commitHistoryData?: CommitHistoryTable;
   isCommitHistoryDataLoading: boolean;
   isMainPageLoading: boolean;
+  commitIntentTokens?: string[] | null;
 }): PreparedTrees[] | void =>
   treeItems?.map(tree => {
     const treeIdentifier = makeTreeIdentifierKey({
@@ -88,27 +119,41 @@ const prepareTreeItems = ({
       gitRepositoryUrl: tree.git_repository_url ?? '',
     });
 
-    const result: PreparedTrees = {
+    const rows = commitHistoryData?.[treeIdentifier] ?? [];
+    const excludeFromCommitIntentDefaultSelection =
+      !!commitIntentTokens?.length &&
+      !isCommitHistoryDataLoading &&
+      !findMatchingCheckout(rows, commitIntentTokens) &&
+      !commitIntentTokens.some(t =>
+        matchesCommitToken(
+          tree.head_git_commit_hash ?? '',
+          tree.head_git_commit_tag,
+          t,
+        ),
+      );
+
+    return {
       tree_name: tree['tree_name'] ?? '-',
       origin: tree['origin'],
       git_repository_branch: tree['git_repository_branch'] ?? '-',
       head_git_commit_name: tree['head_git_commit_name'] ?? '-',
       head_git_commit_hash: tree['head_git_commit_hash'] ?? '-',
+      head_git_commit_tag: tree['head_git_commit_tag'],
       git_repository_url: tree['git_repository_url'] ?? '-',
       index: tree['index'],
       selected_commit_status: tree['selected_commit_status'],
-      selectableCommits: commitHistoryData?.[treeIdentifier] ?? [],
+      selectableCommits: rows,
       isCommitHistoryDataLoading,
-      isMainPageLoading: isMainPageLoading,
+      isMainPageLoading,
+      excludeFromCommitIntentDefaultSelection,
     };
-
-    return result;
   });
 
 function HardwareDetails(): JSX.Element {
-  const { treeIndexes, treeCommits, diffFilter, origin } = useSearch({
-    from: '/_main/hardware/$hardwareId',
-  });
+  const { treeIndexes, treeCommits, diffFilter, origin, hardwareSearch } =
+    useSearch({
+      from: '/_main/hardware/$hardwareId',
+    });
   const { startTimestampInSeconds, endTimestampInSeconds } = useSearch({
     from: '/_main/hardware/$hardwareId/',
   });
@@ -190,7 +235,10 @@ function HardwareDetails(): JSX.Element {
 
   const numIndexes = summaryResponse?.data?.common?.trees?.length || 0;
   const updateTreeFilters = useCallback(
-    (selectedIndexes: number[] | null) => {
+    (
+      selectedIndexes: number[] | null,
+      { replace = false }: { replace?: boolean } = {},
+    ) => {
       const numSelectedIndexes = selectedIndexes?.length || 0;
       const indexes =
         numSelectedIndexes === numIndexes ? null : selectedIndexes;
@@ -200,6 +248,7 @@ function HardwareDetails(): JSX.Element {
           treeIndexes: indexes,
         }),
         state: s => s,
+        replace,
       });
     },
     [navigate, numIndexes],
@@ -259,6 +308,61 @@ function HardwareDetails(): JSX.Element {
       },
       { enabled: !fullResponse.isLoading && !!fullResponse.data },
     );
+
+  const commitHistoryTable = commitHistoryData?.commit_history_table;
+
+  const commitIntent = useMemo(
+    () => parseSearchIntent(hardwareSearch ?? ''),
+    [hardwareSearch],
+  );
+  const intentCommits =
+    commitIntent.intent === 'commits' ? commitIntent.commits : null;
+
+  useEffect(() => {
+    if (!isEmptyObject(treeCommits) || !intentCommits?.length) {
+      return;
+    }
+
+    const trees = summaryResponse.data?.common.trees;
+    if (!trees?.length || !commitHistoryTable || commitHistoryIsLoading) {
+      return;
+    }
+
+    const newTreeCommits: Record<string, string> = {};
+    for (const tree of trees) {
+      const key = makeTreeIdentifierKey({
+        treeName: tree.tree_name ?? '',
+        gitRepositoryBranch: tree.git_repository_branch ?? '',
+        gitRepositoryUrl: tree.git_repository_url ?? '',
+      });
+      const match = findMatchingCheckout(
+        commitHistoryTable[key] ?? [],
+        intentCommits,
+      );
+      if (match && match.git_commit_hash !== tree.head_git_commit_hash) {
+        newTreeCommits[tree.index] = match.git_commit_hash;
+      }
+    }
+
+    if (!Object.keys(newTreeCommits).length) {
+      return;
+    }
+
+    setTreeIndexesLength(trees.length);
+    navigate({
+      search: prev => ({ ...prev, treeCommits: newTreeCommits }),
+      state: s => s,
+      replace: true,
+    });
+  }, [
+    treeCommits,
+    intentCommits,
+    summaryResponse.data?.common.trees,
+    commitHistoryTable,
+    commitHistoryIsLoading,
+    navigate,
+    setTreeIndexesLength,
+  ]);
 
   const filterListElement = useMemo(() => {
     const flatFilter = createFlatFilter(diffFilter);
@@ -360,15 +464,19 @@ function HardwareDetails(): JSX.Element {
     () =>
       prepareTreeItems({
         treeItems: summaryResponse.data?.common.trees,
-        commitHistoryData: commitHistoryData?.commit_history_table,
-        isCommitHistoryDataLoading: commitHistoryIsLoading,
+        commitHistoryData: commitHistoryTable,
+        isCommitHistoryDataLoading:
+          commitHistoryIsLoading || !commitHistoryData,
         isMainPageLoading:
           fullResponse.isLoading || fullResponse.isPlaceholderData,
+        commitIntentTokens: intentCommits,
       }),
     [
       commitHistoryIsLoading,
+      commitHistoryData,
+      commitHistoryTable,
+      intentCommits,
       summaryResponse.data?.common.trees,
-      commitHistoryData?.commit_history_table,
       fullResponse.isLoading,
       fullResponse.isPlaceholderData,
     ],
@@ -481,6 +589,7 @@ function HardwareDetails(): JSX.Element {
                   selectedIndexes={treeIndexes}
                   updateTreeFilters={updateTreeFilters}
                   setTreeIndexesLength={setTreeIndexesLength}
+                  selectionResetKey={`${hardwareId}\0${hardwareSearch ?? ''}`}
                 />
                 {summaryResponse.data &&
                   summaryResponse.data.common.compatibles.length > 0 && (

--- a/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
+++ b/dashboard/src/pages/hardwareDetails/HardwareDetailsHeaderTable.tsx
@@ -2,6 +2,7 @@ import type {
   ColumnDef,
   RowSelectionState,
   SortingState,
+  Updater,
 } from '@tanstack/react-table';
 import {
   flexRender,
@@ -14,7 +15,7 @@ import {
 
 import type { SetStateAction, Dispatch, JSX } from 'react';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -55,8 +56,12 @@ const DEBOUNCE_INTERVAL = 2000;
 interface IHardwareHeader {
   treeItems: PreparedTrees[];
   selectedIndexes: number[] | null;
-  updateTreeFilters: (selectedIndexes: number[] | null) => void;
+  updateTreeFilters: (
+    selectedIndexes: number[] | null,
+    options?: { replace?: boolean },
+  ) => void;
   setTreeIndexesLength: Dispatch<SetStateAction<number>>;
+  selectionResetKey: string;
 }
 
 const CommitSelector = ({
@@ -255,7 +260,7 @@ const getColumns = (
           <CommitSelector
             headCommitName={row.original.head_git_commit_name}
             headCommitHash={row.original.head_git_commit_hash}
-            headCommitTags={row.original.head_git_commit_tags}
+            headCommitTags={row.original.head_git_commit_tag}
             selectableCommits={row.original.selectableCommits}
             isCommitsLoading={row.original.isCommitHistoryDataLoading}
             treeIndex={row.original.index}
@@ -329,23 +334,29 @@ const getColumns = (
 
 const getInitialRowSelection = (
   selectedIndexes: number[] | null,
-  treeItemsLength: number,
+  treeItems: PreparedTrees[],
   isInitialLoad = false,
 ): Record<string, boolean> => {
-  if (selectedIndexes === null) {
-    return Object.fromEntries(
-      Array.from({ length: treeItemsLength }, (_, i) => [i.toString(), true]),
-    );
+  if (treeItems.length === 0) {
+    return {};
   }
 
-  if (selectedIndexes.length === 0 && isInitialLoad) {
+  if (
+    selectedIndexes === null ||
+    (selectedIndexes.length === 0 && isInitialLoad)
+  ) {
     return Object.fromEntries(
-      Array.from({ length: treeItemsLength }, (_, i) => [i.toString(), true]),
+      treeItems
+        .filter(t => !t.excludeFromCommitIntentDefaultSelection)
+        .map(t => [t.index, true]),
     );
   }
 
   return Object.fromEntries(
-    Array.from(selectedIndexes, treeIndex => [treeIndex.toString(), true]),
+    selectedIndexes
+      .map(idx => treeItems.find(t => t.index === String(idx)))
+      .filter((t): t is PreparedTrees => !!t)
+      .map(t => [t.index, true]),
   );
 };
 
@@ -369,6 +380,7 @@ export function HardwareHeader({
   selectedIndexes = null,
   updateTreeFilters,
   setTreeIndexesLength,
+  selectionResetKey,
 }: IHardwareHeader): JSX.Element {
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'tree_name', desc: false },
@@ -377,25 +389,64 @@ export function HardwareHeader({
     'hardwareDetailsTrees',
   );
 
+  const treeItemsRef = useRef(treeItems);
+  treeItemsRef.current = treeItems;
+
+  /** After the user toggles row selection, do not re-apply commit-intent default selection. */
+  const userAdjustedRowSelectionRef = useRef(false);
+
+  useEffect(() => {
+    userAdjustedRowSelectionRef.current = false;
+  }, [selectionResetKey]);
+
+  const commitHistoryReady =
+    treeItems.length > 0 && !treeItems[0]?.isCommitHistoryDataLoading;
+
   // The initial assignment is useful to catch the initial indexes from URL
   const [rowSelection, setRowSelection] = useState(() =>
-    getInitialRowSelection(selectedIndexes, treeItems.length, true),
+    getInitialRowSelection(selectedIndexes, treeItems, true),
   );
 
   const rowSelectionDebounced = useDebounce(rowSelection, DEBOUNCE_INTERVAL);
 
   useEffect(() => {
     const updatedSelection = indexesFromRowSelection(rowSelectionDebounced);
-    updateTreeFilters(updatedSelection);
+    updateTreeFilters(updatedSelection, {
+      replace: !userAdjustedRowSelectionRef.current,
+    });
   }, [rowSelectionDebounced, updateTreeFilters, treeItems.length]);
 
-  // This useEffect update the current row selection when the selectedIndexes change.
-  // Useful when the user select a tree by filter modal.
   useEffect(() => {
-    setRowSelection(() =>
-      getInitialRowSelection(selectedIndexes, treeItems.length),
-    );
-  }, [selectedIndexes, treeItems.length]);
+    if (treeItems.length === 0) {
+      return;
+    }
+
+    if (selectedIndexes !== null) {
+      setRowSelection(() =>
+        getInitialRowSelection(selectedIndexes, treeItemsRef.current),
+      );
+      return;
+    }
+
+    if (userAdjustedRowSelectionRef.current) {
+      return;
+    }
+
+    setRowSelection(() => getInitialRowSelection(null, treeItemsRef.current));
+  }, [
+    selectedIndexes,
+    treeItems.length,
+    selectionResetKey,
+    commitHistoryReady,
+  ]);
+
+  const onRowSelectionChange = useCallback(
+    (updater: Updater<RowSelectionState>) => {
+      userAdjustedRowSelectionRef.current = true;
+      setRowSelection(updater);
+    },
+    [],
+  );
 
   const columns = useMemo(
     () => getColumns(setTreeIndexesLength),
@@ -413,7 +464,7 @@ export function HardwareHeader({
     getFilteredRowModel: getFilteredRowModel(),
     getRowId: originalRow => originalRow.index,
     enableRowSelection: true,
-    onRowSelectionChange: setRowSelection,
+    onRowSelectionChange,
     state: {
       sorting,
       pagination,

--- a/dashboard/src/routes/_main/hardware/$hardwareId/route.tsx
+++ b/dashboard/src/routes/_main/hardware/$hardwareId/route.tsx
@@ -25,6 +25,7 @@ const defaultValues = {
   treeCommits: {},
   tableFilter: zTableFilterInfoDefault,
   diffFilter: DEFAULT_DIFF_FILTER,
+  hardwareSearch: '',
 };
 const hardwareDetailsSearchSchema = z.object({
   origin: zOrigin,
@@ -33,6 +34,7 @@ const hardwareDetailsSearchSchema = z.object({
   treeCommits: zTreeCommits,
   tableFilter: zTableFilterInfoValidator,
   diffFilter: zDiffFilter,
+  hardwareSearch: z.string().catch(''),
 } satisfies SearchSchema);
 
 export const Route = createFileRoute('/_main/hardware/$hardwareId')({

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -21,7 +21,7 @@ export type HardwareTrees = {
   git_repository_url?: string;
   head_git_commit_name?: string;
   head_git_commit_hash?: string;
-  head_git_commit_tags?: string[];
+  head_git_commit_tag?: string[];
   selected_commit_status?: TTreesStatusSummary;
   index: string;
 };
@@ -30,6 +30,7 @@ export type PreparedTrees = HardwareTrees & {
   selectableCommits: CommitHistory[];
   isCommitHistoryDataLoading: boolean;
   isMainPageLoading: boolean;
+  excludeFromCommitIntentDefaultSelection?: boolean;
 };
 
 export type HardwareCommon = {


### PR DESCRIPTION

Include an option to do commit searches on the search bar of the hardware listing page.

## How to test
  * Open the hardware listing page and type a valid commit hash, it should list include only the status of the specified commit.
  * When using regular text (not containing any valid commit hashes), the regular text search should take place.
  * In the case of using both, the page should join the behaviours, listing the selected commits, and applygin textual search for the extra text.
  
  Closes #1900 
