### PR TITLE
fix: move secret check from job-level to step-level in sync-dashboard-team

### DIFF
--- a/.github/workflows/sync-dashboard-team.yaml
+++ b/.github/workflows/sync-dashboard-team.yaml
@@ -29,8 +29,10 @@ permissions:
 jobs:
   # Add validation checks for Pull Requests
   validate:
-    if: github.event_name == 'pull_request' && secrets.ORG_ADMIN_TOKEN != ''
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      ORG_ADMIN_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
 
     permissions:
       contents: read
@@ -51,11 +53,12 @@ jobs:
         run: npm ci
 
       - name: Dry run
+        if: env.ORG_ADMIN_TOKEN != ''
         working-directory: .github/scripts
         run: node sync-dashboard-team.js
         env:
           DRY_RUN: true
-          GITHUB_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ env.ORG_ADMIN_TOKEN }}
           ORG: kernelci
           TEAM_SLUG: dashboard
 


### PR DESCRIPTION
Fix GitHub Actions workflow failure caused by using `secrets.ORG_ADMIN_TOKEN` in job-level `if`.

GitHub Actions does not allow `secrets` context in `jobs.<job_id>.if`, so PR validation now gates only on pull request event. Secret-dependent dry run step checks `env.ORG_ADMIN_TOKEN` instead.

Ref: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#using-secrets-in-a-workflow