### PR TITLE
feat: improve tests table hierarchy nesting

### DIFF
--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -46,6 +46,7 @@ import {
   matchByPathSubstring,
   matchTestByPathSubstring,
 } from './filterTestsTree';
+import { collapseSingleChildChains } from './collapseTestsTree';
 
 export interface ITestsTable {
   tableKey: TableKeys;
@@ -93,13 +94,13 @@ export function TestsTable({
     [pathFilteredTree],
   );
 
-  const data = useMemo(
-    () =>
+  const data = useMemo(() => {
+    const filtered =
       filter === 'all'
         ? pathFilteredTree
-        : pruneTree(pathFilteredTree, { matchTest: matchByStatus(filter) }),
-    [pathFilteredTree, filter],
-  );
+        : pruneTree(pathFilteredTree, { matchTest: matchByStatus(filter) });
+    return collapseSingleChildChains(filtered);
+  }, [pathFilteredTree, filter]);
 
   const table = useReactTable({
     data,

--- a/dashboard/src/components/TestsTable/collapseTestsTree.ts
+++ b/dashboard/src/components/TestsTable/collapseTestsTree.ts
@@ -1,0 +1,44 @@
+import type { TPathTests } from '@/types/general';
+
+/**
+ * Recursively collapses single-child chains in the test tree.
+ *
+ * A node N is merged with its sole child C when:
+ * - N has exactly one sub_group, AND
+ * - N has no individual_tests
+ *
+ * The merge creates a new node with:
+ * - path_group = `${N.path_group}.${C.path_group}`
+ * - path_prefix = N.path_prefix (unchanged)
+ * - All other properties from C (counts, sub_groups, individual_tests, is_leaf_group)
+ */
+export function collapseSingleChildChains(nodes: TPathTests[]): TPathTests[] {
+  return nodes.map(node => collapseNode(node));
+}
+
+function collapseNode(node: TPathTests): TPathTests {
+  const collapsedSubGroups = node.sub_groups
+    ? node.sub_groups.map(child => collapseNode(child))
+    : undefined;
+
+  let current: TPathTests = {
+    ...node,
+    sub_groups: collapsedSubGroups,
+  };
+
+  while (
+    current.sub_groups &&
+    current.sub_groups.length === 1 &&
+    current.individual_tests.length === 0
+  ) {
+    const child = current.sub_groups[0];
+
+    current = {
+      ...child,
+      path_group: `${current.path_group}.${child.path_group}`,
+      path_prefix: current.path_prefix,
+    };
+  }
+
+  return current;
+}

--- a/dashboard/src/components/TestsTable/filterTestsTree.ts
+++ b/dashboard/src/components/TestsTable/filterTestsTree.ts
@@ -28,20 +28,17 @@ export function pruneTree(
 
     const nodeMatchesPath = predicates.matchNodePath?.(fullPath) ?? false;
 
-    let filteredSubGroups: TPathTests[] | undefined;
-    let filteredIndividualTests: TIndividualTest[];
-
     if (nodeMatchesPath) {
-      filteredSubGroups = node.sub_groups;
-      filteredIndividualTests = node.individual_tests;
-    } else {
-      filteredSubGroups = node.sub_groups
-        ? pruneTree(node.sub_groups, predicates)
-        : undefined;
-      filteredIndividualTests = node.individual_tests.filter(
-        predicates.matchTest,
-      );
+      results.push(node);
+      return;
     }
+
+    const filteredSubGroups = node.sub_groups
+      ? pruneTree(node.sub_groups, predicates)
+      : undefined;
+    const filteredIndividualTests = node.individual_tests.filter(
+      predicates.matchTest,
+    );
 
     const hasSubGroups = filteredSubGroups && filteredSubGroups.length > 0;
     const hasIndividualTests = filteredIndividualTests.length > 0;
@@ -51,14 +48,11 @@ export function pruneTree(
     }
 
     const localGroup: TPathTestsStatus = createEmptyGroupStatusCounts();
-
     filteredIndividualTests.forEach(t => {
       countStatus(localGroup, t.status);
     });
 
-    if (nodeMatchesPath) {
-      addCounts(localGroup, node);
-    } else if (hasSubGroups) {
+    if (hasSubGroups) {
       filteredSubGroups!.forEach(g => {
         addCounts(localGroup, g);
       });


### PR DESCRIPTION
## Description

Improve tests table readability by collapsing empty single-child group chains into a single displayed path segment.

## How to test

1. Open a tests table with deeply nested single-child groups
2. Confirm empty intermediate groups are shown as one combined path segment

Closes #1906