### PR TITLE
Add githooks to manage commit DCO sign-off

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,18 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+
+      - id: check-dco
+        name: Check DCO Sign-off
+        stages: [commit-msg]
+        entry: sh
+        args:
+          - -c
+          - |
+            if ! ( git interpret-trailers --parse "$1" | grep -q "Signed-off-by:" ); then
+              echo 'Missing DCO "Signed-off-by:" line. Try committing with "--signoff|-s"'
+              exit 1
+            fi
+          - --
+        language: system
+        always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ You can find more details on the Conventional Commits specification site.
   - Auto-fix lint issues: `poetry run ruff check . --fix`
   - Run type checks (optional but recommended): `poetry run mypy`
   - Run tests: `poetry run pytest`
-  - Install Git hooks once per clone: from the repository root run `poetry -C backend run pre-commit install --hook-type pre-commit --hook-type pre-push --install-hooks`
+  - Install Git hooks once per clone: from the repository root run `poetry -C backend run pre-commit install --hook-type pre-commit --hook-type pre-push --hook-type commit-msg --install-hooks`
   - Run all hooks manually: `poetry -C backend run pre-commit run --all-files`
 - Frontend
   - See [dashboard/README.md](dashboard/README.md) for scripts and commands

--- a/backend/README.md
+++ b/backend/README.md
@@ -112,7 +112,7 @@ The backend uses Ruff for linting and formatting.
 This repository uses pre-commit for Git hooks (`pre-commit` and `pre-push`). Install hooks once per clone from the repository root:
 
 ```sh
-poetry -C backend run pre-commit install --hook-type pre-commit --hook-type pre-push --install-hooks
+poetry -C backend run pre-commit install --hook-type pre-commit --hook-type pre-push --hook-type commit-msg --install-hooks
 ```
 
 To run all configured hooks manually:


### PR DESCRIPTION
Adds a local commit-msg git-hook to check for commit messages without the DCO "Signed-off-by:" trailer.

Closes: #1922
Related: #1930, #1931

## Caveats
- Does not check that the DCO is valid (same email as committer)
- Only works as a dev convenience. Actual repo verification should be enabled via GH settings/CI (see #1930)