### PR TITLE
feat: increase metrics cache time

### DIFF
--- a/backend/kernelCI_app/queries/notifications.py
+++ b/backend/kernelCI_app/queries/notifications.py
@@ -16,6 +16,8 @@ from kernelCI_app.typeModels.metrics_notifications import (
     TopIssue,
 )
 
+METRICS_CACHE_TIMEOUT = 60 * 60 * 6  # 6 hours
+
 
 def kcidb_execute_query(query, params=None):
     try:
@@ -645,7 +647,13 @@ def get_issues_summary_data(*, checkout_ids: list[str]) -> list[dict]:
         return dict_fetchall(cursor=cursor)
 
 
-def query_fetchone_work(*, cache_key: str, query: str, params: dict[str, Any]):
+def query_fetchone_work(
+    *,
+    cache_key: str,
+    query: str,
+    params: dict[str, Any],
+    timeout: int = METRICS_CACHE_TIMEOUT,
+):
     rows = get_query_cache(key=cache_key, params=params)
     if rows is not None:
         return rows
@@ -655,11 +663,17 @@ def query_fetchone_work(*, cache_key: str, query: str, params: dict[str, Any]):
             rows = cursor.fetchone()
     finally:
         connections["default"].close()
-    set_query_cache(key=cache_key, params=params, rows=rows)
+    set_query_cache(key=cache_key, params=params, rows=rows, timeout=timeout)
     return rows
 
 
-def query_fetchall_work(*, cache_key: str, query: str, params: dict[str, Any]):
+def query_fetchall_work(
+    *,
+    cache_key: str,
+    query: str,
+    params: dict[str, Any],
+    timeout: int = METRICS_CACHE_TIMEOUT,
+):
     rows = get_query_cache(key=cache_key, params=params)
     if rows is not None:
         return rows
@@ -669,7 +683,7 @@ def query_fetchall_work(*, cache_key: str, query: str, params: dict[str, Any]):
             rows = cursor.fetchall()
     finally:
         connections["default"].close()
-    set_query_cache(key=cache_key, params=params, rows=rows)
+    set_query_cache(key=cache_key, params=params, rows=rows, timeout=timeout)
     return rows
 
 

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -8,6 +8,7 @@ from drf_spectacular.views import (
 )
 
 from kernelCI_app import views
+from kernelCI_app.queries.notifications import METRICS_CACHE_TIMEOUT
 
 
 def view_cache(view, timeout: int = settings.CACHE_TIMEOUT):
@@ -182,5 +183,9 @@ urlpatterns = [
     path("proxy/", views.ProxyView.as_view(), name="proxyView"),
     path("origins/", views.OriginsView.as_view(), name="originsView"),
     path("tree-report/", views.TreeReport.as_view(), name="treeReportView"),
-    path("metrics/", view_cache(views.MetricsView), name="metricsView"),
+    path(
+        "metrics/",
+        view_cache(views.MetricsView, timeout=METRICS_CACHE_TIMEOUT),
+        name="metricsView",
+    ),
 ]


### PR DESCRIPTION
Increase the metrics endpoint cache time. Right now, metrics queries are expensive, and since they are aggregated over multiple days, we can keep them cached for longer.