### PR TITLE
fix: correct ordering on revisions selector on hardware page

### DIFF
--- a/backend/kernelCI_app/views/hardwareSelectorsView.py
+++ b/backend/kernelCI_app/views/hardwareSelectorsView.py
@@ -53,6 +53,21 @@ class HardwareSelectorsView(APIView):
                 }
             )
 
+        for tree in trees:
+            tree["branches"].sort(
+                key=lambda branch: (
+                    branch["git_repository_url"],
+                    branch["git_repository_branch"],
+                )
+            )
+            for branch in tree["branches"]:
+                branch["revisions"].sort(
+                    key=lambda revision: revision["start_time"],
+                    reverse=True,
+                )
+
+        trees.sort(key=lambda tree: tree["tree_name"])
+
         sanitized_trees: list[HardwareSelectorTree] = []
         for tree in trees:
             branches = [


### PR DESCRIPTION
Fixes inconsistent ordering in the hardware page revision selector by sorting trees, branches, and revisions in the hardware selectors API response before returning them to the frontend.

## How to test

1. Open the hardware page.
2. Open the revision selector dropdown.
3. Confirm trees appear in alphabetical order, branches are grouped and ordered consistently, and revisions within each branch show newest commits first.