### PR TITLE
Refactor: right align metrics email

### DIFF
--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -778,10 +778,10 @@ def generate_hardware_summary_report(
 
 
 def _fmt_change(cur: int, prev: int, show_percentage: bool = True) -> str:
-    """Return a signed change string, e.g. '-246  (-17%)' or '-5'."""
+    """Return a signed change string, e.g. '-246 (-17%)' or '-5'."""
     diff = cur - prev
     if diff == 0:
-        return "0  (0%)"
+        return "0"
 
     abs_formatted_diff = f"{abs(diff):,}"
     signed_diff = f"+{abs_formatted_diff}" if diff > 0 else f"-{abs_formatted_diff}"
@@ -789,7 +789,7 @@ def _fmt_change(cur: int, prev: int, show_percentage: bool = True) -> str:
     if show_percentage and prev != 0:
         percentage = round((diff / prev) * 100)
         percentage_sign = "+" if percentage > 0 else ""
-        return f"{signed_diff}  ({percentage_sign}{percentage}%)"
+        return f"{signed_diff} ({percentage_sign}{percentage}%)"
 
     return signed_diff
 

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -864,10 +864,6 @@ def generate_metrics_report(
 
     deltas = compute_metrics_deltas(data)
 
-    # Compute the text spacing for the labs so it isn't too big or too small
-    lab_spacing = max((len(lab_key) for lab_key in data.lab_maps.keys()), default=0)
-    lab_spacing += 7  # add spacing for leading tab and possible * mark for new labs
-
     report = {}
     template = setup_jinja_template("metrics_report.txt.j2")
     report["content"] = template.render(
@@ -875,7 +871,6 @@ def generate_metrics_report(
         start_datetime=start_datetime.strftime("%Y-%m-%d %H:%M %Z"),
         end_datetime=end_datetime.strftime("%Y-%m-%d %H:%M %Z"),
         deltas=deltas,
-        lab_spacing=lab_spacing,
     )
 
     report["title"] = "KernelCI Metrics Report - %s" % now.strftime("%Y-%m-%d %H:%M %Z")

--- a/backend/kernelCI_app/management/commands/templates/metrics_report.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/metrics_report.txt.j2
@@ -10,13 +10,13 @@ Period: {{ start_datetime }} to {{ end_datetime }}
 
   COVERAGE
   --------
-{{ "{:<22}".format("") -}}{{ "{:<13}".format("This week") -}}{{ "{:<13}".format("Last week") }}Change
-{{ "{:<22}".format("") -}}{{ "{:<13}".format("─────────") -}}{{ "{:<13}".format("─────────") }}──────
-{{ "{:<22}".format("  Trees monitored") -}}{{ "{:<13}".format(fmt(n_trees)) -}}{{ "{:<13}".format(fmt(prev_n_trees)) }}{{ deltas.n_trees }}
-{{ "{:<22}".format("  Checkouts") -}}{{ "{:<13}".format(fmt(n_checkouts)) -}}{{ "{:<13}".format(fmt(prev_n_checkouts)) }}{{ deltas.n_checkouts }}
-{{ "{:<22}".format("  Builds") -}}{{ "{:<13}".format(fmt(n_builds)) -}}{{ "{:<13}".format(fmt(prev_n_builds)) }}{{ deltas.n_builds }}
-{{ "{:<22}".format("  Tests") -}}{{ "{:<13}".format(fmt(n_tests)) -}}{{ "{:<13}".format(fmt(prev_n_tests)) }}{{ deltas.n_tests }}
-
+{#- The "change" column has to have more space for the relative percentage indicator #}
+{{ "{:<22}".format("") -}}{{ "{:>13}".format("This week") -}}{{ "{:>13}".format("Last week") }}{{ "{:>20}".format("Change") }}
+{{ "{:<22}".format("") -}}{{ "{:>13}".format("─────────") -}}{{ "{:>13}".format("─────────") }}{{ "{:>20}".format("─────────") }}
+{{ "{:<22}".format("  Trees monitored") -}}{{ "{:>13}".format(fmt(n_trees)) -}}{{ "{:>13}".format(fmt(prev_n_trees)) }}{{  "{:>20}".format(deltas.n_trees) }}
+{{ "{:<22}".format("  Checkouts") -}}{{ "{:>13}".format(fmt(n_checkouts)) -}}{{ "{:>13}".format(fmt(prev_n_checkouts)) }}{{ "{:>20}".format(deltas.n_checkouts) }}
+{{ "{:<22}".format("  Builds") -}}{{ "{:>13}".format(fmt(n_builds)) -}}{{ "{:>13}".format(fmt(prev_n_builds)) }}{{ "{:>20}".format(deltas.n_builds) }}
+{{ "{:<22}".format("  Tests") -}}{{ "{:>13}".format(fmt(n_tests)) -}}{{ "{:>13}".format(fmt(prev_n_tests)) }}{{ "{:>20}".format(deltas.n_tests) }}
 
   BUILD REGRESSIONS
   -----------------
@@ -82,32 +82,33 @@ Affected builds by top issues
 
 {% if n_labs -%}
 {{ "{:<{width}}".format("  Lab", width=lab_spacing) -}}
-{{ "{:<16}".format("Covered builds") -}}
-{{ "{:<9}".format("Boots") -}}
-{{ "{:<15}".format("Tests") -}}
-Change (tests)
+{{ "{:>16}".format("Covered builds") -}}
+{{ "{:>9}".format("Boots") -}}
+{{ "{:>13}".format("Tests") -}}
+{{ "{:>20}".format("Change (tests)") }}
+{#- Just like the COVERAGE section, the "change" needs more space for the relative percentage indicator #}
   ────────────────────────────────────────────────────────────────────────────────
 {% for lab_key, lab_values in lab_maps.items() | sort -%}
     {%- set display_name = lab_key + " *" if lab_key in deltas.new_lab_keys else lab_key -%}
   {{ "{:<{width}}".format("  " + display_name, width=lab_spacing) -}}
-    {{ "{:<16}".format(fmt(lab_values["builds"])) -}}
-    {{ "{:<9}".format(fmt(lab_values["boots"])) -}}
-    {{ "{:<15}".format(fmt(lab_values["tests"])) -}}
-    {{ deltas.labs.get(lab_key, "") }}
+    {{ "{:>16}".format(fmt(lab_values["builds"])) -}}
+    {{ "{:>9}".format(fmt(lab_values["boots"])) -}}
+    {{ "{:>13}".format(fmt(lab_values["tests"])) -}}
+    {{ "{:>20}".format(deltas.labs.get(lab_key, "")) }}
 {% endfor %}
 {%- for lab_key in deltas.extinct_lab_keys | sort -%}
     {%- set lab_values = prev_lab_maps[lab_key] -%}
   {{ "{:<{width}}".format("  " + lab_key, width=lab_spacing) -}}
-    {{ "{:<16}".format(fmt(0)) -}}
-    {{ "{:<9}".format(fmt(0)) -}}
-    {{ "{:<15}".format(fmt(0)) -}}
-    {{ deltas.labs.get(lab_key, "") }}
+    {{ "{:>16}".format(fmt(0)) -}}
+    {{ "{:>9}".format(fmt(0)) -}}
+    {{ "{:>13}".format(fmt(0)) -}}
+    {{ "{:>20}".format(deltas.labs.get(lab_key, "")) }}
 {% endfor %}  ────────────────────────────────────────────────────────────────────────────────
 {{ "{:<{width}}".format("  Total", width=lab_spacing) -}}
-{{ "{:<16}".format(fmt(lab_maps.values() | map(attribute='builds') | sum)) -}}
-{{ "{:<9}".format(fmt(lab_maps.values() | map(attribute='boots') | sum)) -}}
-{{ "{:<15}".format(fmt(lab_maps.values() | map(attribute='tests') | sum)) -}}
-{{ deltas.n_total_lab_activity }}
+{{ "{:>16}".format(fmt(lab_maps.values() | map(attribute='builds') | sum)) -}}
+{{ "{:>9}".format(fmt(lab_maps.values() | map(attribute='boots') | sum)) -}}
+{{ "{:>13}".format(fmt(lab_maps.values() | map(attribute='tests') | sum)) -}}
+{{ "{:>20}".format(deltas.n_total_lab_activity) }}
 
 {%- endif %}
 

--- a/backend/kernelCI_app/management/commands/templates/metrics_report.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/metrics_report.txt.j2
@@ -10,13 +10,43 @@ Period: {{ start_datetime }} to {{ end_datetime }}
 
   COVERAGE
   --------
-{#- The "change" column has to have more space for the relative percentage indicator #}
-{{ "{:<22}".format("") -}}{{ "{:>13}".format("This week") -}}{{ "{:>13}".format("Last week") }}{{ "{:>20}".format("Change") }}
-{{ "{:<22}".format("") -}}{{ "{:>13}".format("─────────") -}}{{ "{:>13}".format("─────────") }}{{ "{:>20}".format("─────────") }}
-{{ "{:<22}".format("  Trees monitored") -}}{{ "{:>13}".format(fmt(n_trees)) -}}{{ "{:>13}".format(fmt(prev_n_trees)) }}{{  "{:>20}".format(deltas.n_trees) }}
-{{ "{:<22}".format("  Checkouts") -}}{{ "{:>13}".format(fmt(n_checkouts)) -}}{{ "{:>13}".format(fmt(prev_n_checkouts)) }}{{ "{:>20}".format(deltas.n_checkouts) }}
-{{ "{:<22}".format("  Builds") -}}{{ "{:>13}".format(fmt(n_builds)) -}}{{ "{:>13}".format(fmt(prev_n_builds)) }}{{ "{:>20}".format(deltas.n_builds) }}
-{{ "{:<22}".format("  Tests") -}}{{ "{:>13}".format(fmt(n_tests)) -}}{{ "{:>13}".format(fmt(prev_n_tests)) }}{{ "{:>20}".format(deltas.n_tests) }}
+{%- set static_spacing = 2 -%}
+{%- set current_week_space = [n_builds|string|length, n_boots|string|length, n_tests|string|length, "This week"|length] | max + static_spacing %}
+{%- set previous_week_space = [prev_n_builds|string|length, prev_n_boots|string|length, prev_n_tests|string|length, "Last week"|length] | max + static_spacing %}
+{%- set change_space = [deltas.n_builds|string|length, deltas.n_boots|string|length, deltas.n_tests|string|length, "Change"|length] | max + static_spacing -%}
+{%- set label_space = 15 %} {#- length of the longest label -#}
+
+{#- Each group is a row, each line is a column #}
+  {{ "{:<{width}}".format("", width=label_space) -}}
+  {{ "{:>{width}}".format("This week", width=current_week_space) -}}
+  {{ "{:>{width}}".format("Last week", width=previous_week_space) -}}
+  {{ "{:>{width}}".format("Change", width=change_space) }}
+  {#-#}
+  {{ "{:<{width}}".format("", width=label_space) -}}
+  {{ "{:>{width}}".format("─" * (current_week_space-static_spacing), width=current_week_space) -}}
+  {{ "{:>{width}}".format("─" * (previous_week_space-static_spacing), width=previous_week_space) -}}
+  {{ "{:>{width}}".format("─" * (change_space-static_spacing), width=change_space) }}
+  {#-#}
+  {{"{:<{width}}".format("Trees monitored", width=label_space) -}}
+  {{ "{:>{width}}".format(fmt(n_trees), width=current_week_space) -}}
+  {{ "{:>{width}}".format(fmt(prev_n_trees), width=previous_week_space) -}}
+  {{  "{:>{width}}".format(deltas.n_trees, width=change_space) }}
+  {#-#}
+  {{ "{:<{width}}".format("Checkouts", width=label_space) -}}
+  {{ "{:>{width}}".format(fmt(n_checkouts), width=current_week_space) -}}
+  {{ "{:>{width}}".format(fmt(prev_n_checkouts), width=previous_week_space) -}}
+  {{ "{:>{width}}".format(deltas.n_checkouts, width=change_space) }}
+  {#-#}
+  {{ "{:<{width}}".format("Builds", width=label_space) -}}
+  {{ "{:>{width}}".format(fmt(n_builds), width=current_week_space) -}}
+  {{ "{:>{width}}".format(fmt(prev_n_builds), width=previous_week_space) -}}
+  {{ "{:>{width}}".format(deltas.n_builds, width=change_space) }}
+  {#-#}
+  {{ "{:<{width}}".format("Tests", width=label_space) -}}
+  {{ "{:>{width}}".format(fmt(n_tests), width=current_week_space) -}}
+  {{ "{:>{width}}".format(fmt(prev_n_tests), width=previous_week_space) -}}
+  {{ "{:>{width}}".format(deltas.n_tests, width=change_space) }}
+
 
   BUILD REGRESSIONS
   -----------------
@@ -80,35 +110,57 @@ Affected builds by top issues
 
   Labs marked with an asterisk (*) are new.
 
-{% if n_labs -%}
-{{ "{:<{width}}".format("  Lab", width=lab_spacing) -}}
-{{ "{:>16}".format("Covered builds") -}}
-{{ "{:>9}".format("Boots") -}}
-{{ "{:>13}".format("Tests") -}}
-{{ "{:>20}".format("Change (tests)") }}
-{#- Just like the COVERAGE section, the "change" needs more space for the relative percentage indicator #}
-  ────────────────────────────────────────────────────────────────────────────────
+{% if n_labs and lab_maps -%}
+{#- Compute the text spacing in jinja instead of python to consider the `fmt` macro -#}
+{%- set static_spacing = 3 -%}
+{%- set lab_names_len = lab_maps.keys() | map('length') | max -%}
+{%- set lab_names_space = [lab_names_len, "Lab"|length ] | max + static_spacing + 2 -%} {#- +2 for the possible ` *` -#}
+
+{#- a namespace is required to store the values outside of the loop -#}
+{#- initialize with the label length so we consider them as well -#}
+{%- set ns = namespace(lab_builds_len="Covered builds"|length, lab_boots_len="Boots"|length, lab_tests_len="Tests"|length) -%}
+{%- for v in lab_maps.values() -%}
+  {%- set ns.lab_builds_len = [ns.lab_builds_len, (fmt(v.builds))|length] | max -%}
+  {%- set ns.lab_boots_len = [ns.lab_boots_len, (fmt(v.boots))|length] | max -%}
+  {%- set ns.lab_tests_len = [ns.lab_tests_len, (fmt(v.tests))|length] | max -%}
+{%- endfor -%}
+{%- set lab_builds_space = ns.lab_builds_len + static_spacing -%}
+{%- set lab_boots_space = ns.lab_boots_len + static_spacing -%}
+{%- set lab_tests_space = ns.lab_tests_len + static_spacing -%}
+
+{%- set lab_change_len = deltas.labs.values() | map('length') | max -%}
+{%- set lab_change_space = [lab_change_len, "Change (tests)"|length] | max + static_spacing -%}
+
+{%- set hrule_length = lab_names_space + lab_builds_space + lab_boots_space + lab_tests_space + lab_change_space - 2 -%}
+
+{{ "{:<{width}}".format("  Lab", width=lab_names_space) -}}
+{{ "{:>{width}}".format("Covered builds", width=lab_builds_space) -}}
+{{ "{:>{width}}".format("Boots", width=lab_boots_space) -}}
+{{ "{:>{width}}".format("Tests", width=lab_tests_space) -}}
+{{ "{:>{width}}".format("Change (tests)", width=lab_change_space) }}
+  {{ "─" * hrule_length}}
 {% for lab_key, lab_values in lab_maps.items() | sort -%}
-    {%- set display_name = lab_key + " *" if lab_key in deltas.new_lab_keys else lab_key -%}
-  {{ "{:<{width}}".format("  " + display_name, width=lab_spacing) -}}
-    {{ "{:>16}".format(fmt(lab_values["builds"])) -}}
-    {{ "{:>9}".format(fmt(lab_values["boots"])) -}}
-    {{ "{:>13}".format(fmt(lab_values["tests"])) -}}
-    {{ "{:>20}".format(deltas.labs.get(lab_key, "")) }}
+  {%- set display_name = lab_key + " *" if lab_key in deltas.new_lab_keys else lab_key -%}
+  {{ "{:<{width}}".format("  " + display_name, width=lab_names_space) -}}
+  {{ "{:>{width}}".format(fmt(lab_values["builds"]), width=lab_builds_space) -}}
+  {{ "{:>{width}}".format(fmt(lab_values["boots"]), width=lab_boots_space) -}}
+  {{ "{:>{width}}".format(fmt(lab_values["tests"]), width=lab_tests_space) -}}
+  {{ "{:>{width}}".format(deltas.labs.get(lab_key, ""), width=lab_change_space) }}
 {% endfor %}
 {%- for lab_key in deltas.extinct_lab_keys | sort -%}
-    {%- set lab_values = prev_lab_maps[lab_key] -%}
-  {{ "{:<{width}}".format("  " + lab_key, width=lab_spacing) -}}
-    {{ "{:>16}".format(fmt(0)) -}}
-    {{ "{:>9}".format(fmt(0)) -}}
-    {{ "{:>13}".format(fmt(0)) -}}
-    {{ "{:>20}".format(deltas.labs.get(lab_key, "")) }}
-{% endfor %}  ────────────────────────────────────────────────────────────────────────────────
-{{ "{:<{width}}".format("  Total", width=lab_spacing) -}}
-{{ "{:>16}".format(fmt(lab_maps.values() | map(attribute='builds') | sum)) -}}
-{{ "{:>9}".format(fmt(lab_maps.values() | map(attribute='boots') | sum)) -}}
-{{ "{:>13}".format(fmt(lab_maps.values() | map(attribute='tests') | sum)) -}}
-{{ "{:>20}".format(deltas.n_total_lab_activity) }}
+  {%- set lab_values = prev_lab_maps[lab_key] -%}
+  {{ "{:<{width}}".format("  " + lab_key, width=lab_names_space) -}}
+  {{ "{:>{width}}".format(fmt(0), width=lab_builds_space) -}}
+  {{ "{:>{width}}".format(fmt(0), width=lab_boots_space) -}}
+  {{ "{:>{width}}".format(fmt(0), width=lab_tests_space) -}}
+  {{ "{:>{width}}".format(deltas.labs.get(lab_key, ""), width=lab_change_space) }}
+{% endfor %}
+{{- "  " + "─" * hrule_length}}
+{{ "{:<{width}}".format("  Total", width=lab_names_space) -}}
+{{ "{:>{width}}".format(fmt(lab_maps.values() | map(attribute='builds') | sum), width=lab_builds_space) -}}
+{{ "{:>{width}}".format(fmt(lab_maps.values() | map(attribute='boots') | sum), width=lab_boots_space) -}}
+{{ "{:>{width}}".format(fmt(lab_maps.values() | map(attribute='tests') | sum), width=lab_tests_space) -}}
+{{ "{:>{width}}".format(deltas.n_total_lab_activity, width=lab_change_space) }}
 
 {%- endif %}
 

--- a/backend/kernelCI_app/management/commands/templates/metrics_report.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/metrics_report.txt.j2
@@ -54,30 +54,37 @@ Period: {{ start_datetime }} to {{ end_datetime }}
 
 {% if build_incidents_by_origin -%}
 
-{{ "{:<12}".format("  Origin") -}}
-{{ "{:<18}".format("Regressions") -}}
-{{ "{:<19}".format("Affected") -}}
-Affected builds by top issues
-{{ "{:<12}".format("") -}}
-{{ "{:<18}".format("(known + new)") -}}
-{{ "{:<19}".format("Builds (total)") -}}
-{{ "{:<8}".format("#1") -}}{{ "{:<8}".format("#2") -}}#3
-  ─────────────────────────────────────────────────────────────────────────
+{% set origin_space = 12 -%}
+{% set known_reg_space = 6 -%}
+{% set new_reg_space = 6 -%}
+{% set total_reg_space = 6 -%}
+{% set reg_space = known_reg_space + new_reg_space + total_reg_space -%}
+{% set affected_space = 16 -%}
+{% set ind_issues_space = 10 -%}
+{{ "{:<{width}}".format("  Origin", width=origin_space) -}}
+{{ "{:>{width}}".format("Regressions", width=reg_space) -}}
+{{ "{:>{width}}".format("Affected", width=affected_space) -}}
+{{ "{:>{width}}".format("Affected builds by top issues", width=ind_issues_space*3 + 1) }} {#- +1 to get to a 2-space gap, same for the #1 issue and the space after total incidents #}
+{{ "{:<{width}}".format("", width=origin_space) -}}
+{{ "{:>{width}}".format("(known + new)", width=reg_space) -}}
+{{ "{:>{width}}".format("Builds (total)", width=affected_space) -}}
+{{ "{:>{width}}".format("#1", width=ind_issues_space + 1) -}}{{ "{:>{width}}".format("#2", width=ind_issues_space) -}}{{ "{:>{width}}".format("#3", width=ind_issues_space) }}
+  ───────────────────────────────────────────────────────────────────────────
 {% for origin, data in build_incidents_by_origin.items() | sort -%}
-  {{ "{:<12}".format("  " + origin) -}}
-  {{ "{:<4}".format(fmt(data['n_existing_issues'])) -}} +{{" "}}
-  {{- "{:<4}".format(fmt(data['n_new_issues'])) -}} ={{" "}}
-  {{- "{:<6}".format(fmt(data['n_total_issues'])) -}}
-  {{ "{:<19}".format(fmt(data['total_incidents'])) -}}
+  {{ "{:<{width}}".format("  " + origin, width=origin_space) -}}
+  {{ "{:>{width}}".format(fmt(data['n_existing_issues']) + " +", width=known_reg_space) }}
+  {{- "{:>{width}}".format(fmt(data['n_new_issues']) + " =", width=new_reg_space) }}
+  {{- "{:>{width}}".format(fmt(data['n_total_issues']), width=total_reg_space) -}}
+  {{ "{:>{width}}".format(fmt(data['total_incidents']), width=affected_space) -}} {{ " " -}}
   {% for issue_key, data in top_issues_by_origin.get(origin, {}).items() -%}
-    {{ "{:<8}".format(fmt(data['total_incidents'])) -}}
+    {{ "{:>{width}}".format(fmt(data['total_incidents']), width=ind_issues_space) -}}
   {% endfor %}
-{% endfor %}  ─────────────────────────────────────────────────────────────────────────
-{{ "{:<12}".format("  Total") -}}
-{{ "{:<4}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_existing_issues') | sum)) -}} +{{" "}}
-{{- "{:<4}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_new_issues') | sum)) -}} ={{" "}}
-{{- "{:<6}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_total_issues') | sum)) -}}
-{{ fmt(build_incidents_by_origin.values() | map(attribute='total_incidents') | sum) }}
+{% endfor %}  ───────────────────────────────────────────────────────────────────────────
+{{ "{:<{width}}".format("  Total", width=origin_space) -}}
+{{ "{:>{width}}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_existing_issues') | sum) + " +", width=known_reg_space) }}
+{{- "{:>{width}}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_new_issues') | sum) + " =", width=new_reg_space) }}
+{{- "{:>{width}}".format(fmt(build_incidents_by_origin.values() | map(attribute='n_total_issues') | sum), width=total_reg_space) -}}
+{{ "{:>{width}}".format(fmt(build_incidents_by_origin.values() | map(attribute='total_incidents') | sum), width=affected_space) }}
 {%- else %}  No build regressions to show in this period. {%- endif %}
 
 

--- a/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_example.txt
+++ b/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_example.txt
@@ -4,12 +4,13 @@ KernelCI Metrics Summary
 
   COVERAGE
   --------
-                          This week    Last week              Change
-                          ─────────    ─────────           ─────────
-  Trees monitored               105          100                  +5
-  Checkouts                   1,000        1,000                   0
-  Builds                     11,000       10,000       +1,000 (+10%)
-  Tests                   1,000,000    1,500,000     -500,000 (-33%)
+                   This week  Last week           Change
+                   ─────────  ─────────  ───────────────
+  Trees monitored        105        100               +5
+  Checkouts            1,000      1,000                0
+  Builds              11,000     10,000    +1,000 (+10%)
+  Tests            1,000,000  1,500,000  -500,000 (-33%)
+
 
   BUILD REGRESSIONS
   -----------------
@@ -43,12 +44,12 @@ KernelCI Metrics Summary
 
   Labs marked with an asterisk (*) are new.
 
-  Lab                  Covered builds    Boots        Tests      Change (tests)
-  ────────────────────────────────────────────────────────────────────────────────
-  lava-broonie                      0   25,000      475,000     -175,000 (-27%)
-  lava-collabora                    0   50,000      450,000     -250,000 (-36%)
-  ────────────────────────────────────────────────────────────────────────────────
-  Total                             0   75,000      925,000     -425,000 (-31%)
+  Lab                 Covered builds    Boots     Tests    Change (tests)
+  ───────────────────────────────────────────────────────────────────────
+  lava-broonie                     0   25,000   475,000   -175,000 (-27%)
+  lava-collabora                   0   50,000   450,000   -250,000 (-36%)
+  ───────────────────────────────────────────────────────────────────────
+  Total                            0   75,000   925,000   -425,000 (-31%)
 
 --
 This is an experimental report format. Please send feedback in!

--- a/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_example.txt
+++ b/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_example.txt
@@ -16,13 +16,13 @@ KernelCI Metrics Summary
   -----------------
   A "regression" is defined as a reported problem affecting 0 or multiple builds.
 
-  Origin    Regressions       Affected           Affected builds by top issues
-            (known + new)     Builds (total)     #1      #2      #3
-  ─────────────────────────────────────────────────────────────────────────
-  maestro   1   + 1   = 2     70                 50      20      
-  redhat    1   + 0   = 1     5                  5       
-  ─────────────────────────────────────────────────────────────────────────
-  Total     2   + 1   = 3     75
+  Origin           Regressions        Affected  Affected builds by top issues
+                 (known + new)  Builds (total)         #1        #2        #3
+  ───────────────────────────────────────────────────────────────────────────
+  maestro      1 +   1 =     2              70         50        20
+  redhat       1 +   0 =     1               5          5
+  ───────────────────────────────────────────────────────────────────────────
+  Total        2 +   1 =     3              75
 
 
   TOP REGRESSIONS PER ORIGIN

--- a/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_example.txt
+++ b/backend/kernelCI_app/tests/unitTests/commands/fixtures/metrics_notifications_example.txt
@@ -4,13 +4,12 @@ KernelCI Metrics Summary
 
   COVERAGE
   --------
-                      This week    Last week    Change
-                      ─────────    ─────────    ──────
-  Trees monitored     105          100          +5
-  Checkouts           1,000        1,000        0  (0%)
-  Builds              11,000       10,000       +1,000  (+10%)
-  Tests               1,000,000    1,500,000    -500,000  (-33%)
-
+                          This week    Last week              Change
+                          ─────────    ─────────           ─────────
+  Trees monitored               105          100                  +5
+  Checkouts                   1,000        1,000                   0
+  Builds                     11,000       10,000       +1,000 (+10%)
+  Tests                   1,000,000    1,500,000     -500,000 (-33%)
 
   BUILD REGRESSIONS
   -----------------
@@ -44,12 +43,12 @@ KernelCI Metrics Summary
 
   Labs marked with an asterisk (*) are new.
 
-  Lab                Covered builds  Boots    Tests          Change (tests)
+  Lab                  Covered builds    Boots        Tests      Change (tests)
   ────────────────────────────────────────────────────────────────────────────────
-  lava-broonie       0               25,000   475,000        -175,000  (-27%)
-  lava-collabora     0               50,000   450,000        -250,000  (-36%)
+  lava-broonie                      0   25,000      475,000     -175,000 (-27%)
+  lava-collabora                    0   50,000      450,000     -250,000 (-36%)
   ────────────────────────────────────────────────────────────────────────────────
-  Total              0               75,000   925,000        -425,000  (-31%)
+  Total                             0   75,000      925,000     -425,000 (-31%)
 
 --
 This is an experimental report format. Please send feedback in!

--- a/backend/kernelCI_app/tests/unitTests/commands/metrics_notifications_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/metrics_notifications_test.py
@@ -99,19 +99,19 @@ def make_metrics_data(**overrides) -> MetricsReportData:
 
 class TestFmtChange(TestCase):
     def test_no_change(self):
-        assert _fmt_change(100, 100) == "0  (0%)"
+        assert _fmt_change(100, 100) == "0"
 
     def test_positive_change_with_percentage(self):
         result = _fmt_change(110, 100)
-        assert result == "+10  (+10%)"
+        assert result == "+10 (+10%)"
 
     def test_negative_change_with_percentage(self):
         result = _fmt_change(90, 100)
-        assert result == "-10  (-10%)"
+        assert result == "-10 (-10%)"
 
     def test_large_numbers_comma_formatted(self):
         result = _fmt_change(10000, 11000)
-        assert result == "-1,000  (-9%)"
+        assert result == "-1,000 (-9%)"
 
     def test_show_percentage_false(self):
         result = _fmt_change(105, 100, show_percentage=False)
@@ -130,16 +130,16 @@ class TestComputeMetricsDeltas(TestCase):
         deltas = compute_metrics_deltas(data)
         expected = {
             "n_trees": "+5",
-            "n_checkouts": "0  (0%)",
-            "n_builds": "+1,000  (+10%)",
-            "n_tests": "-500,000  (-33%)",
+            "n_checkouts": "0",
+            "n_builds": "+1,000 (+10%)",
+            "n_tests": "-500,000 (-33%)",
             "labs": {
-                "lava-collabora": "-250,000  (-36%)",
-                "lava-broonie": "-175,000  (-27%)",
+                "lava-collabora": "-250,000 (-36%)",
+                "lava-broonie": "-175,000 (-27%)",
             },
             "new_lab_keys": set(),
             "extinct_lab_keys": set(),
-            "n_total_lab_activity": "-425,000  (-31%)",
+            "n_total_lab_activity": "-425,000 (-31%)",
         }
 
         for key, value in deltas.items():

--- a/backend/kernelCI_app/tests/unitTests/commands/metrics_notifications_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/metrics_notifications_test.py
@@ -262,7 +262,6 @@ class TestGenerateMetricsReport(TestCase):
             start_datetime=mock.ANY,
             end_datetime=mock.ANY,
             deltas=mock.ANY,
-            lab_spacing=mock.ANY,
         )
 
     @patch(f"{MOCK_MODULE}.send_email_report")


### PR DESCRIPTION
Readjusts the email formatting so that the larger number sections have a right-aligned text.

## Changes
- Turned left-aligned text in metrics email's sections "COVERAGE" and "TEST LAB ACTIVITY" into right-aligned text;
- Adjusted spacing for some columns;
- Changed double space before change percentage into a single space (that's `123  (+99%)` into `123 (+99%)`);
- Removed percentage sign if the metric diff is 0. This was done because many labs don't have tests, so the `(+0%)` can clutter the change column.
- Used dynamic spacing on Coverage and Test Labs Activity in order to avoid large empty spaces on all-small numbers and also avoid lack of space for larger-than-usual numbers

## How to test
- Have data in the database, I used `/backend/tests_submissions/submissions.zip` for testing
- Run `poetry run python3 manage.py notifications --action metrics_summary` and compare with the older version

## Visual Reference
Example of new format:

```
KernelCI Metrics Summary
========================
Period: 2026-06-13 17:33 UTC to 2026-06-20 17:33 UTC


  COVERAGE
  --------
                   This week  Last week   Change
                   ─────────  ─────────  ───────
  Trees monitored          4          0       +4
  Checkouts               32          0      +32
  Builds                 103          0     +103
  Tests               15,720          0  +15,720


  BUILD REGRESSIONS
  -----------------
  A "regression" is defined as a reported problem affecting 0 or multiple builds.

  Origin    Regressions       Affected           Affected builds by top issues
            (known + new)     Builds (total)     #1      #2      #3
  ─────────────────────────────────────────────────────────────────────────
  maestro   0   + 1   = 1     1                  1       
  ─────────────────────────────────────────────────────────────────────────
  Total     0   + 1   = 1     1


  TOP REGRESSIONS PER ORIGIN
  --------------------------
  maestro:
    #1 (1 occurrences) -  in vmlinux (Makefile:1220) [logspec:kbuild,kbuild.other]
      Dashboard: https://d.kernelci.org/issue/maestro:5dd754a8374e1b44291f37f6a3510603dcbc6348?iv=1
  

  TEST LABS ACTIVITY
  ------------------
  13 labs reported results this week (13 more than last week).

  Labs marked with an asterisk (*) are new.

  Lab                    Covered builds   Boots    Tests   Change (tests)
  ───────────────────────────────────────────────────────────────────────
  lava-baylibre *                     1       1        0                0
  lava-broonie *                     41       8    3,467           +3,467
  lava-cip *                          1       1        0                0
  lava-clabbe *                       3       3        0                0
  lava-collabora *                   82      29    1,805           +1,805
  lava-foundriesio *                  2       2        0                0
  lava-kci-qualcomm *                 1       0        1               +1
  lava-pengutronix *                  3       3        0                0
  linaro *                          174     229   10,119          +10,119
  maestro *                           1       0        2               +2
  microsoft *                         1       0        3               +3
  opentest-ti *                       2       2        0                0
  redhat *                            1       0       45              +45
  ───────────────────────────────────────────────────────────────────────
  Total                             313     278   15,442          +15,442

--
This is an experimental report format. Please send feedback in!
Talk to us at kernelci@lists.linux.dev

Made with love by the KernelCI team - https://kernelci.org
```

Closes #1938