### PR TITLE
feat/prune age

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Run integration tests with coverage
         run: |
-          TEST_BASE_URL=http://localhost:8001 poetry run pytest -m "integration" --use-local-db --run-all --cov=kernelCI_app --cov=kernelCI_cache --cov-report=term-missing
+          DB_HOST=127.0.0.1 DB_PORT=5435 TEST_BASE_URL=http://localhost:8001 DJANGO_SETTINGS_MODULE=kernelCI.test_settings poetry run pytest -m "integration" --use-local-db --run-all --cov=kernelCI_app --cov=kernelCI_cache --cov-report=term-missing
           cp .coverage coverage-integration.sqlite
         working-directory: ./backend
 

--- a/backend/docs/prune_db command.md
+++ b/backend/docs/prune_db command.md
@@ -16,7 +16,7 @@ Models use `DO_NOTHING` foreign keys, so the command applies manual cascade rule
 ### Optional Parameters
 
 - `--tables`: Limit pruning to specific tables (comma-separated). Valid options: `checkouts`, `builds`, `tests`. Default: all three.
-  - Cascade still applies inside the selected tables: a build matched because its checkout is old is deleted when `builds` is selected, and a test matched because its build is doomed is deleted when `tests` is selected.
+  - Cascade only drags a child when the child's parent table is also selected. For example, `--tables tests` removes only tests past the cutoff; recent tests under an old build/checkout are kept because those parents are not being pruned. With `--tables builds,tests`, an old build still drags its recent tests, but an old checkout does not drag its recent builds (checkouts are not selected).
   - Tables not listed are not deleted. For example, `--tables builds` removes old builds but leaves their tests in place. Selecting a parent without its children (e.g. only `checkouts`) can therefore leave orphaned rows.
 - `--origins`: Limit age-based pruning to specific origins (comma-separated). If omitted, any origin is considered.
   - Cascade ignores origin: once a parent row is doomed, its children are removed even if they belong to a different origin.

--- a/backend/docs/prune_db command.md
+++ b/backend/docs/prune_db command.md
@@ -1,0 +1,82 @@
+# prune_db Command Documentation
+
+The `prune_db` command deletes old rows from `checkouts`, `builds`, and `tests` in the dashboard database. It is intended for routine retention: run with `--dry-run` first, review the counts, then execute without `--dry-run`.
+
+Models use `DO_NOTHING` foreign keys, so the command applies manual cascade rules instead of relying on the database:
+
+- An old checkout also removes its builds and tests, even when those children are newer than the cutoff.
+- An old build also removes its tests, even when they are newer than the cutoff.
+
+## Parameters
+
+### Required Parameters
+
+- `--older-than`: Delete rows older than this age. Format: `'x days'`, `'x hours'`, or `'x minutes'` (for example, `'30 days'`).
+
+### Optional Parameters
+
+- `--tables`: Limit pruning to specific tables (comma-separated). Valid options: `checkouts`, `builds`, `tests`. Default: all three.
+  - Cascade still applies inside the selected tables: a build matched because its checkout is old is deleted when `builds` is selected, and a test matched because its build is doomed is deleted when `tests` is selected.
+  - Tables not listed are not deleted. For example, `--tables builds` removes old builds but leaves their tests in place. Selecting a parent without its children (e.g. only `checkouts`) can therefore leave orphaned rows.
+- `--origins`: Limit age-based pruning to specific origins (comma-separated). If omitted, any origin is considered.
+  - Cascade ignores origin: once a parent row is doomed, its children are removed even if they belong to a different origin.
+- `--batch-size`: Number of rows deleted per batch (default: `10000`). Must be at least `1`.
+- `--skip-issue-protection`: Prune builds and tests linked to issues. By default, rows with an associated incident are kept.
+- `--dry-run`: Print counts without deleting anything.
+- `--yes`: Skip the confirmation prompt and delete immediately.
+
+## Examples
+
+### Preview what would be deleted
+
+```bash
+python manage.py prune_db --older-than "30 days" --dry-run
+```
+
+### Delete rows older than 90 days
+
+```bash
+python manage.py prune_db --older-than "90 days" --yes
+```
+
+### Prune only one origin
+
+```bash
+python manage.py prune_db --older-than "30 days" --origins maestro,0dayci --dry-run
+```
+
+### Prune only tests
+
+```bash
+python manage.py prune_db --older-than "30 days" --tables tests --yes
+```
+
+### Prune rows linked to issues (override default protection)
+
+```bash
+python manage.py prune_db --older-than "30 days" --skip-issue-protection --yes
+```
+
+## What Is Not Deleted
+
+The command only touches `checkouts`, `builds`, and `tests`. Related tables are left as-is, including:
+
+- `incidents` rows themselves (only used to decide which builds/tests/checkouts to keep)
+- `hardware_status`, `latest_checkout`, `tree_tests_rollup` (reference checkouts)
+- `pending_build`, `pending_test` (reference builds)
+
+If those tables must stay consistent, plan separate cleanup or accept stale references until another process removes them.
+
+## Recommended Workflow
+
+1. Run with `--dry-run` and review per-table counts.
+2. Add `--origins` when retention should apply to specific origins only.
+3. Use `--tables` only when you intentionally want a partial prune.
+4. Run without `--dry-run`; confirm at the prompt unless `--yes` is set.
+
+## Notes
+
+- Deletion is batched and child-first (`tests`, then `builds`, then `checkouts`) to avoid orphans within the pruned set.
+- Each batch commits separately to keep locks short.
+- `--origins` scopes the age filter only. Cascade deletions do not re-check the child's origin.
+- By default, builds and tests referenced by `incidents` are not pruned, and their parent checkouts are kept too. Use `--skip-issue-protection` to delete them anyway (incident rows are not removed by this command).

--- a/backend/kernelCI_app/management/commands/helpers/intervals.py
+++ b/backend/kernelCI_app/management/commands/helpers/intervals.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+
+
+def parse_interval(interval_str: str) -> datetime:
+    """Turns an 'x days'/'x hours'/'x minutes' interval into an absolute
+    timestamp relative to now (now - interval)."""
+    parts = interval_str.split()
+    if len(parts) != 2:
+        raise ValueError(f"Invalid interval format: {interval_str}")
+
+    value, unit = parts
+    value = int(value)
+
+    if unit.lower() in ["minute", "minutes"]:
+        delta = timedelta(minutes=value)
+    elif unit.lower() in ["hour", "hours"]:
+        delta = timedelta(hours=value)
+    elif unit.lower() in ["day", "days"]:
+        delta = timedelta(days=value)
+    else:
+        raise ValueError(f"Unsupported time unit: {unit}")
+
+    return timezone.now() - delta

--- a/backend/kernelCI_app/management/commands/prune_db.py
+++ b/backend/kernelCI_app/management/commands/prune_db.py
@@ -1,0 +1,220 @@
+"""
+Management command to prune old builds, tests and checkouts.
+
+Removes checkouts, builds and tests older than a given age. To keep referential
+integrity, deletion cascades manually (models use DO_NOTHING): a removed
+checkout drags its builds, and a removed build drags its tests, even when those
+children are newer than the cutoff.
+
+Rows linked to an incident (an issue) are kept by default, together with their
+ancestors so nothing is orphaned; pass --skip-issue-protection to prune them too.
+
+Only checkouts, builds and tests are touched. Aggregate and derived tables (e.g.
+tree_tests_rollup, hardware_status, latest_checkout) are left untouched and must
+be cleaned up separately.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connections
+
+from kernelCI_app.management.commands.helpers.intervals import parse_interval
+
+PRUNABLE_TABLES = ("checkouts", "builds", "tests")
+
+
+class Command(BaseCommand):
+    help = "Prune checkouts, builds and tests older than a given age"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--older-than",
+            type=str,
+            required=True,
+            help="Delete rows older than this age ('x days' or 'x hours' format, "
+            "e.g. '30 days')",
+        )
+        parser.add_argument(
+            "--origins",
+            type=lambda s: [origin.strip() for origin in s.split(",")],
+            default=[],
+            help="Limit age-based pruning to specific origins (comma-separated). "
+            "Children of pruned parents are removed regardless of origin. "
+            "If not provided, any origin is considered.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be deleted without actually deleting",
+        )
+        parser.add_argument(
+            "--yes",
+            action="store_true",
+            help="Skip the confirmation prompt and delete right away",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=10000,
+            help="Number of rows to delete per batch (default: 10000)",
+        )
+        parser.add_argument(
+            "--tables",
+            type=lambda s: [t.strip() for t in s.split(",")],
+            default=list(PRUNABLE_TABLES),
+            help="Limit pruning to specific tables (comma-separated: "
+            f"{', '.join(PRUNABLE_TABLES)}). Only the listed tables are deleted; "
+            "unlisted child tables are left untouched, so selecting a parent without "
+            "its children (e.g. only 'checkouts') can leave orphans. Default: all.",
+        )
+        parser.add_argument(
+            "--skip-issue-protection",
+            action="store_true",
+            help="Prune builds and tests linked to issues (default: keep rows with "
+            "an associated incident)",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            cutoff = parse_interval(options["older_than"])
+        except ValueError as e:
+            raise CommandError(str(e)) from e
+
+        if options["batch_size"] < 1:
+            raise CommandError(
+                f"--batch-size must be at least 1 (got {options['batch_size']}). "
+                "It sets how many rows are deleted per batch, so it needs to be a "
+                "positive number."
+            )
+
+        unknown_tables = [t for t in options["tables"] if t not in PRUNABLE_TABLES]
+        if unknown_tables:
+            raise CommandError(
+                f"Unknown table(s): {', '.join(unknown_tables)}. "
+                f"Valid options are: {', '.join(PRUNABLE_TABLES)}."
+            )
+        selected_tables = [t for t in PRUNABLE_TABLES if t in options["tables"]]
+        protect_incidents = not options["skip_issue_protection"]
+
+        dry_run = options["dry_run"]
+        origins = options["origins"]
+
+        params = {"cutoff": cutoff, "batch_size": options["batch_size"]}
+        origins_condition = ""
+        if origins:
+            params["origins"] = list(origins)
+            origins_condition = "AND origin = ANY(%(origins)s)"
+
+        where_clauses = self._build_where_clauses(origins_condition, protect_incidents)
+
+        with connections["default"].cursor() as cursor:
+            counts = {
+                t: self._count(cursor, t, where_clauses[t], params)
+                for t in selected_tables
+            }
+            total = sum(counts.values())
+
+            lines = [f"Rows older than {cutoff.isoformat()}:"]
+            lines += [f"* {t}:\t{counts[t]:>8}" for t in selected_tables]
+            lines += ["----------------------", f"* total:\t{total:>8}"]
+            lines.append("Note: counts include children cascaded from pruned parents.")
+            if protect_incidents:
+                lines.append("Note: rows linked to an incident are kept.")
+            self.stdout.write("\n".join(lines))
+
+            if total == 0:
+                self.stdout.write(self.style.SUCCESS("Nothing to prune."))
+                return
+
+            if dry_run:
+                self.stdout.write(
+                    self.style.WARNING(
+                        "[DRY RUN] No rows deleted. Run without --dry-run to execute."
+                    )
+                )
+                return
+
+            if not options["yes"]:
+                summary = ", ".join(f"{counts[t]} {t}" for t in selected_tables)
+                try:
+                    answer = (
+                        input(f"Delete {summary} ({total} rows total)? [y/N] ")
+                        .strip()
+                        .lower()
+                    )
+                except EOFError:
+                    answer = ""
+                if answer not in ("y", "yes"):
+                    self.stdout.write("Aborted.")
+                    return
+
+            # Delete child-first (reverse of PRUNABLE_TABLES order): each batch commits
+            # on its own, so a crash mid-run leaves children already gone before their
+            # parents, never the reverse. Reordering this would risk orphans.
+            deleted = 0
+            for table in reversed(selected_tables):
+                deleted += self._batch_delete(
+                    cursor, table, where_clauses[table], params
+                )
+
+        self.stdout.write(self.style.SUCCESS(f"Successfully pruned {deleted} rows."))
+
+    def _build_where_clauses(self, origins_condition, protect_incidents):
+        """Build the per-table WHERE clauses, chaining the cascade so each child
+        matches when its parent is doomed, and appending incident protection when
+        enabled."""
+        age = f"_timestamp < %(cutoff)s {origins_condition}"
+
+        # A row tied to an incident is protected, along with the ancestors that would
+        # otherwise be orphaned: a build is protected when it (or one of its tests) has
+        # an incident, and a checkout when one of its builds is protected.
+        incident_tests = "SELECT test_id FROM incidents WHERE test_id IS NOT NULL"
+        incident_builds = (
+            "SELECT build_id FROM incidents WHERE build_id IS NOT NULL "
+            f"UNION SELECT build_id FROM tests WHERE id IN ({incident_tests})"
+        )
+        exclusion = (
+            {
+                "tests": f" AND id NOT IN ({incident_tests})",
+                "builds": f" AND id NOT IN ({incident_builds})",
+                "checkouts": (
+                    " AND id NOT IN "
+                    f"(SELECT checkout_id FROM builds WHERE id IN ({incident_builds}))"
+                ),
+            }
+            if protect_incidents
+            else {}
+        )
+
+        checkout_where = age + exclusion.get("checkouts", "")
+        build_where = (
+            f"(({age}) OR checkout_id IN (SELECT id FROM checkouts WHERE {checkout_where}))"
+            + exclusion.get("builds", "")
+        )
+        test_where = (
+            f"(({age}) OR build_id IN (SELECT id FROM builds WHERE {build_where}))"
+            + exclusion.get("tests", "")
+        )
+        return {
+            "checkouts": checkout_where,
+            "builds": build_where,
+            "tests": test_where,
+        }
+
+    def _count(self, cursor, table, where, params):
+        cursor.execute(f"SELECT COUNT(*) FROM {table} WHERE {where}", params)
+        return cursor.fetchone()[0]
+
+    def _batch_delete(self, cursor, table, where, params):
+        delete_sql = (
+            f"DELETE FROM {table} WHERE id IN "
+            f"(SELECT id FROM {table} WHERE {where} LIMIT %(batch_size)s)"
+        )
+        deleted_total = 0
+        while True:
+            cursor.execute(delete_sql, params)
+            deleted = cursor.rowcount
+            if deleted == 0:
+                break
+            deleted_total += deleted
+            self.stdout.write(f"Deleted {table}(n={deleted}) total={deleted_total}")
+        return deleted_total

--- a/backend/kernelCI_app/management/commands/prune_db.py
+++ b/backend/kernelCI_app/management/commands/prune_db.py
@@ -98,70 +98,91 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         origins = options["origins"]
 
-        params = {"cutoff": cutoff, "batch_size": options["batch_size"]}
+        params = {"cutoff": cutoff}
         origins_condition = ""
         if origins:
-            params["origins"] = list(origins)
+            params["origins"] = origins
             origins_condition = "AND origin = ANY(%(origins)s)"
 
-        where_clauses = self._build_where_clauses(origins_condition, protect_incidents)
+        where_clauses = self._build_where_clauses(
+            origins_condition, protect_incidents, selected_tables
+        )
+        temp_tables = {t: f"prune_{t}" for t in selected_tables}
 
         with connections["default"].cursor() as cursor:
-            counts = {
-                t: self._count(cursor, t, where_clauses[t], params)
-                for t in selected_tables
-            }
-            total = sum(counts.values())
-
-            lines = [f"Rows older than {cutoff.isoformat()}:"]
-            lines += [f"* {t}:\t{counts[t]:>8}" for t in selected_tables]
-            lines += ["----------------------", f"* total:\t{total:>8}"]
-            lines.append("Note: counts include children cascaded from pruned parents.")
-            if protect_incidents:
-                lines.append("Note: rows linked to an incident are kept.")
-            self.stdout.write("\n".join(lines))
-
-            if total == 0:
-                self.stdout.write(self.style.SUCCESS("Nothing to prune."))
-                return
-
-            if dry_run:
-                self.stdout.write(
-                    self.style.WARNING(
-                        "[DRY RUN] No rows deleted. Run without --dry-run to execute."
+            try:
+                # Snapshot ids while parents still exist, so child predicates can
+                # resolve them. Do all tables before deleting anything.
+                for table in selected_tables:
+                    self._materialize(
+                        cursor, table, temp_tables[table], where_clauses[table], params
                     )
+
+                counts = {
+                    t: self._count(cursor, temp_tables[t]) for t in selected_tables
+                }
+                total = sum(counts.values())
+
+                lines = [f"Rows older than {cutoff.isoformat()}:"]
+                lines += [f"* {t}:\t{counts[t]:>8}" for t in selected_tables]
+                lines += ["----------------------", f"* total:\t{total:>8}"]
+                lines.append(
+                    "Note: counts include children cascaded from pruned parents."
                 )
-                return
+                if protect_incidents:
+                    lines.append("Note: rows linked to an incident are kept.")
+                self.stdout.write("\n".join(lines))
 
-            if not options["yes"]:
-                summary = ", ".join(f"{counts[t]} {t}" for t in selected_tables)
-                try:
-                    answer = (
-                        input(f"Delete {summary} ({total} rows total)? [y/N] ")
-                        .strip()
-                        .lower()
-                    )
-                except EOFError:
-                    answer = ""
-                if answer not in ("y", "yes"):
-                    self.stdout.write("Aborted.")
+                if total == 0:
+                    self.stdout.write(self.style.SUCCESS("Nothing to prune."))
                     return
 
-            # Delete child-first (reverse of PRUNABLE_TABLES order): each batch commits
-            # on its own, so a crash mid-run leaves children already gone before their
-            # parents, never the reverse. Reordering this would risk orphans.
-            deleted = 0
-            for table in reversed(selected_tables):
-                deleted += self._batch_delete(
-                    cursor, table, where_clauses[table], params
+                if dry_run:
+                    self.stdout.write(
+                        self.style.WARNING(
+                            "[DRY RUN] No rows deleted. Run without --dry-run to "
+                            "execute."
+                        )
+                    )
+                    return
+
+                if not options["yes"]:
+                    summary = ", ".join(f"{counts[t]} {t}" for t in selected_tables)
+                    try:
+                        answer = (
+                            input(f"Delete {summary} ({total} rows total)? [y/N] ")
+                            .strip()
+                            .lower()
+                        )
+                    except EOFError:
+                        answer = ""
+                    if answer not in ("y", "yes"):
+                        self.stdout.write("Aborted.")
+                        return
+
+                # Delete child-first (reverse of PRUNABLE_TABLES order): each batch
+                # commits on its own, so a crash mid-run leaves children already gone
+                # before their parents, never the reverse. Reordering this would risk
+                # orphans.
+                deleted = 0
+                for table in reversed(selected_tables):
+                    deleted += self._batch_delete(
+                        cursor, table, temp_tables[table], options["batch_size"]
+                    )
+
+                self.stdout.write(
+                    self.style.SUCCESS(f"Successfully pruned {deleted} rows.")
                 )
+            finally:
+                for temp_table in temp_tables.values():
+                    cursor.execute(f"DROP TABLE IF EXISTS {temp_table}")
 
-        self.stdout.write(self.style.SUCCESS(f"Successfully pruned {deleted} rows."))
-
-    def _build_where_clauses(self, origins_condition, protect_incidents):
+    def _build_where_clauses(
+        self, origins_condition, protect_incidents, selected_tables
+    ):
         """Build the per-table WHERE clauses, chaining the cascade so each child
-        matches when its parent is doomed, and appending incident protection when
-        enabled."""
+        matches when its selected parent is doomed, and appending incident protection
+        when enabled."""
         age = f"_timestamp < %(cutoff)s {origins_condition}"
 
         # A row tied to an incident is protected, along with the ancestors that would
@@ -186,32 +207,50 @@ class Command(BaseCommand):
         )
 
         checkout_where = age + exclusion.get("checkouts", "")
-        build_where = (
-            f"(({age}) OR checkout_id IN (SELECT id FROM checkouts WHERE {checkout_where}))"
-            + exclusion.get("builds", "")
-        )
-        test_where = (
-            f"(({age}) OR build_id IN (SELECT id FROM builds WHERE {build_where}))"
-            + exclusion.get("tests", "")
-        )
+
+        build_terms = [f"({age})"]
+        if "checkouts" in selected_tables:
+            build_terms.append(
+                f"checkout_id IN (SELECT id FROM checkouts WHERE {checkout_where})"
+            )
+        build_where = "(" + " OR ".join(build_terms) + ")" + exclusion.get("builds", "")
+
+        test_terms = [f"({age})"]
+        if "builds" in selected_tables:
+            test_terms.append(
+                f"build_id IN (SELECT id FROM builds WHERE {build_where})"
+            )
+        test_where = "(" + " OR ".join(test_terms) + ")" + exclusion.get("tests", "")
+
         return {
             "checkouts": checkout_where,
             "builds": build_where,
             "tests": test_where,
         }
 
-    def _count(self, cursor, table, where, params):
-        cursor.execute(f"SELECT COUNT(*) FROM {table} WHERE {where}", params)
+    def _materialize(self, cursor, table, temp_table, where, params):
+        """Snapshot the doomed ids into a temp table so the nested predicate runs
+        once instead of per batch."""
+        cursor.execute(f"DROP TABLE IF EXISTS {temp_table}")
+        cursor.execute(
+            f"CREATE TEMP TABLE {temp_table} AS SELECT id FROM {table} WHERE {where}",
+            params,
+        )
+
+    def _count(self, cursor, temp_table):
+        cursor.execute(f"SELECT COUNT(*) FROM {temp_table}")
         return cursor.fetchone()[0]
 
-    def _batch_delete(self, cursor, table, where, params):
-        delete_sql = (
-            f"DELETE FROM {table} WHERE id IN "
-            f"(SELECT id FROM {table} WHERE {where} LIMIT %(batch_size)s)"
+    def _batch_delete(self, cursor, table, temp_table, batch_size):
+        sql = (
+            f"WITH batch AS ("
+            f"DELETE FROM {temp_table} WHERE id IN "
+            f"(SELECT id FROM {temp_table} LIMIT %(batch_size)s) RETURNING id"
+            f") DELETE FROM {table} WHERE id IN (SELECT id FROM batch)"
         )
         deleted_total = 0
         while True:
-            cursor.execute(delete_sql, params)
+            cursor.execute(sql, {"batch_size": batch_size})
             deleted = cursor.rowcount
             if deleted == 0:
                 break

--- a/backend/kernelCI_app/management/commands/prune_db.py
+++ b/backend/kernelCI_app/management/commands/prune_db.py
@@ -19,6 +19,7 @@ from django.db import connections
 
 from kernelCI_app.management.commands.helpers.intervals import parse_interval
 
+# Strict parent-before-child order: a checkout owns builds, a build owns tests.
 PRUNABLE_TABLES = ("checkouts", "builds", "tests")
 
 
@@ -138,7 +139,7 @@ class Command(BaseCommand):
                     return
 
                 if dry_run:
-                    self.stdout.write(
+                    self.stderr.write(
                         self.style.WARNING(
                             "[DRY RUN] No rows deleted. Run without --dry-run to "
                             "execute."
@@ -147,13 +148,8 @@ class Command(BaseCommand):
                     return
 
                 if not options["yes"]:
-                    summary = ", ".join(f"{counts[t]} {t}" for t in selected_tables)
                     try:
-                        answer = (
-                            input(f"Delete {summary} ({total} rows total)? [y/N] ")
-                            .strip()
-                            .lower()
-                        )
+                        answer = input("Delete these rows? [y/N] ").strip().lower()
                     except EOFError:
                         answer = ""
                     if answer not in ("y", "yes"):
@@ -175,7 +171,7 @@ class Command(BaseCommand):
                 )
             finally:
                 for temp_table in temp_tables.values():
-                    cursor.execute(f"DROP TABLE IF EXISTS {temp_table}")
+                    cursor.execute(f'DROP TABLE IF EXISTS "{temp_table}"')
 
     def _build_where_clauses(
         self, origins_condition, protect_incidents, selected_tables
@@ -231,22 +227,23 @@ class Command(BaseCommand):
     def _materialize(self, cursor, table, temp_table, where, params):
         """Snapshot the doomed ids into a temp table so the nested predicate runs
         once instead of per batch."""
-        cursor.execute(f"DROP TABLE IF EXISTS {temp_table}")
+        cursor.execute(f'DROP TABLE IF EXISTS "{temp_table}"')
         cursor.execute(
-            f"CREATE TEMP TABLE {temp_table} AS SELECT id FROM {table} WHERE {where}",
+            f'CREATE TEMP TABLE "{temp_table}" AS '
+            f'SELECT id FROM "{table}" WHERE {where}',
             params,
         )
 
     def _count(self, cursor, temp_table):
-        cursor.execute(f"SELECT COUNT(*) FROM {temp_table}")
+        cursor.execute(f'SELECT COUNT(*) FROM "{temp_table}"')
         return cursor.fetchone()[0]
 
     def _batch_delete(self, cursor, table, temp_table, batch_size):
         sql = (
             f"WITH batch AS ("
-            f"DELETE FROM {temp_table} WHERE id IN "
-            f"(SELECT id FROM {temp_table} LIMIT %(batch_size)s) RETURNING id"
-            f") DELETE FROM {table} WHERE id IN (SELECT id FROM batch)"
+            f'DELETE FROM "{temp_table}" WHERE id IN '
+            f'(SELECT id FROM "{temp_table}" LIMIT %(batch_size)s) RETURNING id'
+            f') DELETE FROM "{table}" WHERE id IN (SELECT id FROM batch)'
         )
         deleted_total = 0
         while True:

--- a/backend/kernelCI_app/management/commands/update_db.py
+++ b/backend/kernelCI_app/management/commands/update_db.py
@@ -3,7 +3,7 @@ import csv
 import json
 import logging
 import tarfile
-from datetime import datetime, timedelta
+from datetime import datetime
 from io import IOBase, StringIO, TextIOWrapper
 from itertools import islice
 from pathlib import Path
@@ -12,9 +12,9 @@ from typing import Generator, Optional
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connections, models
-from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
+from kernelCI_app.management.commands.helpers.intervals import parse_interval
 from kernelCI_app.models import (
     Builds,
     Checkouts,
@@ -47,26 +47,6 @@ def parse_array(array_str) -> Optional[list[str]]:
         return array
     except (ValueError, SyntaxError):
         return None
-
-
-def parse_interval(interval_str: str) -> datetime:
-    parts = interval_str.split()
-    if len(parts) != 2:
-        raise ValueError(f"Invalid interval format: {interval_str}")
-
-    value, unit = parts
-    value = int(value)
-
-    if unit.lower() in ["minute", "minutes"]:
-        delta = timedelta(minutes=value)
-    elif unit.lower() in ["hour", "hours"]:
-        delta = timedelta(hours=value)
-    elif unit.lower() in ["day", "days"]:
-        delta = timedelta(days=value)
-    else:
-        raise ValueError(f"Unsupported time unit: {unit}")
-
-    return timezone.now() - delta
 
 
 def to_human_readable(num_bytes: int) -> str:

--- a/backend/kernelCI_app/tests/integrationTests/prune_db_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/prune_db_test.py
@@ -1,0 +1,210 @@
+"""Integration tests for the prune_db management command."""
+
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils import timezone
+
+from kernelCI_app.models import Builds, Checkouts, Tests
+from kernelCI_app.tests.factories import (
+    BuildFactory,
+    CheckoutFactory,
+    IncidentFactory,
+    TestFactory,
+)
+
+
+def _days_ago(days: int):
+    return timezone.now() - timezone.timedelta(days=days)
+
+
+def _prune(**kwargs) -> str:
+    out = StringIO()
+    call_command("prune_db", older_than="10 days", stdout=out, **kwargs)
+    return out.getvalue()
+
+
+@pytest.mark.django_db
+def test_old_checkout_cascades():
+    """An old checkout drags its builds and tests even when they are newer."""
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30))
+    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(1))
+    test = TestFactory(build=build, field_timestamp=_days_ago(1))
+
+    _prune(yes=True)
+
+    assert not Checkouts.objects.filter(id=checkout.id).exists()
+    assert not Builds.objects.filter(id=build.id).exists()
+    assert not Tests.objects.filter(id=test.id).exists()
+
+
+@pytest.mark.django_db
+def test_old_build_cascades():
+    """An old build drags its newer tests; its recent checkout survives."""
+    checkout = CheckoutFactory(field_timestamp=_days_ago(1))
+    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    test = TestFactory(build=build, field_timestamp=_days_ago(1))
+
+    _prune(yes=True)
+
+    assert Checkouts.objects.filter(id=checkout.id).exists()
+    assert not Builds.objects.filter(id=build.id).exists()
+    assert not Tests.objects.filter(id=test.id).exists()
+
+
+@pytest.mark.django_db
+def test_remove_old_only():
+    """Recent rows survive; an old test is removed while its recent build/checkout stay."""
+    checkout = CheckoutFactory(field_timestamp=_days_ago(1))
+    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(1))
+    recent_test = TestFactory(build=build, field_timestamp=_days_ago(1))
+    old_test = TestFactory(build=build, field_timestamp=_days_ago(30))
+
+    _prune(yes=True)
+
+    assert Checkouts.objects.filter(id=checkout.id).exists()
+    assert Builds.objects.filter(id=build.id).exists()
+    assert Tests.objects.filter(id=recent_test.id).exists()
+    assert not Tests.objects.filter(id=old_test.id).exists()
+
+
+@pytest.mark.django_db
+def test_dry_run_no_deletion():
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30))
+    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    test = TestFactory(build=build, field_timestamp=_days_ago(30))
+
+    output = _prune(dry_run=True)
+
+    assert "DRY RUN" in output
+    for label in ("checkouts", "builds", "tests", "total"):
+        assert label in output
+    assert Checkouts.objects.filter(id=checkout.id).exists()
+    assert Builds.objects.filter(id=build.id).exists()
+    assert Tests.objects.filter(id=test.id).exists()
+
+
+@pytest.mark.django_db
+def test_origins_limit_age_prune():
+    """--origins limits age-based pruning; rows from other origins are kept."""
+    kept_checkout = CheckoutFactory(field_timestamp=_days_ago(30), origin="keep-me")
+    kept_build = BuildFactory(
+        checkout=kept_checkout, field_timestamp=_days_ago(30), origin="keep-me"
+    )
+    pruned_checkout = CheckoutFactory(field_timestamp=_days_ago(30), origin="prune-me")
+    pruned_build = BuildFactory(
+        checkout=pruned_checkout, field_timestamp=_days_ago(30), origin="prune-me"
+    )
+
+    _prune(yes=True, origins=["prune-me"])
+
+    assert Checkouts.objects.filter(id=kept_checkout.id).exists()
+    assert Builds.objects.filter(id=kept_build.id).exists()
+    assert not Checkouts.objects.filter(id=pruned_checkout.id).exists()
+    assert not Builds.objects.filter(id=pruned_build.id).exists()
+
+
+@pytest.mark.django_db
+def test_origins_cascade_ignores_child_origin():
+    """Children of a pruned parent are removed even when their origin differs."""
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30), origin="parent-origin")
+    build = BuildFactory(
+        checkout=checkout,
+        field_timestamp=_days_ago(1),
+        origin="child-origin",
+    )
+    test = TestFactory(
+        build=build,
+        field_timestamp=_days_ago(1),
+        origin="child-origin",
+    )
+
+    _prune(yes=True, origins=["parent-origin"])
+
+    assert not Checkouts.objects.filter(id=checkout.id).exists()
+    assert not Builds.objects.filter(id=build.id).exists()
+    assert not Tests.objects.filter(id=test.id).exists()
+
+
+@pytest.mark.django_db
+def test_tables_tests_only():
+    """--tables limits deletion to the selected table."""
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30))
+    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    test = TestFactory(build=build, field_timestamp=_days_ago(30))
+
+    _prune(yes=True, tables=["tests"])
+
+    assert Checkouts.objects.filter(id=checkout.id).exists()
+    assert Builds.objects.filter(id=build.id).exists()
+    assert not Tests.objects.filter(id=test.id).exists()
+
+
+@pytest.mark.django_db
+def test_tables_builds_only():
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30))
+    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    test = TestFactory(build=build, field_timestamp=_days_ago(30))
+
+    _prune(yes=True, tables=["builds"])
+
+    assert Checkouts.objects.filter(id=checkout.id).exists()
+    assert not Builds.objects.filter(id=build.id).exists()
+    assert Tests.objects.filter(id=test.id).exists()
+
+
+@pytest.mark.django_db
+def test_invalid_table():
+    with pytest.raises(CommandError, match="Unknown table"):
+        _prune(yes=True, tables=["incidents"])
+
+
+@pytest.mark.django_db
+def test_incident_linked_rows_kept_by_default():
+    """Builds and tests with incidents are kept unless --skip-issue-protection is set."""
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30))
+    kept_build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    kept_test = TestFactory(build=kept_build, field_timestamp=_days_ago(30))
+    IncidentFactory(build=kept_build, test=kept_test)
+
+    pruned_build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    pruned_test = TestFactory(build=pruned_build, field_timestamp=_days_ago(30))
+
+    _prune(yes=True)
+
+    assert Checkouts.objects.filter(id=checkout.id).exists()
+    assert Builds.objects.filter(id=kept_build.id).exists()
+    assert Tests.objects.filter(id=kept_test.id).exists()
+    assert not Builds.objects.filter(id=pruned_build.id).exists()
+    assert not Tests.objects.filter(id=pruned_test.id).exists()
+
+
+@pytest.mark.django_db
+def test_incident_on_test_protects_parent_build():
+    """A test tied to an incident keeps its parent build to avoid orphaning it."""
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30))
+    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    test = TestFactory(build=build, field_timestamp=_days_ago(30))
+    IncidentFactory(build=None, test=test)
+
+    _prune(yes=True)
+
+    assert Checkouts.objects.filter(id=checkout.id).exists()
+    assert Builds.objects.filter(id=build.id).exists()
+    assert Tests.objects.filter(id=test.id).exists()
+
+
+@pytest.mark.django_db
+def test_skip_issue_protection_deletes_linked_rows():
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30))
+    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    test = TestFactory(build=build, field_timestamp=_days_ago(30))
+    IncidentFactory(build=build, test=test)
+
+    _prune(yes=True, skip_issue_protection=True)
+
+    assert not Checkouts.objects.filter(id=checkout.id).exists()
+    assert not Builds.objects.filter(id=build.id).exists()
+    assert not Tests.objects.filter(id=test.id).exists()

--- a/backend/kernelCI_app/tests/integrationTests/prune_db_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/prune_db_test.py
@@ -130,29 +130,57 @@ def test_origins_cascade_ignores_child_origin():
 
 @pytest.mark.django_db
 def test_tables_tests_only():
-    """--tables limits deletion to the selected table."""
+    """--tables tests deletes only old tests; parents and a recent test under an old
+    build/checkout are kept because those parents are not being pruned."""
     checkout = CheckoutFactory(field_timestamp=_days_ago(30))
     build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
-    test = TestFactory(build=build, field_timestamp=_days_ago(30))
+    old_test = TestFactory(build=build, field_timestamp=_days_ago(30))
+    recent_test = TestFactory(build=build, field_timestamp=_days_ago(1))
 
     _prune(yes=True, tables=["tests"])
 
     assert Checkouts.objects.filter(id=checkout.id).exists()
     assert Builds.objects.filter(id=build.id).exists()
-    assert not Tests.objects.filter(id=test.id).exists()
+    assert not Tests.objects.filter(id=old_test.id).exists()
+    assert Tests.objects.filter(id=recent_test.id).exists()
 
 
 @pytest.mark.django_db
 def test_tables_builds_only():
+    """--tables builds deletes only old builds; a recent build survives, the checkout is
+    untouched, and an unlisted child test is left in place (orphaned)."""
     checkout = CheckoutFactory(field_timestamp=_days_ago(30))
-    build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
-    test = TestFactory(build=build, field_timestamp=_days_ago(30))
+    old_build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    orphaned_test = TestFactory(build=old_build, field_timestamp=_days_ago(30))
+    recent_build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(1))
 
     _prune(yes=True, tables=["builds"])
 
     assert Checkouts.objects.filter(id=checkout.id).exists()
-    assert not Builds.objects.filter(id=build.id).exists()
-    assert Tests.objects.filter(id=test.id).exists()
+    assert not Builds.objects.filter(id=old_build.id).exists()
+    assert Builds.objects.filter(id=recent_build.id).exists()
+    assert Tests.objects.filter(id=orphaned_test.id).exists()
+
+
+@pytest.mark.django_db
+def test_tables_builds_tests_cascade_within_selection():
+    """With builds and tests selected, an old build still drags its recent tests, but
+    an old checkout does not drag its recent builds (checkouts not selected)."""
+    checkout = CheckoutFactory(field_timestamp=_days_ago(30))
+    old_build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(30))
+    old_build_recent_test = TestFactory(build=old_build, field_timestamp=_days_ago(1))
+    recent_build = BuildFactory(checkout=checkout, field_timestamp=_days_ago(1))
+    recent_build_recent_test = TestFactory(
+        build=recent_build, field_timestamp=_days_ago(1)
+    )
+
+    _prune(yes=True, tables=["builds", "tests"])
+
+    assert Checkouts.objects.filter(id=checkout.id).exists()
+    assert not Builds.objects.filter(id=old_build.id).exists()
+    assert not Tests.objects.filter(id=old_build_recent_test.id).exists()
+    assert Builds.objects.filter(id=recent_build.id).exists()
+    assert Tests.objects.filter(id=recent_build_recent_test.id).exists()
 
 
 @pytest.mark.django_db

--- a/backend/kernelCI_app/tests/integrationTests/prune_db_test.py
+++ b/backend/kernelCI_app/tests/integrationTests/prune_db_test.py
@@ -22,8 +22,9 @@ def _days_ago(days: int):
 
 def _prune(**kwargs) -> str:
     out = StringIO()
-    call_command("prune_db", older_than="10 days", stdout=out, **kwargs)
-    return out.getvalue()
+    err = StringIO()
+    call_command("prune_db", older_than="10 days", stdout=out, stderr=err, **kwargs)
+    return out.getvalue() + err.getvalue()
 
 
 @pytest.mark.django_db

--- a/docs/IntegrationTests.md
+++ b/docs/IntegrationTests.md
@@ -258,7 +258,7 @@ docker compose -f docker-compose.test.yml up --build -d
 **Step 5: Run integration tests**
 ```bash
 cd backend
-TEST_BASE_URL=http://localhost:8001 poetry run pytest -m integration --use-local-db --run-all
+DB_HOST=127.0.0.1 DB_PORT=5435 TEST_BASE_URL=http://localhost:8001 DJANGO_SETTINGS_MODULE=kernelCI.test_settings poetry run pytest -m integration --use-local-db --run-all
 ```
 
 **Step 6: Clean up**
@@ -275,26 +275,45 @@ The test environment uses `backend/kernelCI/test_settings.py` which:
 - Configures local PostgreSQL database
 - Sets `TEST_BASE_URL=http://localhost:8001/`
 
+Most integration tests are HTTP black-box tests against the running `test_backend`
+container, but some (e.g. management-command tests) are DB-backed and use
+`@pytest.mark.django_db` with factories. Those connect to PostgreSQL directly from
+the host, so the run commands set `DB_HOST=127.0.0.1` and `DB_PORT=5435` to reach the
+`test_db` container (published on port `5435`) instead of the in-network `test_db:5432`
+default. The name/user/password come from `test_settings` defaults (`kcidb_test`/
+`test_user`/`test_password`), so they don't need to be passed. `pytest-django` then
+creates its own isolated `test_*` database, separate from the seeded one used by the
+HTTP tests.
+
+The commands also set `DJANGO_SETTINGS_MODULE=kernelCI.test_settings` explicitly. The
+`--use-local-db` flag alone is not enough: `pytest-django` reads the `DJANGO_SETTINGS_MODULE`
+ini option from `pyproject.toml` (`kernelCI.settings`) and configures Django before
+`conftest.py` can switch it. Under `kernelCI.settings` the `cache`/`notifications` DBs are
+file-based sqlite under `/volume_data`, which does not exist on the CI runner; the parallel
+(`-n 4`) test-DB setup then fails with "unable to open database file". `test_settings` uses
+in-memory sqlite instead, and the env var wins over the ini, so it forces the correct
+settings.
+
 ### Running Specific Tests
 
 **Run all integration tests:**
 ```bash
-TEST_BASE_URL=http://localhost:8001 poetry run pytest -m integration --use-local-db --run-all
+DB_HOST=127.0.0.1 DB_PORT=5435 TEST_BASE_URL=http://localhost:8001 DJANGO_SETTINGS_MODULE=kernelCI.test_settings poetry run pytest -m integration --use-local-db --run-all
 ```
 
 **Run only a subset of tests (faster):**
 ```bash
-TEST_BASE_URL=http://localhost:8001 poetry run pytest -m integration --use-local-db
+DB_HOST=127.0.0.1 DB_PORT=5435 TEST_BASE_URL=http://localhost:8001 DJANGO_SETTINGS_MODULE=kernelCI.test_settings poetry run pytest -m integration --use-local-db
 ```
 
 **Run specific test file:**
 ```bash
-TEST_BASE_URL=http://localhost:8001 poetry run pytest -m integration --use-local-db backend/kernelCI_app/tests/integrationTests/<your_test>.py
+DB_HOST=127.0.0.1 DB_PORT=5435 TEST_BASE_URL=http://localhost:8001 DJANGO_SETTINGS_MODULE=kernelCI.test_settings poetry run pytest -m integration --use-local-db backend/kernelCI_app/tests/integrationTests/<your_test>.py
 ```
 
 **Run specific method:**
 ```bash
-TEST_BASE_URL=http://localhost:8001 poetry run pytest -m integration --use-local-db backend/kernelCI_app/tests/integrationTests/<your_test>.py::<your_function>
+DB_HOST=127.0.0.1 DB_PORT=5435 TEST_BASE_URL=http://localhost:8001 DJANGO_SETTINGS_MODULE=kernelCI.test_settings poetry run pytest -m integration --use-local-db backend/kernelCI_app/tests/integrationTests/<your_test>.py::<your_function>
 ```
 
 ### Troubleshooting


### PR DESCRIPTION
## Summary

Add `prune_db`, a manual management command to delete old data and reclaim space.

* Deletes checkouts, builds and tests older than a given age (e.g. `--older-than "30 days"`).
* Manual cascade (models use `DO_NOTHING`): pruning a checkout removes its builds, pruning a build removes its tests — even when children are newer.
* `--origins` scopes the age filter; cascade stays origin-agnostic so no orphans are left.
* Batched deletes (`--batch-size`) that each commit on their own to keep locks short.
* `--dry-run` and a per-table confirmation prompt showing exactly how many rows will be affected (skip with `--yes`).
* Extracts `parse_interval` from `update_db` into a shared helper.

## Usage

```bash
python manage.py prune_db --older-than "30 days" --dry-run                                                                                                                                                         
python manage.py prune_db --older-than "30 days" --origins maestro                                                                                                                                          
```

## How to Test

  * In a local database create newly seeded data `poetry run python3 manage.py seed_data --clear --yes`
  * Run command `poetry run python3 manage.py prune_db --dry-run` with different arguments for older-than parameter.
  * Verify the number of selected rows matches the database.
  * Run command `poetry run python3 manage.py prune_db` with different arguments for older-than parameter.
  * Verify the rows are properly deleted.

