### PR TITLE
fix: Handle undefined histories in test details

### DIFF
--- a/dashboard/src/api/testDetails.ts
+++ b/dashboard/src/api/testDetails.ts
@@ -1,5 +1,5 @@
 import type { UseQueryResult } from '@tanstack/react-query';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type {
   TTestDetails,
@@ -9,6 +9,7 @@ import type {
 
 import type { TIssue } from '@/types/issues';
 import type { ApiUseQueryOptions } from '@/types/api';
+import { isBadRequestError, DEFAULT_QUERY_RETRY_COUNT } from '@/utils/query';
 
 import { RequestData } from './commonRequest';
 
@@ -64,9 +65,30 @@ const fetchTestStatusHistory = async (
 export const useTestStatusHistory = (
   params?: TestStatusHistoryParams,
 ): UseQueryResult<TestStatusHistory> => {
+  const queryClient = useQueryClient();
+
   return useQuery({
     queryKey: ['testStatusHistoryData', params],
     queryFn: () => fetchTestStatusHistory(params),
+    retry: (failureCount, error) => {
+      if (isBadRequestError(error)) {
+        return false;
+      }
+
+      const globalRetry =
+        queryClient.getDefaultOptions().queries?.retry ??
+        DEFAULT_QUERY_RETRY_COUNT;
+
+      if (typeof globalRetry === 'function') {
+        return globalRetry(failureCount, error);
+      }
+
+      if (typeof globalRetry === 'number') {
+        return failureCount < globalRetry;
+      }
+
+      return globalRetry;
+    },
     enabled: params !== undefined && Object.keys(params).length > 0,
   });
 };

--- a/dashboard/src/api/testDetails.ts
+++ b/dashboard/src/api/testDetails.ts
@@ -1,5 +1,5 @@
 import type { UseQueryResult } from '@tanstack/react-query';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import type {
   TTestDetails,
@@ -9,7 +9,6 @@ import type {
 
 import type { TIssue } from '@/types/issues';
 import type { ApiUseQueryOptions } from '@/types/api';
-import { isBadRequestError, DEFAULT_QUERY_RETRY_COUNT } from '@/utils/query';
 
 import { RequestData } from './commonRequest';
 
@@ -65,30 +64,9 @@ const fetchTestStatusHistory = async (
 export const useTestStatusHistory = (
   params?: TestStatusHistoryParams,
 ): UseQueryResult<TestStatusHistory> => {
-  const queryClient = useQueryClient();
-
   return useQuery({
     queryKey: ['testStatusHistoryData', params],
     queryFn: () => fetchTestStatusHistory(params),
-    retry: (failureCount, error) => {
-      if (isBadRequestError(error)) {
-        return false;
-      }
-
-      const globalRetry =
-        queryClient.getDefaultOptions().queries?.retry ??
-        DEFAULT_QUERY_RETRY_COUNT;
-
-      if (typeof globalRetry === 'function') {
-        return globalRetry(failureCount, error);
-      }
-
-      if (typeof globalRetry === 'number') {
-        return failureCount < globalRetry;
-      }
-
-      return globalRetry;
-    },
     enabled: params !== undefined && Object.keys(params).length > 0,
   });
 };

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -67,6 +67,7 @@ import { processLogData } from '@/hooks/useLogData';
 
 import { dateObjectToTimestampInSeconds, daysToSeconds } from '@/utils/date';
 import { REDUCED_TIME_SEARCH } from '@/utils/constants/general';
+import { isBadRequestError } from '@/utils/query';
 
 import { MemoizedKcidevFooter } from '@/components/Footer/KcidevFooter';
 
@@ -223,9 +224,8 @@ const TestDetailsSections = ({
   }, [statusHistory?.status_history, test.id]);
 
   const regressionSection: ISection | undefined = useMemo(() => {
-    if (statusHistoryStatus === 'error') {
-      return;
-    }
+    const cannotFetchHistory =
+      statusHistoryStatus === 'error' && isBadRequestError(statusHistoryError);
 
     const regressionTypeTooltip: string | null = ((): string | null => {
       switch (statusHistory?.regression_type) {
@@ -294,12 +294,18 @@ const TestDetailsSections = ({
                   status={statusHistoryStatus}
                   data={statusHistory}
                   customError={
-                    <MemoizedSectionError
-                      isLoading={statusHistoryStatus === 'pending'}
-                      errorMessage={statusHistoryError?.message}
-                      emptyLabel="global.error"
-                      variant="warning"
-                    />
+                    cannotFetchHistory ? (
+                      <div className="text-weak-gray flex flex-col items-center py-6 text-2xl font-semibold">
+                        <FormattedMessage id="testDetails.cannotFetchHistory" />
+                      </div>
+                    ) : (
+                      <MemoizedSectionError
+                        isLoading={statusHistoryStatus === 'pending'}
+                        errorMessage={statusHistoryError?.message}
+                        emptyLabel="global.error"
+                        variant="warning"
+                      />
+                    )
                   }
                 >
                   <div className="flex items-center">{regressionData}</div>
@@ -314,7 +320,7 @@ const TestDetailsSections = ({
     formatMessage,
     regressionData,
     statusHistory,
-    statusHistoryError?.message,
+    statusHistoryError,
     statusHistoryStatus,
   ]);
 

--- a/dashboard/src/components/TestDetails/TestDetails.tsx
+++ b/dashboard/src/components/TestDetails/TestDetails.tsx
@@ -223,9 +223,19 @@ const TestDetailsSections = ({
       });
   }, [statusHistory?.status_history, test.id]);
 
+  const hasRequiredTrackingFields = Boolean(
+    test.path &&
+      test.origin &&
+      test.git_repository_url &&
+      test.git_repository_branch &&
+      test.config_name,
+  );
+
   const regressionSection: ISection | undefined = useMemo(() => {
     const cannotFetchHistory =
-      statusHistoryStatus === 'error' && isBadRequestError(statusHistoryError);
+      !hasRequiredTrackingFields ||
+      (statusHistoryStatus === 'error' &&
+        isBadRequestError(statusHistoryError));
 
     const regressionTypeTooltip: string | null = ((): string | null => {
       switch (statusHistory?.regression_type) {
@@ -291,7 +301,9 @@ const TestDetailsSections = ({
               children: (
                 <QuerySwitcher
                   skeletonClassname="h-[100px]"
-                  status={statusHistoryStatus}
+                  status={
+                    hasRequiredTrackingFields ? statusHistoryStatus : 'error'
+                  }
                   data={statusHistory}
                   customError={
                     cannotFetchHistory ? (
@@ -318,6 +330,7 @@ const TestDetailsSections = ({
     };
   }, [
     formatMessage,
+    hasRequiredTrackingFields,
     regressionData,
     statusHistory,
     statusHistoryError,
@@ -531,27 +544,37 @@ const TestDetails = ({ breadcrumb }: TestsDetailsProps): JSX.Element => {
     status: issueStatus,
     error: issueError,
   } = useTestIssues(testId ?? '', data !== undefined);
+  const statusHistoryParams = useMemo(() => {
+    if (
+      !data?.path ||
+      !data.origin ||
+      !data.git_repository_url ||
+      !data.git_repository_branch ||
+      !data.config_name
+    ) {
+      return undefined;
+    }
+
+    return {
+      path: data.path,
+      origin: data.origin,
+      git_repository_url: data.git_repository_url,
+      git_repository_branch: data.git_repository_branch,
+      platform:
+        typeof data.environment_misc?.['platform'] === 'string'
+          ? data.environment_misc['platform']
+          : undefined,
+      current_test_start_time: data.start_time,
+      config_name: data.config_name,
+      field_timestamp: data.field_timestamp,
+    };
+  }, [data]);
+
   const {
     data: statusHistoryData,
     status: statusHistoryStatus,
     error: statusHistoryError,
-  } = useTestStatusHistory(
-    data !== undefined
-      ? {
-          path: data.path,
-          origin: data.origin,
-          git_repository_url: data.git_repository_url,
-          git_repository_branch: data.git_repository_branch,
-          platform:
-            typeof data.environment_misc?.['platform'] === 'string'
-              ? data.environment_misc['platform']
-              : undefined,
-          current_test_start_time: data.start_time,
-          config_name: data.config_name,
-          field_timestamp: data.field_timestamp,
-        }
-      : undefined,
-  );
+  } = useTestStatusHistory(statusHistoryParams);
 
   const logData = useMemo(() => {
     if (!data) {

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -336,6 +336,7 @@ export const messages = {
       'Inconclusive - test concluded with inconclusive results such as infrastructure errors.{br}{br}' +
       'Inconclusive groups tests with ERROR, MISS, SKIP, DONE, and unknown statuses defined by KCIDB.',
     'testDetails.buildInfo': 'Build Info',
+    'testDetails.cannotFetchHistory': 'No tracking information available',
     'testDetails.notFound': 'Test not found',
     'testDetails.regressionTooltip.fixed':
       'Test was failing but passed in the last iterations',

--- a/dashboard/src/utils/query.test.ts
+++ b/dashboard/src/utils/query.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { AxiosError, HttpStatusCode } from 'axios';
+
+import {
+  DEFAULT_QUERY_RETRY_COUNT,
+  isBadRequestError,
+  retryHandler,
+} from './query';
+
+const createAxiosError = (status: number): AxiosError => {
+  return new AxiosError(
+    'Request failed',
+    AxiosError.ERR_BAD_REQUEST,
+    undefined,
+    undefined,
+    {
+      status,
+      statusText: 'Error',
+      headers: {},
+      config: {} as never,
+      data: {},
+    },
+  );
+};
+
+describe('isBadRequestError', () => {
+  it('returns true for Axios 400 errors', () => {
+    expect(isBadRequestError(createAxiosError(HttpStatusCode.BadRequest))).toBe(
+      true,
+    );
+  });
+
+  it('returns false for Axios non-400 errors', () => {
+    expect(
+      isBadRequestError(createAxiosError(HttpStatusCode.InternalServerError)),
+    ).toBe(false);
+  });
+
+  it('returns false for plain Error and non-error values', () => {
+    expect(isBadRequestError(new Error('400:Bad request'))).toBe(false);
+    expect(isBadRequestError('400')).toBe(false);
+    expect(isBadRequestError(null)).toBe(false);
+  });
+});
+
+describe('retryHandler', () => {
+  it('defaults to DEFAULT_QUERY_RETRY_COUNT', () => {
+    const shouldRetry = retryHandler();
+    const error = new Error('500:Server error');
+
+    expect(shouldRetry(DEFAULT_QUERY_RETRY_COUNT - 1, error)).toBe(true);
+    expect(shouldRetry(DEFAULT_QUERY_RETRY_COUNT, error)).toBe(false);
+  });
+
+  it('does not retry on Axios 400 errors', () => {
+    const shouldRetry = retryHandler();
+    expect(shouldRetry(0, createAxiosError(HttpStatusCode.BadRequest))).toBe(
+      false,
+    );
+  });
+
+  it('still retries other Axios errors until the retry limit', () => {
+    const shouldRetry = retryHandler();
+    const error = createAxiosError(HttpStatusCode.InternalServerError);
+
+    expect(shouldRetry(0, error)).toBe(true);
+    expect(shouldRetry(DEFAULT_QUERY_RETRY_COUNT, error)).toBe(false);
+  });
+});

--- a/dashboard/src/utils/query.ts
+++ b/dashboard/src/utils/query.ts
@@ -1,3 +1,7 @@
+import { AxiosError, HttpStatusCode } from 'axios';
+
+export const DEFAULT_QUERY_RETRY_COUNT = 3;
+
 export const retryHandler = (retryCount: number | boolean = 3) => {
   return (failureCount: number, error: Error): boolean => {
     const splittedError = error.message.split(':');
@@ -18,4 +22,17 @@ export const retryHandler = (retryCount: number | boolean = 3) => {
     }
     return true;
   };
+};
+
+export const isBadRequestError = (error: unknown): boolean => {
+  if (error instanceof AxiosError) {
+    return error.response?.status === HttpStatusCode.BadRequest;
+  }
+
+  if (error instanceof Error) {
+    const statusCode = Number(error.message.split(':')[0]);
+    return statusCode === HttpStatusCode.BadRequest;
+  }
+
+  return false;
 };

--- a/dashboard/src/utils/query.ts
+++ b/dashboard/src/utils/query.ts
@@ -2,8 +2,21 @@ import { AxiosError, HttpStatusCode } from 'axios';
 
 export const DEFAULT_QUERY_RETRY_COUNT = 3;
 
-export const retryHandler = (retryCount: number | boolean = 3) => {
+export const isBadRequestError = (error: unknown): boolean => {
+  return (
+    error instanceof AxiosError &&
+    error.response?.status === HttpStatusCode.BadRequest
+  );
+};
+
+export const retryHandler = (
+  retryCount: number | boolean = DEFAULT_QUERY_RETRY_COUNT,
+) => {
   return (failureCount: number, error: Error): boolean => {
+    if (isBadRequestError(error)) {
+      return false;
+    }
+
     const splittedError = error.message.split(':');
     if (
       splittedError &&
@@ -22,17 +35,4 @@ export const retryHandler = (retryCount: number | boolean = 3) => {
     }
     return true;
   };
-};
-
-export const isBadRequestError = (error: unknown): boolean => {
-  if (error instanceof AxiosError) {
-    return error.response?.status === HttpStatusCode.BadRequest;
-  }
-
-  if (error instanceof Error) {
-    const statusCode = Number(error.message.split(':')[0]);
-    return statusCode === HttpStatusCode.BadRequest;
-  }
-
-  return false;
 };


### PR DESCRIPTION
## Summary

This PR fixes the dashboard behavior on `/test/<test_id>` for tests without a meaningful history.

Current behavior: Shows "Status History" as loading for a long while, hides on failure, and retries many times.

New behavior: Shows a message under "Status History" indicating that it is not available for this test

## Testing

Navigate to `test/<test_id>` and compare with production for tests with complete or missing data

Example: [test missing git_repository_url](https://dashboard.kernelci.org/test/broonie:0a40c6fbd105802fbbcaadca249e0948fbf8095a-sirena-2791999)

## Context

Tests in the same history must match (at least) on origin, tree, path, and build config for their comparison to be meaningful. Many tests do not have all of this information available (because of a missing build, checkout, or incomplete submission), so we can't track a meaningful history for them.

## Related Issues
- Closes #1167
- Related to #1976