### PR TITLE
fix/cache metrics

### DIFF
--- a/backend/kernelCI_app/cache.py
+++ b/backend/kernelCI_app/cache.py
@@ -1,3 +1,5 @@
+import json
+from hashlib import sha256
 from typing import Optional
 
 from django.conf import settings
@@ -13,11 +15,9 @@ _build_lookup = {}
 _test_lookup = {}
 
 
-def _create_cache_params_hash(params: dict):
-    params_list = list(params.items())
-    params_list.sort(key=lambda x: x[0])
-    params_string = ",".join([str(i[1]) for i in params_list])
-    return hash(params_string)
+def _create_cache_params_hash(params: dict) -> str:
+    params_string = json.dumps(params, sort_keys=True, default=str)
+    return sha256(params_string.encode("utf-8")).hexdigest()
 
 
 def set_query_cache(

--- a/backend/kernelCI_app/cache.py
+++ b/backend/kernelCI_app/cache.py
@@ -1,9 +1,10 @@
 import json
-from hashlib import sha256
 from typing import Optional
 
 from django.conf import settings
 from django.core.cache import cache
+
+from kernelCI_app.utils import stable_hash
 
 timeout = settings.CACHE_TIMEOUT
 DISCORD_NOTIFICATION_COOLDOWN = 600
@@ -17,7 +18,7 @@ _test_lookup = {}
 
 def _create_cache_params_hash(params: dict) -> str:
     params_string = json.dumps(params, sort_keys=True, default=str)
-    return sha256(params_string.encode("utf-8")).hexdigest()
+    return stable_hash(params_string)
 
 
 def set_query_cache(
@@ -51,13 +52,13 @@ def get_query_cache(key, params: Optional[dict] = None):
 
 
 def set_notification_cache(*, notification: str) -> None:
-    notification_hash = hash(notification)
+    notification_hash = stable_hash(notification)
     hash_key = f"{DISCORD_NOTIFICATION_KEY}-{notification_hash}"
     return cache.set(hash_key, notification, DISCORD_NOTIFICATION_COOLDOWN)
 
 
 def get_notification_cache(*, notification: str) -> str:
-    notification_hash = hash(notification)
+    notification_hash = stable_hash(notification)
     hash_key = f"{DISCORD_NOTIFICATION_KEY}-{notification_hash}"
     return cache.get(hash_key)
 

--- a/backend/kernelCI_app/tests/unitTests/utils_test.py
+++ b/backend/kernelCI_app/tests/unitTests/utils_test.py
@@ -19,6 +19,7 @@ from kernelCI_app.utils import (
     is_boot,
     read_yaml_file,
     sanitize_dict,
+    stable_hash,
     string_to_json,
     validate_str_to_dict,
 )
@@ -496,3 +497,18 @@ class TestReadYamlFile:
                 result = read_yaml_file(base_dir="/test", file="empty.yaml")
 
         assert result is None
+
+
+class TestStableHash:
+    def test_stable_hash_is_deterministic(self):
+        assert stable_hash("value") == stable_hash("value")
+
+    def test_stable_hash_distinct_inputs(self):
+        assert stable_hash("value1") != stable_hash("value2")
+
+    def test_stable_hash_known_vector(self):
+        """Fixed sha256 hex independent of PYTHONHASHSEED (guards #1971)."""
+        assert (
+            stable_hash("test notification")
+            == "2ecb59da1e4ffd4b18658e810f6c439b1fbe9cd8505eb116710404090d916222"
+        )

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 from datetime import timedelta
+from hashlib import sha256
 from typing import List, Optional, Union
 
 import yaml
@@ -78,6 +79,12 @@ def get_query_time_interval(**kwargs):
 
 def get_error_body_response(reason: str) -> bytes:
     return json.dumps({"error": True, "reason": reason}).encode("utf-8")
+
+
+def stable_hash(value: str) -> str:
+    """Deterministic hash, stable across processes unlike builtin hash()
+    which is seeded per process (PYTHONHASHSEED)."""
+    return sha256(value.encode("utf-8")).hexdigest()
 
 
 def string_to_json(string: str) -> Optional[dict]:


### PR DESCRIPTION
* Changes the redis hashing function to a sha256 stable hash.
* Creates a new `stable_hash` utility function to be used across project. Avoiding the standard python function that can have different hashing seeds and cause unstable hashing across processes.
* Include tests to guarantee invariability of the `stable_hash`.

## How to test

Inside the backend project folder, compare the behaviour of the standard hash function and compare with the stable hash function, which should show different values for hash.

```bash
python3 -c "print(hash('so long and thanks for all the fish'))"
python3 -c "print(hash('so long and thanks for all the fish'))"
```

And comparing with the stable function, we should be stable across different processes.

```bash
python3 -c "from kernelCI_app.utils import stable_hash; print(stable_hash('so long and thanks for all the fish'))"
python3 -c "from kernelCI_app.utils import stable_hash; print(stable_hash('so long and thanks for all the fish'))"
```
