### PR TITLE
reports: limit regzbot tags and lore link to upstream trees

### DIFF
--- a/backend/kernelCI_app/management/commands/helpers/common.py
+++ b/backend/kernelCI_app/management/commands/helpers/common.py
@@ -13,7 +13,7 @@ KERNELCI_RESULTS = "kernelci-results@groups.io"
 KERNELCI_REPLYTO = "kernelci@lists.linux.dev"
 REGRESSIONS_LIST = "regressions@lists.linux.dev"
 
-REGZBOT_TREES = {"mainline", "next"}
+REGZBOT_TREES = {"mainline", "next", "stable"}
 
 
 def is_regzbot_tree(tree_name) -> bool:

--- a/backend/kernelCI_app/management/commands/helpers/common.py
+++ b/backend/kernelCI_app/management/commands/helpers/common.py
@@ -13,6 +13,18 @@ KERNELCI_RESULTS = "kernelci-results@groups.io"
 KERNELCI_REPLYTO = "kernelci@lists.linux.dev"
 REGRESSIONS_LIST = "regressions@lists.linux.dev"
 
+REGZBOT_TREES = {"mainline", "next"}
+
+
+def is_regzbot_tree(tree_name) -> bool:
+    """Trees whose regression reports are tracked by regzbot.
+
+    Reports for these trees are CC'd to the regressions list, which is
+    archived on lore and followed by regzbot, so only they carry the
+    #regzbot tags and a lore link to their own Message-ID.
+    """
+    return tree_name in REGZBOT_TREES
+
 
 def setup_jinja_template(template_name: str) -> Template:
     """Gets the template file from management/commands/templates
@@ -145,7 +157,7 @@ def send_email_report(
     if (
         email_args.add_mailing_lists
         and email_args.regression_report
-        and (email_args.tree_name == "mainline" or email_args.tree_name == "next")
+        and is_regzbot_tree(email_args.tree_name)
     ):
         cc = ", ".join([REGRESSIONS_LIST, cc]) if cc else REGRESSIONS_LIST
 

--- a/backend/kernelCI_app/management/commands/notifications.py
+++ b/backend/kernelCI_app/management/commands/notifications.py
@@ -15,6 +15,7 @@ from kernelCI_app.helpers.logger import log_message
 from kernelCI_app.helpers.system import get_running_instance
 from kernelCI_app.helpers.trees import sanitize_tree
 from kernelCI_app.management.commands.helpers.common import (
+    is_regzbot_tree,
     send_email_report,
     setup_jinja_template,
 )
@@ -158,11 +159,13 @@ def ask_ignore_issue():
 
 def generate_build_issue_report(issue, incidents, message_id=None):
     template = setup_jinja_template("issue_build.txt.j2")
+    regzbot_tracked = is_regzbot_tree(issue["tree_name"])
     report = {}
     report["content"] = template.render(
         issue=issue,
         builds=incidents,
-        message_id=message_id.strip("<>") if message_id else None,
+        regzbot_tracked=regzbot_tracked,
+        message_id=message_id.strip("<>") if message_id and regzbot_tracked else None,
     )
     snippet = (
         issue["comment"]
@@ -177,11 +180,13 @@ def generate_build_issue_report(issue, incidents, message_id=None):
 
 def generate_boot_issue_report(issue, incidents, message_id=None):
     template = setup_jinja_template("issue_boot.txt.j2")
+    regzbot_tracked = is_regzbot_tree(issue["tree_name"])
     report = {}
     report["content"] = template.render(
         issue=issue,
         boots=incidents,
-        message_id=message_id.strip("<>") if message_id else None,
+        regzbot_tracked=regzbot_tracked,
+        message_id=message_id.strip("<>") if message_id and regzbot_tracked else None,
     )
     snippet = (
         issue["comment"]
@@ -616,7 +621,12 @@ def generate_test_report(*, service, test_id, email_args, signup_folder):
     message_id = make_msgid(domain="kernelci.org")
 
     template = setup_jinja_template("test_report.txt.j2")
-    report_content = template.render(test=test, message_id=message_id.strip("<>"))
+    regzbot_tracked = is_regzbot_tree(test.get("tree_name"))
+    report_content = template.render(
+        test=test,
+        regzbot_tracked=regzbot_tracked,
+        message_id=message_id.strip("<>") if regzbot_tracked else None,
+    )
 
     if is_boot(path=test["path"]):
         subject_prefix = "[BOOT REGRESSION]"

--- a/backend/kernelCI_app/management/commands/templates/issue_boot.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/issue_boot.txt.j2
@@ -45,7 +45,7 @@ on the KernelCI dashboard:
     - commit hash:  {{ boot["last_pass_commit"] }}
     - test id:  {{ boot["last_pass_id"] }}
 {% endfor %}
-{% if boots and boots[0]["last_pass_commit"] -%}
+{% if regzbot_tracked and boots and boots[0]["last_pass_commit"] -%}
 #regzbot introduced: {{ boots[0]["last_pass_commit"] }}..{{ issue["git_commit_hash"] }}
 #regzbot link: https://d.kernelci.org/i/{{ issue["id"] }}
 

--- a/backend/kernelCI_app/management/commands/templates/issue_build.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/issue_build.txt.j2
@@ -35,7 +35,7 @@ on the KernelCI dashboard:
 - config: {{ build["config_url"] }}
 - dashboard: https://d.kernelci.org/build/{{build["id"]}}
 {% endfor %}
-{% if builds and builds[0]["last_pass_commit"] -%}
+{% if regzbot_tracked and builds and builds[0]["last_pass_commit"] -%}
 #regzbot introduced: {{ builds[0]["last_pass_commit"] }}..{{ issue["git_commit_hash"] }}
 #regzbot link: https://d.kernelci.org/i/{{ issue["id"] }}
 

--- a/backend/kernelCI_app/management/commands/templates/test_report.txt.j2
+++ b/backend/kernelCI_app/management/commands/templates/test_report.txt.j2
@@ -53,7 +53,7 @@ history: {{ test["status_history"] }}
 - compiler: {{ test["compiler"] }}
 {%- endif %}
 
-{% if test["last_pass_commit"] -%}
+{% if regzbot_tracked and test["last_pass_commit"] -%}
 #regzbot introduced: {{ test["last_pass_commit"] }}..{{ test["git_commit_hash"] }}
 #regzbot link: https://d.kernelci.org/t/{{ test["id"] }}
 

--- a/backend/kernelCI_app/tests/unitTests/commands/fixtures/report_notifications_data.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/fixtures/report_notifications_data.py
@@ -20,14 +20,14 @@ _LAST_PASS_COMMIT = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
 MESSAGE_ID = "<20260601120000.123456-1@kernelci.org>"
 
 
-def make_build_issue(*, with_range: bool = True):
+def make_build_issue(*, with_range: bool = True, tree_name: str = "mainline"):
     """Returns an (issue, incidents) pair for a build regression report.
 
     When with_range is False the incident has no last passing commit, which
     is how the regzbot block is omitted in the rendered report.
     """
     issue = {
-        "tree_name": "mainline",
+        "tree_name": tree_name,
         "git_repository_branch": "master",
         "comment": (
             "include/linux/signal.h:160:1: error: array index 2 is past the end "
@@ -66,10 +66,10 @@ def make_build_issue(*, with_range: bool = True):
     return issue, [incident]
 
 
-def make_boot_issue(*, with_range: bool = True):
+def make_boot_issue(*, with_range: bool = True, tree_name: str = "mainline"):
     """Returns an (issue, incidents) pair for a boot regression report."""
     issue = {
-        "tree_name": "mainline",
+        "tree_name": tree_name,
         "git_repository_branch": "master",
         "comment": "Kernel panic - not syncing: Attempted to kill init!",
         "id": "maestro:0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
@@ -110,10 +110,10 @@ def make_boot_issue(*, with_range: bool = True):
     return issue, [incident]
 
 
-def make_test(*, with_range: bool = True):
+def make_test(*, with_range: bool = True, tree_name: str = "mainline"):
     """Returns a test dict for a standalone test regression report."""
     return {
-        "tree_name": "mainline",
+        "tree_name": tree_name,
         "git_repository_branch": "master",
         "path": "kselftest.net.fib_tests",
         "platform": "rk3568-rock-3a",

--- a/backend/kernelCI_app/tests/unitTests/commands/fixtures/report_notifications_data.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/fixtures/report_notifications_data.py
@@ -20,7 +20,9 @@ _LAST_PASS_COMMIT = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
 MESSAGE_ID = "<20260601120000.123456-1@kernelci.org>"
 
 
-def make_build_issue(*, with_range: bool = True, tree_name: str = "mainline"):
+def make_build_issue(
+    *, with_range: bool = True, tree_name: str = "mainline", branch: str = "master"
+):
     """Returns an (issue, incidents) pair for a build regression report.
 
     When with_range is False the incident has no last passing commit, which
@@ -28,7 +30,7 @@ def make_build_issue(*, with_range: bool = True, tree_name: str = "mainline"):
     """
     issue = {
         "tree_name": tree_name,
-        "git_repository_branch": "master",
+        "git_repository_branch": branch,
         "comment": (
             "include/linux/signal.h:160:1: error: array index 2 is past the end "
             "of the array (that has type 'unsigned long[2]') [-Werror,-Warray-bounds] "
@@ -66,11 +68,13 @@ def make_build_issue(*, with_range: bool = True, tree_name: str = "mainline"):
     return issue, [incident]
 
 
-def make_boot_issue(*, with_range: bool = True, tree_name: str = "mainline"):
+def make_boot_issue(
+    *, with_range: bool = True, tree_name: str = "mainline", branch: str = "master"
+):
     """Returns an (issue, incidents) pair for a boot regression report."""
     issue = {
         "tree_name": tree_name,
-        "git_repository_branch": "master",
+        "git_repository_branch": branch,
         "comment": "Kernel panic - not syncing: Attempted to kill init!",
         "id": "maestro:0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c",
         "git_repository_url": (
@@ -110,11 +114,13 @@ def make_boot_issue(*, with_range: bool = True, tree_name: str = "mainline"):
     return issue, [incident]
 
 
-def make_test(*, with_range: bool = True, tree_name: str = "mainline"):
+def make_test(
+    *, with_range: bool = True, tree_name: str = "mainline", branch: str = "master"
+):
     """Returns a test dict for a standalone test regression report."""
     return {
         "tree_name": tree_name,
-        "git_repository_branch": "master",
+        "git_repository_branch": branch,
         "path": "kselftest.net.fib_tests",
         "platform": "rk3568-rock-3a",
         "git_repository_url": (

--- a/backend/kernelCI_app/tests/unitTests/commands/report_notifications_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/report_notifications_test.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
 
-from kernelCI_app.management.commands.helpers.common import setup_jinja_template
+from kernelCI_app.management.commands.helpers.common import (
+    is_regzbot_tree,
+    setup_jinja_template,
+)
 from kernelCI_app.management.commands.notifications import (
     generate_boot_issue_report,
     generate_build_issue_report,
@@ -27,20 +30,29 @@ class TestReportTemplates(TestCase):
     """
 
     @staticmethod
-    def render_build_report(*, with_range: bool = True) -> str:
-        issue, incidents = make_build_issue(with_range=with_range)
+    def render_build_report(
+        *, with_range: bool = True, tree_name: str = "mainline"
+    ) -> str:
+        issue, incidents = make_build_issue(with_range=with_range, tree_name=tree_name)
         return generate_build_issue_report(issue, incidents, MESSAGE_ID)["content"]
 
     @staticmethod
-    def render_boot_report(*, with_range: bool = True) -> str:
-        issue, incidents = make_boot_issue(with_range=with_range)
+    def render_boot_report(
+        *, with_range: bool = True, tree_name: str = "mainline"
+    ) -> str:
+        issue, incidents = make_boot_issue(with_range=with_range, tree_name=tree_name)
         return generate_boot_issue_report(issue, incidents, MESSAGE_ID)["content"]
 
     @staticmethod
-    def render_test_report(*, with_range: bool = True) -> str:
-        test = make_test(with_range=with_range)
+    def render_test_report(
+        *, with_range: bool = True, tree_name: str = "mainline"
+    ) -> str:
+        test = make_test(with_range=with_range, tree_name=tree_name)
+        regzbot_tracked = is_regzbot_tree(test["tree_name"])
         return setup_jinja_template("test_report.txt.j2").render(
-            test=test, message_id=MESSAGE_ID.strip("<>")
+            test=test,
+            regzbot_tracked=regzbot_tracked,
+            message_id=MESSAGE_ID.strip("<>") if regzbot_tracked else None,
         )
 
     def test_build_report_structure(self):
@@ -91,5 +103,20 @@ class TestReportTemplates(TestCase):
         ):
             content = render(with_range=False)
             assert "#regzbot" not in content
+            assert "Reported-by: kernelci.org bot <bot@kernelci.org>" in content
+            assert "#kernelci" in content
+
+    def test_reports_omit_regzbot_tags_for_non_upstream_trees(self):
+        # Only trees whose reports are CC'd to the regressions list (and are
+        # therefore archived on lore and followed by regzbot) carry the
+        # regzbot tags and a lore link to their own Message-ID.
+        for render in (
+            self.render_build_report,
+            self.render_boot_report,
+            self.render_test_report,
+        ):
+            content = render(tree_name="android")
+            assert "#regzbot" not in content
+            assert "Link:" not in content
             assert "Reported-by: kernelci.org bot <bot@kernelci.org>" in content
             assert "#kernelci" in content

--- a/backend/kernelCI_app/tests/unitTests/commands/report_notifications_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/report_notifications_test.py
@@ -31,23 +31,27 @@ class TestReportTemplates(TestCase):
 
     @staticmethod
     def render_build_report(
-        *, with_range: bool = True, tree_name: str = "mainline"
+        *, with_range: bool = True, tree_name: str = "mainline", branch: str = "master"
     ) -> str:
-        issue, incidents = make_build_issue(with_range=with_range, tree_name=tree_name)
+        issue, incidents = make_build_issue(
+            with_range=with_range, tree_name=tree_name, branch=branch
+        )
         return generate_build_issue_report(issue, incidents, MESSAGE_ID)["content"]
 
     @staticmethod
     def render_boot_report(
-        *, with_range: bool = True, tree_name: str = "mainline"
+        *, with_range: bool = True, tree_name: str = "mainline", branch: str = "master"
     ) -> str:
-        issue, incidents = make_boot_issue(with_range=with_range, tree_name=tree_name)
+        issue, incidents = make_boot_issue(
+            with_range=with_range, tree_name=tree_name, branch=branch
+        )
         return generate_boot_issue_report(issue, incidents, MESSAGE_ID)["content"]
 
     @staticmethod
     def render_test_report(
-        *, with_range: bool = True, tree_name: str = "mainline"
+        *, with_range: bool = True, tree_name: str = "mainline", branch: str = "master"
     ) -> str:
-        test = make_test(with_range=with_range, tree_name=tree_name)
+        test = make_test(with_range=with_range, tree_name=tree_name, branch=branch)
         regzbot_tracked = is_regzbot_tree(test["tree_name"])
         return setup_jinja_template("test_report.txt.j2").render(
             test=test,
@@ -120,3 +124,14 @@ class TestReportTemplates(TestCase):
             assert "Link:" not in content
             assert "Reported-by: kernelci.org bot <bot@kernelci.org>" in content
             assert "#kernelci" in content
+
+    def test_stable_tree_reports_carry_regzbot_tags(self):
+        for render in (
+            self.render_build_report,
+            self.render_boot_report,
+            self.render_test_report,
+        ):
+            content = render(tree_name="stable", branch="linux-6.15.y")
+            assert "stable/linux-6.15.y" in content
+            assert "#regzbot introduced:" in content
+            assert LORE_LINK in content


### PR DESCRIPTION
Regression reports currently carry the #regzbot tags and a lore link to their own Message-ID regardless of the tree, but only mainline and next reports are CC'd to the regressions list. Reports for other trees (android, chromeos and so on) are out of regzbot's scope, and their lore link can point at a mail that never reached lore.

Gate the regzbot tags and the lore link on the same tree check that adds the regressions list CC, through a shared is_regzbot_tree() helper, so the tags only appear on reports that regzbot will actually see and the link only appears on mails guaranteed to be archived. Reports for other trees keep the Reported-by attribution and the