### PR TITLE
fix/repo url malformed

### DIFF
--- a/backend/kernelCI_app/management/commands/treeproof.py
+++ b/backend/kernelCI_app/management/commands/treeproof.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 from typing import Optional
+from urllib.parse import urlparse
 
 import yaml
 from django.conf import settings
@@ -21,25 +22,51 @@ def process_dict(d):
             process_dict(value)
 
 
+def _repo_from_segments(segments: list[str]) -> Optional[str]:
+    repo = segments[-1]
+    repo = repo[:-4] if repo.lower().endswith(".git") else repo
+    return repo or None
+
+
+def _owner_from_segments(segments: list[str]) -> Optional[str]:
+    if len(segments) < 2:
+        return None
+    return segments[-2]
+
+
+def _tree_name_from_owner_and_repo(owner: str, repo: str) -> str:
+    if repo.lower() in owner.lower():
+        return owner
+    return f"{owner}-{repo}"
+
+
 class Command(BaseCommand):
     def __init__(self):
         self.maestro_trees = dict()
         self.non_maestro_trees = dict()
         self.trees: dict[str, dict] = {"trees": {}}
 
-    def _define_tree_name(self, git_url: str):
-        regex = r"([^/]+)/([^/]+)?$"
-        match = re.search(regex, git_url)
+    def _define_tree_name(self, git_url: Optional[str]) -> Optional[str]:
+        if not isinstance(git_url, str) or not git_url.strip():
+            return None
 
-        first_part = match.group(1)
-        second_part = match.group(2).split(".")[0]
+        raw = git_url.strip().rstrip("/")
+        if "://" not in raw:
+            return None
 
-        new_tree_name = first_part
+        segments = [s for s in urlparse(raw).path.split("/") if s]
+        if not segments:
+            return None
 
-        if second_part.lower() not in first_part.lower():
-            new_tree_name += f"-{second_part}"
+        repo = _repo_from_segments(segments)
+        if repo is None:
+            return None
 
-        return new_tree_name
+        owner = _owner_from_segments(segments)
+        if owner is None:
+            return repo
+
+        return _tree_name_from_owner_and_repo(owner, repo)
 
     def _get_trees_proofs(self, *, is_maestro=False):
         query = (
@@ -64,6 +91,13 @@ class Command(BaseCommand):
 
             if not tree_name or tree_name in origin_trees:
                 tree_name = self._define_tree_name(git_url)
+                if tree_name is None:
+                    logger.warning(
+                        "Skipping treeproof record, cannot derive tree name "
+                        "from git_repository_url=%r",
+                        git_url,
+                    )
+                    continue
 
             if tree_name in origin_trees:
                 suffix_match = re.search(r"-(\d+)$", tree_name)

--- a/backend/kernelCI_app/tests/unitTests/commands/treeproof_test.py
+++ b/backend/kernelCI_app/tests/unitTests/commands/treeproof_test.py
@@ -1,0 +1,85 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from kernelCI_app.management.commands.treeproof import Command
+
+
+class TestDefineTreeName(TestCase):
+    def setUp(self):
+        self.command = Command()
+
+    def test_https_org_repo(self):
+        url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+        self.assertEqual(self.command._define_tree_name(url), "torvalds-linux")
+
+    def test_trailing_slash(self):
+        url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/"
+        self.assertEqual(self.command._define_tree_name(url), "torvalds-linux")
+
+    def test_single_path_segment(self):
+        url = "https://example.com/linux.git"
+        self.assertEqual(self.command._define_tree_name(url), "linux")
+
+    def test_no_git_suffix(self):
+        url = "https://android.googlesource.com/kernel/common"
+        self.assertEqual(self.command._define_tree_name(url), "kernel-common")
+
+    def test_ssh_url(self):
+        url = "ssh://git@github.com/org/repo.git"
+        self.assertEqual(self.command._define_tree_name(url), "org-repo")
+
+    def test_ssh_url_with_port(self):
+        url = "ssh://git@github.com:22/org/repo.git"
+        self.assertEqual(self.command._define_tree_name(url), "org-repo")
+
+    def test_repo_substring_of_org(self):
+        url = "https://example.com/linux/linux.git"
+        self.assertEqual(self.command._define_tree_name(url), "linux")
+
+    def test_unmatched_returns_none(self):
+        for url in (
+            "",
+            "   ",
+            "https://example.com/",
+            "https://example.com",
+            "linux.git",
+            "git@github.com:org/repo.git",
+            "not a url at all!!!",
+            None,
+        ):
+            self.assertIsNone(self.command._define_tree_name(url), msg=repr(url))
+
+
+class TestGetTreesProofsSkip(TestCase):
+    @patch("kernelCI_app.management.commands.treeproof.Checkouts.objects")
+    def test_skips_unparseable_url(self, mock_objects):
+        records = [
+            {"tree_name": None, "git_repository_url": "https://example.com/"},
+            {
+                "tree_name": None,
+                "git_repository_url": (
+                    "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+                ),
+            },
+        ]
+        query = MagicMock()
+        query.distinct.return_value = query
+        query.filter.return_value = query
+        query.exclude.return_value = records
+        mock_objects.values.return_value = query
+
+        command = Command()
+        with self.assertLogs(
+            "kernelCI_app.management.commands.treeproof", level="WARNING"
+        ) as logs:
+            command._get_trees_proofs()
+
+        self.assertEqual(
+            command.non_maestro_trees,
+            {
+                "torvalds-linux": (
+                    "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+                )
+            },
+        )
+        self.assertTrue(any("https://example.com/" in msg for msg in logs.output))


### PR DESCRIPTION
### What it is

Defensive check for malformed url on git repository url submissions.
Altough it is not an observed scenario, we are now making sure a malformed input cannot break the ingester.

### How to test

1. Start a local database
2. In the submissions folder include invalid git_repository_url on the json submissions.
3. Make sure it cannot cause a crash.
