### PR TITLE
feat/issue list ordering

### DIFF
--- a/dashboard/src/components/IssueTable/IssueTable.tsx
+++ b/dashboard/src/components/IssueTable/IssueTable.tsx
@@ -198,7 +198,9 @@ export const IssueTable = ({
   const { listingSize } = useSearch({ from: '/_main/issues' });
   const navigate = useNavigate({ from: '/issues' });
 
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'first_seen', desc: true },
+  ]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     culprit: false,
   });


### PR DESCRIPTION
### What it is

Issues listing page is originally shown with no specific ordering.
We are changing it show on cronological order by default.

### How to test

1. Start a local instance.
2. Go to /issues page.
3. Make sure the issues have the First Seen column set to descending order.
