### PR TITLE
feat/issues list cache

### DIFF
--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -111,6 +111,15 @@ def get_issue_listing_data(
         "start_date": start_date,
         "end_date": end_date,
     }
+    cache_params = {
+        "start_date": int(start_date.timestamp()),
+        "end_date": int(end_date.timestamp()),
+    }
+    cache_key = "issueList"
+
+    rows = get_query_cache(key=cache_key, params=cache_params)
+    if rows is not None:
+        return rows
 
     # Note that an issue with timestamp younger than x days ago
     # can still have incidents in tests older than x days ago
@@ -139,7 +148,9 @@ def get_issue_listing_data(
 
     with connection.cursor() as cursor:
         cursor.execute(query, params)
-        return dict_fetchall(cursor)
+        rows = dict_fetchall(cursor)
+        set_query_cache(key=cache_key, params=cache_params, rows=rows)
+        return rows
 
 
 # TODO: combine this query with the other queries for issues

--- a/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
@@ -86,7 +86,27 @@ class TestGetIssueListingData:
     @patch("kernelCI_app.queries.issues.set_query_cache")
     @patch("kernelCI_app.queries.issues.dict_fetchall")
     @patch("kernelCI_app.queries.issues.connection")
-    def test_get_issue_listing_data_success(
+    def test_get_issue_listing_data_cache_hit(
+        self, mock_connection, mock_dict_fetchall, mock_set_cache, mock_get_cache
+    ):
+        cached_result = [{"id": "issue", "version": 1}]
+        mock_get_cache.return_value = cached_result
+
+        result = get_issue_listing_data(
+            start_date=datetime(2025, 11, 4),
+            end_date=datetime(2025, 11, 11),
+        )
+
+        assert result == cached_result
+        mock_connection.cursor.assert_not_called()
+        mock_dict_fetchall.assert_not_called()
+        mock_set_cache.assert_not_called()
+
+    @patch("kernelCI_app.queries.issues.get_query_cache")
+    @patch("kernelCI_app.queries.issues.set_query_cache")
+    @patch("kernelCI_app.queries.issues.dict_fetchall")
+    @patch("kernelCI_app.queries.issues.connection")
+    def test_get_issue_listing_data_cache_miss(
         self, mock_connection, mock_dict_fetchall, mock_set_cache, mock_get_cache
     ):
         mock_get_cache.return_value = None
@@ -101,6 +121,7 @@ class TestGetIssueListingData:
 
         assert result == expected_result
         mock_set_cache.assert_called_once()
+        mock_get_cache.assert_called_once()
 
 
 class TestGetLatestIssueVersion:

--- a/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
@@ -82,9 +82,14 @@ class TestGetIssueTests:
 
 
 class TestGetIssueListingData:
+    @patch("kernelCI_app.queries.issues.get_query_cache")
+    @patch("kernelCI_app.queries.issues.set_query_cache")
     @patch("kernelCI_app.queries.issues.dict_fetchall")
     @patch("kernelCI_app.queries.issues.connection")
-    def test_get_issue_listing_data_success(self, mock_connection, mock_dict_fetchall):
+    def test_get_issue_listing_data_success(
+        self, mock_connection, mock_dict_fetchall, mock_set_cache, mock_get_cache
+    ):
+        mock_get_cache.return_value = None
         expected_result = [{"id": "issue", "version": 1}]
         mock_dict_fetchall.return_value = expected_result
         setup_mock_cursor(mock_connection)
@@ -95,6 +100,7 @@ class TestGetIssueListingData:
         )
 
         assert result == expected_result
+        mock_set_cache.assert_called_once()
 
 
 class TestGetLatestIssueVersion:


### PR DESCRIPTION
### What it is

  * Add redis cache to top level issues listing.

### How to test

  * Start backend locally with `CACHE_TIMEOUT>0` setting
  * call /api/issue endpoint
  * Make sure that subsequent calls (during the cache window time) fetch values from redis cache.

Closes #1615
