### PR TITLE
fix/crash test hardware deselected tree

### DIFF
--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -305,10 +305,29 @@ export function BootsTable({
     [modelRows],
   );
 
-  const [currentLog, setLog] = useState<number | undefined>(undefined);
+  const [currentLogId, setLog] = useState<string | undefined>(undefined);
+
+  const currentLog = useMemo(() => {
+    const index = sortedItems.findIndex(item => item.id === currentLogId);
+    return index === -1 ? undefined : index;
+  }, [sortedItems, currentLogId]);
+
+  const activeLogId = currentLog !== undefined ? currentLogId ?? '' : '';
 
   const onOpenChange = useCallback(() => setLog(undefined), [setLog]);
-  const openLogSheet = useCallback((index: number) => setLog(index), [setLog]);
+  const openLogSheet = useCallback(
+    (index: number) => setLog(sortedItems[index]?.id),
+    [setLog, sortedItems],
+  );
+
+  useEffect(() => {
+    if (
+      currentLogId !== undefined &&
+      !sortedItems.some(item => item.id === currentLogId)
+    ) {
+      setLog(undefined);
+    }
+  }, [currentLogId, sortedItems]);
 
   const tableRows = useMemo((): JSX.Element[] | JSX.Element => {
     return modelRows?.length ? (
@@ -332,32 +351,18 @@ export function BootsTable({
   }, [modelRows, getRowLink, openLogSheet, currentLog, columns.length]);
 
   const handlePreviousItem = useCallback(() => {
-    setLog(previousLog => {
-      if (typeof previousLog === 'number' && previousLog > 0) {
-        return previousLog - 1;
-      }
-
-      return previousLog;
-    });
-  }, [setLog]);
+    if (currentLog !== undefined && currentLog > 0) {
+      setLog(sortedItems[currentLog - 1]?.id);
+    }
+  }, [setLog, currentLog, sortedItems]);
 
   const handleNextItem = useCallback(() => {
-    setLog(previousLog => {
-      if (
-        typeof previousLog === 'number' &&
-        previousLog < sortedItems.length - 1
-      ) {
-        return previousLog + 1;
-      }
+    if (currentLog !== undefined && currentLog < sortedItems.length - 1) {
+      setLog(sortedItems[currentLog + 1]?.id);
+    }
+  }, [setLog, currentLog, sortedItems]);
 
-      return previousLog;
-    });
-  }, [setLog, sortedItems.length]);
-
-  const { data: logData, isLoading } = useLogData(
-    sortedItems.length > 0 ? sortedItems[currentLog ?? 0].id : '',
-    'test',
-  );
+  const { data: logData, isLoading } = useLogData(activeLogId, 'test');
 
   const navigationLogsActions = useMemo(
     () => ({
@@ -381,13 +386,7 @@ export function BootsTable({
     return getRowLink(logData?.id ?? '');
   }, [logData?.id, getRowLink]);
 
-  const {
-    data: issues,
-    status,
-    error,
-  } = useTestIssues(
-    currentLog !== undefined ? sortedItems[currentLog]?.id : '',
-  );
+  const { data: issues, status, error } = useTestIssues(activeLogId);
 
   return (
     <WrapperTableWithLogSheet

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -197,10 +197,29 @@ export function BuildsTable({
     [modelRows],
   );
 
-  const [currentLog, setLog] = useState<number | undefined>(undefined);
+  const [currentLogId, setLog] = useState<string | undefined>(undefined);
+
+  const currentLog = useMemo(() => {
+    const index = sortedItems.findIndex(item => item.id === currentLogId);
+    return index === -1 ? undefined : index;
+  }, [sortedItems, currentLogId]);
+
+  const activeLogId = currentLog !== undefined ? currentLogId ?? '' : '';
 
   const onOpenChange = useCallback(() => setLog(undefined), [setLog]);
-  const openLogSheet = useCallback((index: number) => setLog(index), [setLog]);
+  const openLogSheet = useCallback(
+    (index: number) => setLog(sortedItems[index]?.id),
+    [setLog, sortedItems],
+  );
+
+  useEffect(() => {
+    if (
+      currentLogId !== undefined &&
+      !sortedItems.some(item => item.id === currentLogId)
+    ) {
+      setLog(undefined);
+    }
+  }, [currentLogId, sortedItems]);
 
   const tableBody = useMemo((): JSX.Element[] | JSX.Element => {
     {
@@ -228,32 +247,18 @@ export function BuildsTable({
   }, [modelRows, columns.length, openLogSheet, currentLog, getRowLink]);
 
   const handlePreviousItem = useCallback(() => {
-    setLog(previousLog => {
-      if (typeof previousLog === 'number' && previousLog > 0) {
-        return previousLog - 1;
-      }
-
-      return previousLog;
-    });
-  }, [setLog]);
+    if (currentLog !== undefined && currentLog > 0) {
+      setLog(sortedItems[currentLog - 1]?.id);
+    }
+  }, [setLog, currentLog, sortedItems]);
 
   const handleNextItem = useCallback(() => {
-    setLog(previousLog => {
-      if (
-        typeof previousLog === 'number' &&
-        previousLog < sortedItems.length - 1
-      ) {
-        return previousLog + 1;
-      }
+    if (currentLog !== undefined && currentLog < sortedItems.length - 1) {
+      setLog(sortedItems[currentLog + 1]?.id);
+    }
+  }, [setLog, currentLog, sortedItems]);
 
-      return previousLog;
-    });
-  }, [setLog, sortedItems.length]);
-
-  const { data: logData, isLoading } = useLogData(
-    sortedItems.length > 0 ? sortedItems[currentLog ?? 0]?.id : '',
-    'build',
-  );
+  const { data: logData, isLoading } = useLogData(activeLogId, 'build');
 
   const navigationLogsActions = useMemo(
     () => ({
@@ -277,13 +282,7 @@ export function BuildsTable({
     return getRowLink(sortedItems[currentLog ?? 0]?.id ?? '');
   }, [currentLog, getRowLink, sortedItems]);
 
-  const {
-    data: issues,
-    status,
-    error,
-  } = useBuildIssues(
-    currentLog !== undefined ? sortedItems[currentLog]?.id : '',
-  );
+  const { data: issues, status, error } = useBuildIssues(activeLogId);
 
   return (
     <WrapperTableWithLogSheet

--- a/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
+++ b/dashboard/src/components/TestsTable/IndividualTestsTable.tsx
@@ -8,7 +8,7 @@ import {
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { CSSProperties, JSX } from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { LinkProps } from '@tanstack/react-router';
 
@@ -87,10 +87,29 @@ export function IndividualTestsTable({
     [modelRows],
   );
 
-  const [currentLog, setLog] = useState<number | undefined>(undefined);
+  const [currentLogId, setLog] = useState<string | undefined>(undefined);
+
+  const currentLog = useMemo(() => {
+    const index = originalItems.findIndex(item => item.id === currentLogId);
+    return index === -1 ? undefined : index;
+  }, [originalItems, currentLogId]);
+
+  const activeLogId = currentLog !== undefined ? currentLogId ?? '' : '';
 
   const onOpenChange = useCallback(() => setLog(undefined), [setLog]);
-  const openLogSheet = useCallback((index: number) => setLog(index), [setLog]);
+  const openLogSheet = useCallback(
+    (index: number) => setLog(originalItems[index]?.id),
+    [setLog, originalItems],
+  );
+
+  useEffect(() => {
+    if (
+      currentLogId !== undefined &&
+      !originalItems.some(item => item.id === currentLogId)
+    ) {
+      setLog(undefined);
+    }
+  }, [currentLogId, originalItems]);
 
   const tableRows = useMemo((): JSX.Element[] => {
     return virtualItems.map(virtualRow => {
@@ -126,32 +145,18 @@ export function IndividualTestsTable({
     }, [virtualItems, virtualizer]);
 
   const handlePreviousItem = useCallback(() => {
-    setLog(previousLog => {
-      if (typeof previousLog === 'number' && previousLog > 0) {
-        return previousLog - 1;
-      }
-
-      return previousLog;
-    });
-  }, [setLog]);
+    if (currentLog !== undefined && currentLog > 0) {
+      setLog(originalItems[currentLog - 1]?.id);
+    }
+  }, [setLog, currentLog, originalItems]);
 
   const handleNextItem = useCallback(() => {
-    setLog(previousLog => {
-      if (
-        typeof previousLog === 'number' &&
-        previousLog < originalItems.length - 1
-      ) {
-        return previousLog + 1;
-      }
+    if (currentLog !== undefined && currentLog < originalItems.length - 1) {
+      setLog(originalItems[currentLog + 1]?.id);
+    }
+  }, [setLog, currentLog, originalItems]);
 
-      return previousLog;
-    });
-  }, [setLog, originalItems.length]);
-
-  const { data: logData, isLoading } = useLogData(
-    originalItems.length > 0 ? originalItems[currentLog ?? 0].id : '',
-    'test',
-  );
+  const { data: logData, isLoading } = useLogData(activeLogId, 'test');
 
   const navigationLogsActions = useMemo(
     () => ({
@@ -175,13 +180,7 @@ export function IndividualTestsTable({
     return getRowLink(logData?.id ?? '');
   }, [logData?.id, getRowLink]);
 
-  const {
-    data: issues,
-    status,
-    error,
-  } = useTestIssues(
-    currentLog !== undefined ? originalItems[currentLog]?.id : '',
-  );
+  const { data: issues, status, error } = useTestIssues(activeLogId);
 
   return (
     <WrapperTableWithLogSheet


### PR DESCRIPTION
### What it is

Fixes the crash where opening the log sheet of a boot whose tree was just deselected broke hardware details.

The log-sheet tables (BootsTable, BuildsTable, IndividualTestsTable) tracked the open log by row index. When a tree was deselected, the reloaded data dropped/reordered rows, so the stored index pointed past the list (sortedItems[currentLog].id → crash) or at the wrong item.

The tables now track the open log by the item's stable id and derive the row index from the live list each render. When the reloaded data no longer contains that id, the sheet closes on its own. This removes the fragile positional indexing entirely (crash impossible by construction) and also fixes the sheet reopening by itself when the tree was reselected.

### How to test

  1. Open a hardware details page and select two trees, A and B, both with boots.
  2. Go to the Boots tab, deselect tree A, and quickly open the log sheet of a boot from A before B finishes loading.
  3. Expected: no crash. Once the filtered data reloads, the sheet closes automatically.
  4. Reselect tree A — the log sheet should stay closed (it must only open on an explicit click).
  5. Repeat on the Builds and Tests tabs to confirm consistent behavior.

Closes #1482