### PR TITLE
chore: add recipient for qcom hardware subscriptions

### DIFF
--- a/backend/data/notifications/subscriptions/qcs615_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs615_hardware.yaml
@@ -8,3 +8,4 @@ qcs615-ride:
     - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
     - Yijie Yang <yijie.yang@oss.qualcomm.com>
     - Yushan Li <yushan.li@oss.qualcomm.com>
+    - Zhaohui Xin <zhaoxin@qti.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs6490_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs6490_hardware.yaml
@@ -8,3 +8,4 @@ qcs6490-rb3gen2:
     - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
     - Yijie Yang <yijie.yang@oss.qualcomm.com>
     - Yushan Li <yushan.li@oss.qualcomm.com>
+    - Zhaohui Xin <zhaoxin@qti.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs8300_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs8300_hardware.yaml
@@ -8,3 +8,4 @@ qcs8300-ride:
     - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
     - Yijie Yang <yijie.yang@oss.qualcomm.com>
     - Yushan Li <yushan.li@oss.qualcomm.com>
+    - Zhaohui Xin <zhaoxin@qti.qualcomm.com>

--- a/backend/data/notifications/subscriptions/qcs9100_hardware.yaml
+++ b/backend/data/notifications/subscriptions/qcs9100_hardware.yaml
@@ -8,3 +8,4 @@ qcs9100-ride:
     - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
     - Yijie Yang <yijie.yang@oss.qualcomm.com>
     - Yushan Li <yushan.li@oss.qualcomm.com>
+    - Zhaohui Xin <zhaoxin@qti.qualcomm.com>

--- a/backend/data/notifications/subscriptions/x1e80100_hardware.yaml
+++ b/backend/data/notifications/subscriptions/x1e80100_hardware.yaml
@@ -8,3 +8,4 @@ x1e80100:
     - Yogesh Lal <yogesh.lal@oss.qualcomm.com>
     - Yijie Yang <yijie.yang@oss.qualcomm.com>
     - Yushan Li <yushan.li@oss.qualcomm.com>
+    - Zhaohui Xin <zhaoxin@qti.qualcomm.com>


### PR DESCRIPTION
Add recipient for qcom hardware report notification on:
- qcs615
- qcs6490
- qcs8300
- qcs9100
- x1e80100