### PR TITLE
proxy: add Anubis bot protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ IMAGE_OWNER=kernelci
 IMAGE_REPOSITORY=dashboard
 IMAGE_TAG=latest
 
+# Anubis bot protection. The Compose files pin the current stable release when
+# ANUBIS_IMAGE is unset. Set ANUBIS_COOKIE_SECURE=false only for plain HTTP.
+# ANUBIS_IMAGE=ghcr.io/techarohq/anubis:v1.25.0
+# ANUBIS_COOKIE_SECURE=true
+
 # -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -48,6 +48,20 @@ This guide covers three deployment scenarios: [development](#1-development), [pr
 | pnpm | Frontend package management | `npm install -g pnpm` |
 | Poetry | Backend package management | `python3 -m pip install poetry` | 
 
+### Bot protection
+
+The standard Compose deployments place
+[Anubis](https://anubis.techaro.lol/) between the public NGINX listener and
+the dashboard. Its policy is stored in `anubis/botPolicy.yaml`. Requests whose
+user agent starts with `curl`, `wget`, `python-requests`, or `kci-dev` are
+explicitly allowed without a challenge; other traffic uses Anubis's default
+policy.
+
+Anubis uses secure cookies by default in `docker-compose-next.yml`. Set
+`ANUBIS_COOKIE_SECURE=false` only when the public dashboard is intentionally
+served over plain HTTP. `docker-compose.yml` defaults this setting to `false`
+for local development.
+
 ### Accessing production database
 
 If direct access to the production database is required,

--- a/anubis/botPolicy.yaml
+++ b/anubis/botPolicy.yaml
@@ -1,0 +1,9 @@
+bots:
+  # Keep documented API clients out of the challenge flow. These rules must
+  # precede the default policy import because ALLOW stops further evaluation.
+  - name: allow-kernelci-api-clients
+    user_agent_regex: >-
+      (?i)^(curl|wget|python-requests|kci-dev)(/|$)
+    action: ALLOW
+
+  - import: (data)/meta/default-config.yaml

--- a/docker-compose-next.yml
+++ b/docker-compose-next.yml
@@ -68,12 +68,36 @@ services:
         volumes:
             - static-data:/data/static
 
+    anubis:
+        image: ${ANUBIS_IMAGE:-ghcr.io/techarohq/anubis:v1.25.0}
+        restart: always
+        networks:
+            - public
+        environment:
+            BIND: ":8923"
+            METRICS_BIND: ":9090"
+            TARGET: "http://proxy:8080"
+            POLICY_FNAME: "/data/cfg/botPolicy.yaml"
+            COOKIE_SECURE: ${ANUBIS_COOKIE_SECURE:-true}
+        volumes:
+            - ./anubis/botPolicy.yaml:/data/cfg/botPolicy.yaml:ro
+        healthcheck:
+            test: ["CMD", "anubis", "--healthcheck"]
+            interval: 5s
+            timeout: 30s
+            retries: 5
+            start_period: 500ms
+
     proxy:
         image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_OWNER:-kernelci}/${IMAGE_REPOSITORY:-dashboard}/dashboard-proxy:${IMAGE_TAG:-latest}
         restart: always
         depends_on:
-            - backend
-            - dashboard
+            backend:
+                condition: service_started
+            dashboard:
+                condition: service_started
+            anubis:
+                condition: service_healthy
         networks:
             - public
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,13 +118,37 @@ services:
         volumes:
             - static-data:/data/static
 
+    anubis:
+        image: ${ANUBIS_IMAGE:-ghcr.io/techarohq/anubis:v1.25.0}
+        restart: always
+        networks:
+            - public
+        environment:
+            BIND: ":8923"
+            METRICS_BIND: ":9090"
+            TARGET: "http://proxy:8080"
+            POLICY_FNAME: "/data/cfg/botPolicy.yaml"
+            COOKIE_SECURE: ${ANUBIS_COOKIE_SECURE:-false}
+        volumes:
+            - ./anubis/botPolicy.yaml:/data/cfg/botPolicy.yaml:ro
+        healthcheck:
+            test: ["CMD", "anubis", "--healthcheck"]
+            interval: 5s
+            timeout: 30s
+            retries: 5
+            start_period: 500ms
+
     proxy:
         build: ./proxy
         image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_REPOSITORY:-local}/dashboard-proxy:${IMAGE_TAG:-latest}
         restart: always
         depends_on:
-            - backend
-            - dashboard
+            backend:
+                condition: service_started
+            dashboard:
+                condition: service_started
+            anubis:
+                condition: service_healthy
         networks:
             - public
         volumes:

--- a/proxy/etc/nginx/templates/default.conf.template
+++ b/proxy/etc/nginx/templates/default.conf.template
@@ -1,4 +1,34 @@
+upstream anubis {
+    server anubis:8923;
+    keepalive 32;
+}
+
 server {
+    listen 80 default_server;
+
+    # NGINX remains the public entry point and TLS terminator. Anubis filters
+    # requests before returning accepted traffic to the internal server below.
+    location / {
+        proxy_pass http://anubis;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Http-Version $server_protocol;
+        proxy_connect_timeout 240s;
+        proxy_read_timeout 240s;
+        proxy_send_timeout 240s;
+        send_timeout 240s;
+    }
+}
+
+server {
+    # This listener is only reachable inside the Compose network. Anubis sends
+    # accepted requests here after applying its policy.
+    listen 8080;
+
     location /api {
         proxy_pass ${PROXY_TARGET};
         proxy_connect_timeout 240s;


### PR DESCRIPTION
Route public dashboard traffic through an Anubis sidecar before it reaches the existing NGINX API and static-file handlers. Pin the stable v1.25.0 image and wait for its health check before starting the proxy.\n\nImport Anubis's default policy after an explicit allow rule for curl, wget, python-requests, and kci-dev user agents so documented API clients bypass browser challenges. Document the deployment and secure-cookie override.