### PR TITLE
feat/tables default ordering

### DIFF
--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -143,7 +143,9 @@ export function BootsTable({
   updatePathFilter,
   currentPathFilter,
 }: IBootsTable): JSX.Element {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'path', desc: false },
+  ]);
   const { pagination, paginationUpdater } = usePaginationState(tableKey);
   const [globalFilter, setGlobalFilter] = useState<string | undefined>(
     currentPathFilter,
@@ -183,6 +185,7 @@ export function BootsTable({
   const table = useReactTable({
     data: testsData,
     columns,
+    enableSortingRemoval: false,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -59,7 +59,9 @@ export function BuildsTable({
   onClickFilter,
   getRowLink,
 }: IBuildsTable): JSX.Element {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'config', desc: false },
+  ]);
   const { pagination, paginationUpdater } = usePaginationState(tableKey);
 
   const intl = useIntl();
@@ -87,6 +89,7 @@ export function BuildsTable({
   const table = useReactTable({
     data: rawData,
     columns,
+    enableSortingRemoval: false,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/dashboard/src/components/Table/TableHeader.tsx
+++ b/dashboard/src/components/Table/TableHeader.tsx
@@ -6,7 +6,7 @@ import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
 
 import { z } from 'zod';
 
-import { useCallback, type JSX } from 'react';
+import type { JSX } from 'react';
 
 import type { MessagesKey } from '@/locales/messages';
 
@@ -39,24 +39,12 @@ export const TableHeader = <T,>({
   intlKey,
   tooltipId,
 }: ITableHeader<T>): JSX.Element => {
-  const headerSort = useCallback(() => {
-    if (sortable) {
-      if (column.getIsSorted() === 'asc') {
-        column.toggleSorting(true);
-      } else if (column.getIsSorted() === 'desc') {
-        column.clearSorting();
-      } else {
-        column.toggleSorting(false);
-      }
-    }
-  }, [column, sortable]);
-
   return (
     <span className="flex">
       <Button
         variant="ghost"
         className="justify-start px-2"
-        onClick={headerSort}
+        onClick={sortable ? column.getToggleSortingHandler() : undefined}
       >
         <FormattedMessage key={intlKey} id={intlKey} />
 

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -96,7 +96,9 @@ export function TestsTable({
   updatePathFilter,
   currentPathFilter,
 }: ITestsTable): JSX.Element {
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'path_group', desc: false },
+  ]);
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [groupingMode, setGroupingMode] =
     useState<TableGroupingMode>('grouped');
@@ -162,6 +164,7 @@ export function TestsTable({
   const table = useReactTable({
     data,
     columns,
+    enableSortingRemoval: false,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
@@ -30,39 +30,14 @@ const TreeListingPage = ({
       return [];
     }
 
-    return data
-      .filter(tree => {
-        return (
-          matchesRegexOrIncludes(tree.git_commit_hash, inputFilter) ||
-          matchesRegexOrIncludes(tree.git_repository_branch, inputFilter) ||
-          matchesRegexOrIncludes(tree.git_repository_url, inputFilter) ||
-          matchesRegexOrIncludes(tree.tree_name, inputFilter)
-        );
-      })
-      .sort((a, b) => {
-        const currentATreeName = a.tree_name ?? '';
-        const currentBTreeName = b.tree_name ?? '';
-        const treeNameComparison =
-          currentATreeName.localeCompare(currentBTreeName);
-
-        if (treeNameComparison !== 0) {
-          return treeNameComparison;
-        }
-
-        const currentABranch = a.git_repository_branch ?? '';
-        const currentBBranch = b.git_repository_branch ?? '';
-        const branchComparison = currentABranch.localeCompare(currentBBranch);
-        if (branchComparison !== 0) {
-          return branchComparison;
-        }
-
-        if (a.start_time === undefined || b.start_time === undefined) {
-          return 0;
-        }
-        return (
-          new Date(b.start_time).getTime() - new Date(a.start_time).getTime()
-        );
-      });
+    return data.filter(tree => {
+      return (
+        matchesRegexOrIncludes(tree.git_commit_hash, inputFilter) ||
+        matchesRegexOrIncludes(tree.git_repository_branch, inputFilter) ||
+        matchesRegexOrIncludes(tree.git_repository_url, inputFilter) ||
+        matchesRegexOrIncludes(tree.tree_name, inputFilter)
+      );
+    });
   }, [data, inputFilter]);
 
   const kcidevComponent = useMemo(

--- a/dashboard/src/components/TreeListingPage/treeTableUtils.tsx
+++ b/dashboard/src/components/TreeListingPage/treeTableUtils.tsx
@@ -88,7 +88,7 @@ export const commonTreeTableColumns: ColumnDef<TreeListingItem>[] = [
 export const sortTreesWithPinnedFirst = <T extends TreeListingItem>(
   treeTableRows: T[],
 ): T[] => {
-  return treeTableRows.sort((a, b) => {
+  return [...treeTableRows].sort((a, b) => {
     const aKey = makeTreeIdentifierKey({
       treeName: valueOrEmpty(a.tree_name),
       gitRepositoryBranch: valueOrEmpty(a.git_repository_branch),

--- a/dashboard/src/pages/Hardware/HardwareListingPage.tsx
+++ b/dashboard/src/pages/Hardware/HardwareListingPage.tsx
@@ -188,8 +188,7 @@ const HardwareListingPage = ({
           test_status_summary: hardware.test_status_summary,
           boot_status_summary: hardware.boot_status_summary,
         };
-      })
-      .sort((a, b) => a.platform.localeCompare(b.platform));
+      });
   }, [activeListing.data, activeListing.error, inputFilter]);
 
   const selectedRevision =

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -397,16 +397,14 @@ export function HardwareTable({
   const { listingSize, intervalInDays } = useSearch({ strict: false });
   const navigate = useNavigate({ from: navigateFrom });
 
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'platform', desc: false },
+  ]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const { pagination, paginationUpdater } = usePaginationState(
     'hardwareListing',
     listingSize,
   );
-
-  const data = useMemo(() => {
-    return treeTableRows;
-  }, [treeTableRows]);
 
   const columns = useMemo(
     () =>
@@ -415,8 +413,9 @@ export function HardwareTable({
   );
 
   const table = useReactTable({
-    data,
+    data: treeTableRows,
     columns,
+    enableSortingRemoval: false,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),


### PR DESCRIPTION
### What it is
  * Hardware sorting no longer clears to an unsorted state, so Platform stays `asc` or `desc`.
  * TableHeader now uses TanStack’s getToggleSortingHandler(), so table sorting options (including `enableSortingRemoval`) are respected everywhere.
  * Removes redundant page-level sorts on hardware and tree listing; trees still use pinned-first ordering when unsorted.

### How to test

#### Hardware

* Go to /hardware page
* Platform shows asc order; rows using asc order by platform.
* Click Platform
* Platform shows desc order; rows using desc order by platform.
* Click Platform
* Platform shows again asc (not unsorted).
* Click another column (e.g. Builds) → sorts; cycle asc/desc/clear as usual.

#### Trees
* Go to /tree page
* Unsorted keeps pinned trees first (mainline/master, next/master, stable/*);
* Click Tree
* Column sort overrides; clear restores pinned-first.

Closes #2004
