### PR TITLE
Fix: tests table height

### DIFF
--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -260,7 +260,7 @@ export function TestsTable({
         onSearchChange={onSearchChange}
         currentPathFilter={currentPathFilter}
       />
-      <div className="h-[600px] overflow-auto">
+      <div className="max-h-150 overflow-auto">
         <DumbBaseTable containerClassName="overflow-visible h-full bg-white">
           <DumbTableHeader className="sticky top-0 z-10">
             {tableHeaders}


### PR DESCRIPTION
## Summary
Replaces static height with a max limit on individual tests table, allowing tables with less data to be shorter

## Changes
- Replaces static table height with max-h
- Replaces static px with tailwind's size

## How to test
- Go to a page that has the individual tests table (treeDetails/hardwareDetails tests tab, buildDetails, issueDetails) and has only a few tests.
- Check that the table doesn't have whitespace at the bottom but still allows for scrolling on other pages when it has a lot of tests.
- Compare with the original

## Visual Examples

Before / After:

<img width="1853" height="966" alt="image" src="https://github.com/user-attachments/assets/b0e71ae6-a379-41b4-9403-6e57c4fe27fa" />

<img width="1853" height="966" alt="image" src="https://github.com/user-attachments/assets/e915ea8f-b85d-42a0-a6ee-0223e17be1fb" />

Test with staging environment: https://staging.dashboard.kernelci.org/issue/redhat%3Aissue_2504?iv=1774001989&o=redhat

Closes #2025