### PR TITLE
feat: sync table sort state to the URL

### DIFF
--- a/dashboard/src/components/BootsTable/BootsTable.tsx
+++ b/dashboard/src/components/BootsTable/BootsTable.tsx
@@ -33,6 +33,7 @@ import { useTestIssues } from '@/api/testDetails';
 import { useLogData } from '@/hooks/useLogData';
 import WrapperTableWithLogSheet from '@/pages/TreeDetails/Tabs/WrapperTableWithLogSheet';
 import { usePaginationState } from '@/hooks/usePaginationState';
+import { useSortingState } from '@/hooks/useSortingState';
 
 import type { TableKeys } from '@/utils/constants/tables';
 
@@ -132,6 +133,8 @@ interface IBootsTable {
   currentPathFilter?: string;
 }
 
+const DEFAULT_BOOTS_SORTING: SortingState = [{ id: 'path', desc: false }];
+
 // TODO: would be useful if the navigation happened within the table, so the parent component would only be required to pass the navigation url instead of the whole function for the update and the currentPath diffFilter (boots/tests Table)
 export function BootsTable({
   tableKey,
@@ -143,9 +146,9 @@ export function BootsTable({
   updatePathFilter,
   currentPathFilter,
 }: IBootsTable): JSX.Element {
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: 'path', desc: false },
-  ]);
+  const { sorting, handleSortingChange } = useSortingState({
+    defaultSorting: DEFAULT_BOOTS_SORTING,
+  });
   const { pagination, paginationUpdater } = usePaginationState(tableKey);
   const [globalFilter, setGlobalFilter] = useState<string | undefined>(
     currentPathFilter,
@@ -186,7 +189,7 @@ export function BootsTable({
     data: testsData,
     columns,
     enableSortingRemoval: false,
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     onPaginationChange: paginationUpdater,

--- a/dashboard/src/components/BuildsTable/BuildsTable.tsx
+++ b/dashboard/src/components/BuildsTable/BuildsTable.tsx
@@ -26,6 +26,7 @@ import {
 import WrapperTableWithLogSheet from '@/pages/TreeDetails/Tabs/WrapperTableWithLogSheet';
 
 import { usePaginationState } from '@/hooks/usePaginationState';
+import { useSortingState } from '@/hooks/useSortingState';
 
 import type { TableKeys } from '@/utils/constants/tables';
 
@@ -49,7 +50,10 @@ export interface IBuildsTable {
   filter: PossibleTableFilters;
   onClickFilter: (filter: PossibleTableFilters) => void;
   getRowLink: (buildId: string) => LinkProps;
+  sortKey?: string;
 }
+
+const DEFAULT_BUILDS_SORTING: SortingState = [{ id: 'config', desc: false }];
 
 export function BuildsTable({
   tableKey,
@@ -58,10 +62,12 @@ export function BuildsTable({
   filter,
   onClickFilter,
   getRowLink,
+  sortKey,
 }: IBuildsTable): JSX.Element {
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: 'config', desc: false },
-  ]);
+  const { sorting, handleSortingChange } = useSortingState({
+    defaultSorting: DEFAULT_BUILDS_SORTING,
+    sortKey,
+  });
   const { pagination, paginationUpdater } = usePaginationState(tableKey);
 
   const intl = useIntl();
@@ -90,7 +96,7 @@ export function BuildsTable({
     data: rawData,
     columns,
     enableSortingRemoval: false,
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     onPaginationChange: paginationUpdater,

--- a/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsBuildSection.tsx
@@ -80,6 +80,7 @@ export const IssueDetailsBuildSection = ({
             getRowLink={getTableRowLink}
             onClickFilter={onClickFilter}
             columns={columns}
+            sortKey="buildsTable"
           />
         </div>
       ) : (

--- a/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetailsTestSection.tsx
@@ -72,6 +72,7 @@ export const IssueDetailsTestSection = ({
             filter={testTableFilter}
             getRowLink={getTableRowLink}
             innerColumns={innerColumns}
+            sortKey="testsTable"
           />
         </div>
       ) : (

--- a/dashboard/src/components/IssueTable/IssueTable.tsx
+++ b/dashboard/src/components/IssueTable/IssueTable.tsx
@@ -30,6 +30,7 @@ import type {
 } from '@/types/issueListing';
 import { TableHeader } from '@/components/Table/TableHeader';
 import { usePaginationState } from '@/hooks/usePaginationState';
+import { useSortingState } from '@/hooks/useSortingState';
 import { PaginationInfo } from '@/components/Table/PaginationInfo';
 import {
   TableBody,
@@ -63,7 +64,7 @@ const getLinkProps = (
       to: '/tree/$treeId',
       params: { treeId: row.original.git_commit_hash },
       state: s => s,
-      search: previousSearch => ({
+      search: ({ tableSort: _tableSort, ...previousSearch }) => ({
         ...previousSearch,
         origin: row.original.origin,
         treeInfo: {
@@ -188,6 +189,8 @@ interface IIssueTable {
   isLoading?: boolean;
 }
 
+const DEFAULT_ISSUE_SORTING: SortingState = [{ id: 'first_seen', desc: true }];
+
 export const IssueTable = ({
   issueListing,
   status,
@@ -198,9 +201,9 @@ export const IssueTable = ({
   const { listingSize } = useSearch({ from: '/_main/issues' });
   const navigate = useNavigate({ from: '/issues' });
 
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: 'first_seen', desc: true },
-  ]);
+  const { sorting, handleSortingChange } = useSortingState({
+    defaultSorting: DEFAULT_ISSUE_SORTING,
+  });
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     culprit: false,
   });
@@ -224,7 +227,7 @@ export const IssueTable = ({
   const table = useReactTable({
     data: issueTableRows,
     columns,
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     onPaginationChange: paginationUpdater,

--- a/dashboard/src/components/TestsTable/TestsTable.tsx
+++ b/dashboard/src/components/TestsTable/TestsTable.tsx
@@ -54,6 +54,8 @@ import { useTestIssues } from '@/api/testDetails';
 import { useLogData } from '@/hooks/useLogData';
 import WrapperTableWithLogSheet from '@/pages/TreeDetails/Tabs/WrapperTableWithLogSheet';
 
+import { useSortingState } from '@/hooks/useSortingState';
+
 import {
   adaptColumnsForUnifiedTable,
   defaultInnerColumns,
@@ -85,7 +87,10 @@ export interface ITestsTable {
   getRowLink: (testId: TestHistory['id']) => LinkProps;
   updatePathFilter?: (pathFilter: string) => void;
   currentPathFilter?: string;
+  sortKey?: string;
 }
+
+const DEFAULT_TESTS_SORTING: SortingState = [{ id: 'path_group', desc: false }];
 
 export function TestsTable({
   testHistory,
@@ -95,10 +100,12 @@ export function TestsTable({
   getRowLink,
   updatePathFilter,
   currentPathFilter,
+  sortKey,
 }: ITestsTable): JSX.Element {
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: 'path_group', desc: false },
-  ]);
+  const { sorting, handleSortingChange } = useSortingState({
+    defaultSorting: DEFAULT_TESTS_SORTING,
+    sortKey,
+  });
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const [groupingMode, setGroupingMode] =
     useState<TableGroupingMode>('grouped');
@@ -165,7 +172,7 @@ export function TestsTable({
     data,
     columns,
     enableSortingRemoval: false,
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getSubRows: row => row.subRows,

--- a/dashboard/src/components/TreeListingPage/TreeTable.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeTable.tsx
@@ -1,9 +1,4 @@
-import type {
-  ColumnDef,
-  ColumnFiltersState,
-  Row,
-  SortingState,
-} from '@tanstack/react-table';
+import type { ColumnDef, ColumnFiltersState, Row } from '@tanstack/react-table';
 import {
   flexRender,
   getCoreRowModel,
@@ -30,6 +25,7 @@ import { formattedBreakLineValue } from '@/locales/messages';
 import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
 
 import { usePaginationState } from '@/hooks/usePaginationState';
+import { useSortingState } from '@/hooks/useSortingState';
 
 import BaseTable, { TableHead } from '@/components/Table/BaseTable';
 import { TableBody, TableCell, TableRow } from '@/components/ui/table';
@@ -272,7 +268,7 @@ export function TreeTable({
   });
   const navigate = useNavigate({ from: urlFromMap.navigate });
 
-  const [sorting, setSorting] = useState<SortingState>([]);
+  const { sorting, handleSortingChange } = useSortingState();
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const { pagination, paginationUpdater } = usePaginationState(
     'treeListing',
@@ -288,7 +284,7 @@ export function TreeTable({
   const table = useReactTable({
     data: orderedData,
     columns,
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/dashboard/src/hooks/useSortingState.test.ts
+++ b/dashboard/src/hooks/useSortingState.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SortingState } from '@tanstack/react-table';
+
+import { TABLE_SORT_UNSORTED } from '@/types/general';
+
+import {
+  getTableSortValue,
+  searchValueToSorting,
+  sortingToSearchValue,
+  updateTableSortParam,
+} from './useSortingState';
+
+describe('sortingToSearchValue', () => {
+  it('encodes unsorted as none', () => {
+    expect(sortingToSearchValue([])).toBe(TABLE_SORT_UNSORTED);
+  });
+
+  it('encodes ascending and descending sorts', () => {
+    expect(sortingToSearchValue([{ id: 'status', desc: false }])).toBe(
+      'status',
+    );
+    expect(sortingToSearchValue([{ id: 'status', desc: true }])).toBe(
+      '-status',
+    );
+  });
+});
+
+describe('searchValueToSorting', () => {
+  const defaultSorting: SortingState = [{ id: 'first_seen', desc: true }];
+
+  it('returns default when value is absent', () => {
+    expect(searchValueToSorting(undefined, defaultSorting)).toEqual(
+      defaultSorting,
+    );
+  });
+
+  it('parses none as unsorted', () => {
+    expect(searchValueToSorting(TABLE_SORT_UNSORTED, defaultSorting)).toEqual(
+      [],
+    );
+  });
+
+  it('parses ascending and descending values', () => {
+    expect(searchValueToSorting('status', [])).toEqual([
+      { id: 'status', desc: false },
+    ]);
+    expect(searchValueToSorting('-status', [])).toEqual([
+      { id: 'status', desc: true },
+    ]);
+  });
+});
+
+describe('getTableSortValue', () => {
+  it('reads a flat string when no sortKey is set', () => {
+    expect(getTableSortValue('-status')).toBe('-status');
+    expect(getTableSortValue({ buildsTable: 'path' })).toBeUndefined();
+  });
+
+  it('reads a keyed value when sortKey is set', () => {
+    expect(getTableSortValue({ buildsTable: 'path' }, 'buildsTable')).toBe(
+      'path',
+    );
+    expect(getTableSortValue('-status', 'buildsTable')).toBeUndefined();
+  });
+});
+
+describe('updateTableSortParam', () => {
+  it('stores a flat string without a sortKey', () => {
+    expect(updateTableSortParam(undefined, undefined, '-status')).toBe(
+      '-status',
+    );
+    expect(updateTableSortParam('-status', undefined, undefined)).toBe(
+      undefined,
+    );
+  });
+
+  it('stores keyed values when sortKey is set', () => {
+    expect(updateTableSortParam(undefined, 'buildsTable', 'path')).toEqual({
+      buildsTable: 'path',
+    });
+    expect(
+      updateTableSortParam({ buildsTable: 'path' }, 'testsTable', '-startTime'),
+    ).toEqual({
+      buildsTable: 'path',
+      testsTable: '-startTime',
+    });
+    expect(
+      updateTableSortParam({ buildsTable: 'path' }, 'buildsTable', undefined),
+    ).toBeUndefined();
+  });
+});

--- a/dashboard/src/hooks/useSortingState.ts
+++ b/dashboard/src/hooks/useSortingState.ts
@@ -1,0 +1,141 @@
+import { useCallback, useMemo } from 'react';
+
+import type { OnChangeFn, SortingState } from '@tanstack/react-table';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+
+import { TABLE_SORT_UNSORTED, type TableSortSearch } from '@/types/general';
+import { EMPTY_OBJECT } from '@/utils/constants/general';
+
+const EMPTY_SORTING: SortingState = [];
+
+const sortingEquals = (a: SortingState, b: SortingState): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every(
+    (sort, index) => sort.id === b[index]?.id && sort.desc === b[index]?.desc,
+  );
+};
+
+export const sortingToSearchValue = (sorting: SortingState): string => {
+  if (sorting.length === 0) {
+    return TABLE_SORT_UNSORTED;
+  }
+  const sort = sorting[0];
+  return sort.desc ? `-${sort.id}` : sort.id;
+};
+
+export const searchValueToSorting = (
+  value: string | undefined,
+  defaultSorting: SortingState,
+): SortingState => {
+  if (value === undefined) {
+    return defaultSorting;
+  }
+  if (value === TABLE_SORT_UNSORTED) {
+    return [];
+  }
+  if (value.startsWith('-')) {
+    return [{ id: value.slice(1), desc: true }];
+  }
+  return [{ id: value, desc: false }];
+};
+
+const toUrlValue = (
+  sorting: SortingState,
+  defaultSorting: SortingState,
+): string | undefined => {
+  if (sortingEquals(sorting, defaultSorting)) {
+    return undefined;
+  }
+  return sortingToSearchValue(sorting);
+};
+
+export const getTableSortValue = (
+  tableSort: TableSortSearch,
+  sortKey?: string,
+): string | undefined => {
+  if (tableSort === undefined) {
+    return undefined;
+  }
+  if (sortKey === undefined) {
+    return typeof tableSort === 'string' ? tableSort : undefined;
+  }
+  if (typeof tableSort === 'object') {
+    return tableSort[sortKey];
+  }
+  return undefined;
+};
+
+export const updateTableSortParam = (
+  prev: TableSortSearch,
+  sortKey: string | undefined,
+  value: string | undefined,
+): TableSortSearch => {
+  if (sortKey === undefined) {
+    return value;
+  }
+
+  const next: Record<string, string> =
+    typeof prev === 'object' && prev !== null ? { ...prev } : {};
+  if (value === undefined) {
+    delete next[sortKey];
+  } else {
+    next[sortKey] = value;
+  }
+  return Object.keys(next).length === 0 ? undefined : next;
+};
+
+type UseSortingStateOptions = {
+  defaultSorting?: SortingState;
+  /** Set only when multiple tables on the same page need distinct sort params. */
+  sortKey?: string;
+};
+
+export const useSortingState = (
+  options: UseSortingStateOptions = EMPTY_OBJECT,
+): {
+  sorting: SortingState;
+  handleSortingChange: OnChangeFn<SortingState>;
+} => {
+  const { defaultSorting = EMPTY_SORTING, sortKey } = options;
+  const { tableSort } = useSearch({ strict: false });
+  const navigate = useNavigate();
+
+  const sortValue = getTableSortValue(tableSort, sortKey);
+
+  const sorting = useMemo(
+    () => searchValueToSorting(sortValue, defaultSorting),
+    [defaultSorting, sortValue],
+  );
+
+  const handleSortingChange: OnChangeFn<SortingState> = useCallback(
+    updater => {
+      navigate({
+        to: '.',
+        search: prev => {
+          const current = searchValueToSorting(
+            getTableSortValue(prev.tableSort, sortKey),
+            defaultSorting,
+          );
+          const nextSorting =
+            typeof updater === 'function' ? updater(current) : updater;
+
+          return {
+            ...prev,
+            tableSort: updateTableSortParam(
+              prev.tableSort,
+              sortKey,
+              toUrlValue(nextSorting, defaultSorting),
+            ),
+          };
+        },
+        state: s => s,
+        replace: true,
+      });
+    },
+    [defaultSorting, navigate, sortKey],
+  );
+
+  return { sorting, handleSortingChange };
+};

--- a/dashboard/src/pages/Hardware/HardwareTable.tsx
+++ b/dashboard/src/pages/Hardware/HardwareTable.tsx
@@ -49,6 +49,7 @@ import { sumStatus } from '@/utils/status';
 import { REDUCED_TIME_SEARCH } from '@/utils/constants/general';
 
 import { usePaginationState } from '@/hooks/usePaginationState';
+import { useSortingState } from '@/hooks/useSortingState';
 
 import { zPossibleTabValidator } from '@/types/tree/TreeDetails';
 
@@ -376,6 +377,10 @@ const getColumns = (
   ];
 };
 
+const DEFAULT_HARDWARE_SORTING: SortingState = [
+  { id: 'platform', desc: false },
+];
+
 export function HardwareTable({
   treeTableRows,
   startTimestampInSeconds,
@@ -397,9 +402,9 @@ export function HardwareTable({
   const { listingSize, intervalInDays } = useSearch({ strict: false });
   const navigate = useNavigate({ from: navigateFrom });
 
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: 'platform', desc: false },
-  ]);
+  const { sorting, handleSortingChange } = useSortingState({
+    defaultSorting: DEFAULT_HARDWARE_SORTING,
+  });
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const { pagination, paginationUpdater } = usePaginationState(
     'hardwareListing',
@@ -416,7 +421,7 @@ export function HardwareTable({
     data: treeTableRows,
     columns,
     enableSortingRemoval: false,
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/dashboard/src/pages/Hardware/hardwareTableUtils.ts
+++ b/dashboard/src/pages/Hardware/hardwareTableUtils.ts
@@ -23,6 +23,7 @@ export const buildHardwareDetailsSearch = ({
     gitRepositoryUrl: _gitRepositoryUrl,
     gitBranch: _gitBranch,
     gitCommitHash: _gitCommitHash,
+    tableSort: _tableSort,
     ...searchWithoutTreeParams
   } = previousSearch;
 

--- a/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
+++ b/dashboard/src/pages/TreeDetails/Tabs/TreeDetailsTab.tsx
@@ -88,6 +88,7 @@ const TreeDetailsTab = ({
           return {
             ...previousParams,
             currentPageTab: validatedValue,
+            tableSort: undefined,
           };
         },
         state: s => s,

--- a/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
+++ b/dashboard/src/pages/hardwareDetails/Tabs/HardwareDetailsTabs.tsx
@@ -54,6 +54,7 @@ const HardwareDetailsTabs = ({
           return {
             ...previousParams,
             currentPageTab: validatedValue,
+            tableSort: undefined,
           };
         },
         state: s => s,

--- a/dashboard/src/routes/__root.tsx
+++ b/dashboard/src/routes/__root.tsx
@@ -7,14 +7,21 @@ import type { JSX } from 'react';
 
 import { z } from 'zod';
 
-import { DEFAULT_ORIGIN, type SearchSchema, zOrigin } from '@/types/general';
+import {
+  DEFAULT_ORIGIN,
+  type SearchSchema,
+  zOrigin,
+  zTableSortValidator,
+} from '@/types/general';
 
 const defaultValues = {
   origin: DEFAULT_ORIGIN,
+  tableSort: undefined,
 };
 
 const RouteSchema = z.object({
   origin: zOrigin,
+  tableSort: zTableSortValidator,
 } satisfies SearchSchema);
 
 const RouteComponent = (): JSX.Element => {

--- a/dashboard/src/types/general.ts
+++ b/dashboard/src/types/general.ts
@@ -140,6 +140,17 @@ export const zListingSize = z
   .optional(z.number().min(1).catch(DEFAULT_LISTING_ITEMS))
   .default(DEFAULT_LISTING_ITEMS);
 
+/** Sentinel for an explicit unsorted state when the table default is not unsorted. */
+export const TABLE_SORT_UNSORTED = 'none' as const;
+
+/** Flat string for one table; record only when multiple tables share a page. */
+export const zTableSortValidator = z
+  .union([z.string(), z.record(z.string())])
+  .optional()
+  .catch(undefined);
+
+export type TableSortSearch = z.infer<typeof zTableSortValidator>;
+
 const zIntervalInDaysUncatched = z.number().min(1);
 
 export const makeZIntervalInDays = (
@@ -247,6 +258,7 @@ export type SearchParamsKeys =
   | 'intervalInDays'
   | 'currentPageTab'
   | 'tableFilter'
+  | 'tableSort'
   | 'diffFilter'
   | 'treeSearch'
   | 'listingSize'

--- a/dashboard/src/utils/constants/general.ts
+++ b/dashboard/src/utils/constants/general.ts
@@ -10,3 +10,5 @@ export const DEFAULT_TIME_SEARCH = 7;
 export const REDUCED_TIME_SEARCH = 5;
 export const DEFAULT_LISTING_ITEMS = 10;
 export const DEFAULT_LISTING_INTERVAL_IN_DAYS = 30;
+
+export const EMPTY_OBJECT = {};

--- a/dashboard/src/utils/search.test.ts
+++ b/dashboard/src/utils/search.test.ts
@@ -19,6 +19,7 @@ const simpleObject = {
   intervalInDays: 7,
   // eslint-disable-next-line no-magic-numbers
   treeIndexes: [1, 2, 3],
+  tableSort: '-status',
 };
 
 const simpleObjectMinify = {
@@ -26,9 +27,10 @@ const simpleObjectMinify = {
   i: 7,
   // eslint-disable-next-line no-magic-numbers
   x: [1, 2, 3],
+  s: '-status',
 };
 
-const simpleObjectStringify = '?o=maestro&i=7&x[]=1,2,3';
+const simpleObjectStringify = '?o=maestro&i=7&x[]=1,2,3&s=-status';
 
 const nestedObject = {
   origin: 'maestro',
@@ -37,6 +39,10 @@ const nestedObject = {
     bootsTable: 'all',
     buildsTable: 'failed',
     testsTable: 'all',
+  },
+  tableSort: {
+    buildsTable: 'path',
+    testsTable: '-startTime',
   },
   treeInfo: {
     treeName: 'android',
@@ -58,6 +64,10 @@ const nestedObjectMinify = {
     b: 'f',
     t: 'a',
   },
+  s: {
+    b: 'path',
+    t: '-startTime',
+  },
   tri: {
     t: 'android',
     ch: 'hash',
@@ -73,6 +83,7 @@ const nestedObjectMinify = {
 const nestedObjectStringify =
   '?o=maestro&i=7' +
   '&tf|bt=a&tf|b=f&tf|t=a' +
+  '&s|b=path&s|t=-startTime' +
   '&tri|t=android&tri|ch=hash' +
   '&df|c|defconfig=true&df|a|arm=true&df|tp=amlogic' +
   '&x[]=0,1,2';
@@ -83,6 +94,8 @@ const flatObject = {
   'tableFilter|bootsTable': 'all',
   'tableFilter|buildsTable': 'failed',
   'tableFilter|testsTable': 'all',
+  'tableSort|buildsTable': 'path',
+  'tableSort|testsTable': '-startTime',
   'treeInfo|treeName': 'android',
   'treeInfo|headCommitHash': 'hash',
   'diffFilter|configs|defconfig': true,
@@ -97,6 +110,8 @@ const flatObjectMinify = {
   'tf|bt': 'a',
   'tf|b': 'f',
   'tf|t': 'a',
+  's|b': 'path',
+  's|t': '-startTime',
   'tri|t': 'android',
   'tri|ch': 'hash',
   'df|c|defconfig': true,
@@ -234,7 +249,7 @@ describe('parseSearch', () => {
 
   it('Simple object with empty array', () => {
     const simpleObjectEmptyArray = { ...simpleObject, treeIndexes: [] };
-    const simpleObjectEmptyArrayStringify = '?o=maestro&i=7&x[]';
+    const simpleObjectEmptyArrayStringify = '?o=maestro&i=7&x[]&s=-status';
     expect(parseSearch(simpleObjectEmptyArrayStringify)).toStrictEqual(
       simpleObjectEmptyArray,
     );

--- a/dashboard/src/utils/search.ts
+++ b/dashboard/src/utils/search.ts
@@ -139,6 +139,7 @@ const generalMinifiedParams: Record<SearchParamsKeys, string> = {
   intervalInDays: 'i',
   currentPageTab: 'p',
   tableFilter: 'tf',
+  tableSort: 's',
   diffFilter: 'df',
   treeSearch: 'ts',
   listingSize: 'ls',
@@ -274,6 +275,8 @@ const groupedMinifiedParams = {
   general: Object.fromEntries(generalMinifiedParamsArray),
   tri: Object.fromEntries(treeInfoMinifiedParamsArray),
   tf: Object.fromEntries(tableFilterMinifiedParamsArray),
+  // Multi-table sort keys reuse the tableFilter abbreviations (b, bt, t).
+  s: Object.fromEntries(tableFilterMinifiedParamsArray),
   df: Object.fromEntries(diffFilterMinifiedParamsArray),
   value: Object.fromEntries(minifiedValuesArray),
 } as const;


### PR DESCRIPTION
## Summary

- Persist sortable table state in the URL via a shared `useSortingState` hook and root `tableSort` search param, so sort order is shareable and bookmarkable.
- Encode a single active table as flat `s=…`; use keyed params (`s|b=…`, `s|t=…`) only on pages with multiple tracked tables (issue details).
- Clear `tableSort` when switching tree/hardware details tabs so inactive tables do not keep stale sort.

## Test plan

- [ ] Sort tree, hardware, and issue listing tables; confirm the URL updates and reload/share restores the same sort
- [ ] Reset to default sort and confirm the `s` / `tableSort` param is omitted
- [ ] On tree and hardware details, sort a tab, switch tabs, and confirm sort resets for the newly active table
- [ ] On issue details, sort builds and tests independently and confirm keyed URL params (`s|b`, `s|t`)
- [ ] Confirm unit tests: `useSortingState.test.ts`, `search.test.ts`

## Related issues

- Closes #2005
- Impacts A/B comparison - #1951 et al.
- Impacts #2006