### PR TITLE
fix/e2e useragent

### DIFF
--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
   testDir: './e2e',
   use: {
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:5173',
+    userAgent: 'kci-dev',
   },
 });

--- a/dashboard/tsconfig.e2e.json
+++ b/dashboard/tsconfig.e2e.json
@@ -3,6 +3,7 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
     "skipLibCheck": false,
+    "noEmit": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## What it is

* Add `kci-dev` user-agent to allow e2e tests on anubis.
* Adds `noEmit: true` to `tsconfig.e2e.json`, to avoid generating artifacts.

## What to test
* `PLAYWRIGHT_TEST_BASE_URL=https://staging.dashboard.kernelci.org pnpm e2e` runs sucessfully.
* `pnpm typecheck` leaves `e2e/` TS-only.

Closes #2032
