### PR TITLE
fix(hardware): support cross-origin builds in revision selectors

### DIFF
--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -118,8 +118,28 @@ def get_hardware_selectors(origin: str) -> list[dict]:
         return rows
 
     params = {"origin": origin}
+    cross_origin_test_origins = {"aspeed", "ti"}
 
-    query = """
+    if origin in cross_origin_test_origins:
+        from_where = """
+            FROM tests t
+            INNER JOIN builds b ON b.id = t.build_id
+            INNER JOIN checkouts c ON c.id = b.checkout_id
+            WHERE
+                t.origin = %(origin)s
+                AND t.start_time > (NOW() - INTERVAL '30 days')
+                AND t.environment_misc ->> 'platform' IS NOT NULL
+        """
+    else:
+        from_where = """
+            FROM checkouts c
+            INNER JOIN builds b ON b.checkout_id = c.id
+            WHERE
+                b.origin = %(origin)s
+                AND b.start_time > (NOW() - INTERVAL '30 days')
+        """
+
+    query = f"""
         SELECT DISTINCT ON (
             c.tree_name,
             c.git_repository_url,
@@ -133,11 +153,7 @@ def get_hardware_selectors(origin: str) -> list[dict]:
             c.git_commit_hash,
             c.git_commit_name,
             c.start_time
-        FROM checkouts c
-        INNER JOIN builds b ON b.checkout_id = c.id
-        WHERE
-            b.origin = %(origin)s
-            AND b.start_time > (NOW() - INTERVAL '30 days')
+        {from_where}
             AND c.git_repository_url IS NOT NULL
             AND c.git_repository_branch IS NOT NULL
             AND c.git_commit_hash IS NOT NULL


### PR DESCRIPTION
## What it is

Hardware revision selectors filtered by `builds.origin`, so origins like `ti` (tests on other origins' builds) got an empty tree/branch/revision list.

For those cross-origin test origins, selectors now drive from `tests` (last 30 days, platform set) so only revisions that actually have tests for that origin appear. Other origins keep the builds-based path.

Closes #2047

## How to test

1. Open `/hardware?o=ti` — Tree / Branch / Revision selectors should appear and be non-empty.
2. Pick a revision — hardware listing should load for that selection.
3. Open `/hardware` (maestro) — selectors still work as before.