### PR TITLE
feat(issues): add next checkout after last seen

### DIFF
--- a/backend/kernelCI_app/helpers/issueExtras.py
+++ b/backend/kernelCI_app/helpers/issueExtras.py
@@ -7,6 +7,7 @@ from kernelCI_app.queries.issues import (
     get_issue_first_good_checkouts,
     get_issue_first_seen_data,
     get_issue_last_seen_data,
+    get_issue_next_checkout_data,
     get_issue_trees_data,
 )
 from kernelCI_app.typeModels.issues import (
@@ -14,6 +15,7 @@ from kernelCI_app.typeModels.issues import (
     Incident,
     IssueCheckout,
     IssueWithExtraInfo,
+    NextCheckout,
     ProcessedExtraDetailedIssues,
     TreeSeenData,
     TreeSetItem,
@@ -69,6 +71,19 @@ def _tree_key(record: dict) -> tuple:
     )
 
 
+def _next_checkout_from_record(record: dict) -> NextCheckout:
+    return NextCheckout(
+        checkout_id=record["checkout_id"],
+        start_time=record["start_time"],
+        git_commit_hash=record["git_commit_hash"],
+        git_commit_name=record["git_commit_name"],
+        git_repository_url=record["git_repository_url"],
+        git_repository_branch=record["git_repository_branch"],
+        tree_name=record["tree_name"],
+        origin=record["origin"],
+    )
+
+
 def process_issues_extra_details(
     *,
     issue_key_list: List[Tuple[str, int]],
@@ -94,7 +109,7 @@ def assign_issue_incidents(
     processed_issues_table: ProcessedExtraDetailedIssues,
 ) -> None:
     """
-    Assigns first and last seen data to the processed_issues_table
+    Assigns first/last seen and next-checkout data to the processed_issues_table
     by querying with the issue_key_list.
     """
     issue_id_set = {issue_id for issue_id, _ in issue_key_list}
@@ -103,21 +118,30 @@ def assign_issue_incidents(
     for issue_id, issue_version in issue_key_list:
         versions_per_issue[issue_id].add(issue_version)
 
-    first_incident_records = get_issue_first_seen_data(issue_id_list=list(issue_id_set))
-    last_incident_records = get_issue_last_seen_data(issue_id_list=list(issue_id_set))
+    issue_id_list = list(issue_id_set)
+    first_incident_records = get_issue_first_seen_data(issue_id_list=issue_id_list)
+    last_incident_records = get_issue_last_seen_data(issue_id_list=issue_id_list)
+    next_checkout_records = get_issue_next_checkout_data(issue_id_list=issue_id_list)
     last_incident_by_id = {
         record["issue_id"]: record for record in last_incident_records
+    }
+    next_checkout_by_id = {
+        record["issue_id"]: record for record in next_checkout_records
     }
 
     for record in first_incident_records:
         issue_id = record["issue_id"]
         last_record = last_incident_by_id.get(issue_id)
+        next_record = next_checkout_by_id.get(issue_id)
 
         processed_issue_from_id = processed_issues_table.setdefault(
             issue_id,
             ExtraIssuesData(
                 first_incident=_incident_from_record(record),
                 last_incident=_incident_from_record(last_record),
+                next_checkout=(
+                    _next_checkout_from_record(next_record) if next_record else None
+                ),
                 versions={},
             ),
         )

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -474,6 +474,81 @@ def get_issue_first_good_checkouts(
         return dict_fetchall(cursor)
 
 
+def get_issue_next_checkout_data(*, issue_id_list: list[str]) -> list[dict]:
+    """
+    For each issue, finds the next checkout after the last-seen checkout
+    on the same tree, ordered by checkout start_time.
+
+    Tree identity is (origin, tree_name, git_repository_url, git_repository_branch).
+    "Next" is the earliest checkout with start_time greater than the last-seen
+    checkout's start_time (no parent-commit hierarchy available).
+
+    Issues with no last-seen checkout, no start_time, or no later checkout
+    on that tree are omitted from the result.
+    """
+    if not issue_id_list:
+        return []
+
+    params = {"issue_id_list": issue_id_list}
+
+    query = """
+        WITH last_seen AS (
+            SELECT DISTINCT ON (IC.issue_id)
+                IC.issue_id,
+                C.id AS last_checkout_id,
+                C.start_time AS last_start_time,
+                C.origin,
+                C.tree_name,
+                C.git_repository_url,
+                C.git_repository_branch
+            FROM
+                incidents IC
+            LEFT JOIN tests T ON IC.test_id = T.id
+            LEFT JOIN builds B ON (
+                IC.build_id = B.id
+                OR T.build_id = B.id
+            )
+            LEFT JOIN checkouts C ON B.checkout_id = C.id
+            WHERE
+                IC.issue_id = ANY(%(issue_id_list)s)
+            ORDER BY
+                IC.issue_id,
+                IC.issue_version DESC,
+                IC._timestamp DESC
+        )
+        SELECT DISTINCT ON (LS.issue_id)
+            LS.issue_id,
+            C.id AS checkout_id,
+            C.start_time,
+            C.git_commit_hash,
+            C.git_commit_name,
+            C.git_repository_url,
+            C.git_repository_branch,
+            C.tree_name,
+            C.origin
+        FROM
+            last_seen LS
+            INNER JOIN checkouts C ON (
+                C.origin = LS.origin
+                AND C.tree_name IS NOT DISTINCT FROM LS.tree_name
+                AND C.git_repository_url IS NOT DISTINCT FROM LS.git_repository_url
+                AND C.git_repository_branch IS NOT DISTINCT FROM LS.git_repository_branch
+                AND C.start_time > LS.last_start_time
+            )
+        WHERE
+            LS.last_checkout_id IS NOT NULL
+            AND LS.last_start_time IS NOT NULL
+        ORDER BY
+            LS.issue_id,
+            C.start_time ASC,
+            C.id ASC
+    """
+
+    with connection.cursor() as cursor:
+        cursor.execute(query, params)
+        return dict_fetchall(cursor)
+
+
 def get_issue_trees_data(
     *, issue_key_list: list[tuple[str, int]]
 ) -> list[dict[str, Any]]:

--- a/backend/kernelCI_app/queries/issues.py
+++ b/backend/kernelCI_app/queries/issues.py
@@ -489,7 +489,11 @@ def get_issue_next_checkout_data(*, issue_id_list: list[str]) -> list[dict]:
     if not issue_id_list:
         return []
 
+    cache_key = "issue_next_checkout"
     params = {"issue_id_list": issue_id_list}
+    records = get_query_cache(key=cache_key, params=params)
+    if records is not None:
+        return records
 
     query = """
         WITH last_seen AS (
@@ -516,7 +520,7 @@ def get_issue_next_checkout_data(*, issue_id_list: list[str]) -> list[dict]:
                 IC.issue_version DESC,
                 IC._timestamp DESC
         )
-        SELECT DISTINCT ON (LS.issue_id)
+        SELECT
             LS.issue_id,
             C.id AS checkout_id,
             C.start_time,
@@ -528,25 +532,40 @@ def get_issue_next_checkout_data(*, issue_id_list: list[str]) -> list[dict]:
             C.origin
         FROM
             last_seen LS
-            INNER JOIN checkouts C ON (
-                C.origin = LS.origin
-                AND C.tree_name IS NOT DISTINCT FROM LS.tree_name
-                AND C.git_repository_url IS NOT DISTINCT FROM LS.git_repository_url
-                AND C.git_repository_branch IS NOT DISTINCT FROM LS.git_repository_branch
-                AND C.start_time > LS.last_start_time
-            )
+            CROSS JOIN LATERAL (
+                SELECT
+                    C.id,
+                    C.start_time,
+                    C.git_commit_hash,
+                    C.git_commit_name,
+                    C.git_repository_url,
+                    C.git_repository_branch,
+                    C.tree_name,
+                    C.origin
+                FROM
+                    checkouts C
+                WHERE
+                    C.origin = LS.origin
+                    AND C.tree_name IS NOT DISTINCT FROM LS.tree_name
+                    AND C.git_repository_url IS NOT DISTINCT FROM LS.git_repository_url
+                    AND C.git_repository_branch IS NOT DISTINCT FROM LS.git_repository_branch
+                    AND C.start_time > LS.last_start_time
+                ORDER BY
+                    C.start_time ASC,
+                    C.id ASC
+                LIMIT 1
+            ) C
         WHERE
             LS.last_checkout_id IS NOT NULL
             AND LS.last_start_time IS NOT NULL
-        ORDER BY
-            LS.issue_id,
-            C.start_time ASC,
-            C.id ASC
     """
 
     with connection.cursor() as cursor:
         cursor.execute(query, params)
-        return dict_fetchall(cursor)
+        records = dict_fetchall(cursor)
+
+    set_query_cache(key=cache_key, params=params, rows=records)
+    return records
 
 
 def get_issue_trees_data(

--- a/backend/kernelCI_app/tests/unitTests/helpers/issueExtras_test.py
+++ b/backend/kernelCI_app/tests/unitTests/helpers/issueExtras_test.py
@@ -53,10 +53,11 @@ class TestProcessIssuesExtraDetails:
 
 
 class TestAssignIssueFirstSeen:
+    @patch("kernelCI_app.helpers.issueExtras.get_issue_next_checkout_data")
     @patch("kernelCI_app.helpers.issueExtras.get_issue_last_seen_data")
     @patch("kernelCI_app.helpers.issueExtras.get_issue_first_seen_data")
     def test_assign_issue_first_seen_with_data(
-        self, mock_get_first_data, mock_get_last_data
+        self, mock_get_first_data, mock_get_last_data, mock_get_next_checkout
     ):
         """Test assign_issue_incidents with data."""
         mock_get_first_data.return_value = [
@@ -85,6 +86,19 @@ class TestAssignIssueFirstSeen:
                 "checkout_id": "checkout2",
             }
         ]
+        mock_get_next_checkout.return_value = [
+            {
+                "issue_id": "issue1",
+                "checkout_id": "checkout_next",
+                "start_time": "2024-06-16T10:00:00Z",
+                "git_commit_hash": "next123",
+                "git_commit_name": "commit_next",
+                "git_repository_url": TagUrls.MAINLINE_URL,
+                "git_repository_branch": "master",
+                "tree_name": "mainline",
+                "origin": "maestro",
+            }
+        ]
 
         issue_key_list = [("issue1", 1)]
         processed_issues_table = {}
@@ -95,6 +109,7 @@ class TestAssignIssueFirstSeen:
 
         mock_get_first_data.assert_called_once_with(issue_id_list=["issue1"])
         mock_get_last_data.assert_called_once_with(issue_id_list=["issue1"])
+        mock_get_next_checkout.assert_called_once_with(issue_id_list=["issue1"])
 
         assert "issue1" in processed_issues_table
         issue_data = processed_issues_table["issue1"]
@@ -104,12 +119,16 @@ class TestAssignIssueFirstSeen:
         )
         assert issue_data.first_incident.git_commit_hash == "abc123"
         assert issue_data.last_incident.git_commit_hash == "xyz789"
+        assert issue_data.next_checkout is not None
+        assert issue_data.next_checkout.checkout_id == "checkout_next"
+        assert issue_data.next_checkout.git_commit_hash == "next123"
         assert 1 in issue_data.versions
 
+    @patch("kernelCI_app.helpers.issueExtras.get_issue_next_checkout_data")
     @patch("kernelCI_app.helpers.issueExtras.get_issue_last_seen_data")
     @patch("kernelCI_app.helpers.issueExtras.get_issue_first_seen_data")
     def test_assign_issue_incidents_with_multiple_versions(
-        self, mock_get_first_data, mock_get_last_data
+        self, mock_get_first_data, mock_get_last_data, mock_get_next_checkout
     ):
         """Test assign_issue_incidents with multiple versions."""
         mock_get_first_data.return_value = [
@@ -126,6 +145,7 @@ class TestAssignIssueFirstSeen:
             }
         ]
         mock_get_last_data.return_value = mock_get_first_data.return_value
+        mock_get_next_checkout.return_value = []
 
         issue_key_list = [("issue1", 1), ("issue1", 2)]
         processed_issues_table = {}
@@ -141,15 +161,17 @@ class TestAssignIssueFirstSeen:
         )
         assert issue_data.first_incident.git_commit_hash == "abc123"
         assert issue_data.first_incident.issue_version == 1
+        assert issue_data.next_checkout is None
         assert 1 in issue_data.versions
         assert 2 in issue_data.versions
         assert issue_data.versions[1] is None
         assert issue_data.versions[2] is None
 
+    @patch("kernelCI_app.helpers.issueExtras.get_issue_next_checkout_data")
     @patch("kernelCI_app.helpers.issueExtras.get_issue_last_seen_data")
     @patch("kernelCI_app.helpers.issueExtras.get_issue_first_seen_data")
     def test_assign_issue_incidents_with_multiple_issues(
-        self, mock_get_first_data, mock_get_last_data
+        self, mock_get_first_data, mock_get_last_data, mock_get_next_checkout
     ):
         """Test assign_issue_incidents with multiple issues."""
         mock_get_first_data.return_value = [
@@ -177,6 +199,7 @@ class TestAssignIssueFirstSeen:
             },
         ]
         mock_get_last_data.return_value = mock_get_first_data.return_value
+        mock_get_next_checkout.return_value = []
 
         issue_key_list = [("issue1", 1), ("issue2", 1)]
         processed_issues_table = {}
@@ -189,14 +212,16 @@ class TestAssignIssueFirstSeen:
         assert "issue2" in processed_issues_table
         assert len(processed_issues_table) == 2
 
+    @patch("kernelCI_app.helpers.issueExtras.get_issue_next_checkout_data")
     @patch("kernelCI_app.helpers.issueExtras.get_issue_last_seen_data")
     @patch("kernelCI_app.helpers.issueExtras.get_issue_first_seen_data")
     def test_assign_issue_incidents_no_data(
-        self, mock_get_first_data, mock_get_last_data
+        self, mock_get_first_data, mock_get_last_data, mock_get_next_checkout
     ):
         """Test assign_issue_incidents with no data."""
         mock_get_first_data.return_value = []
         mock_get_last_data.return_value = []
+        mock_get_next_checkout.return_value = []
 
         issue_key_list = [("issue1", 1)]
         processed_issues_table = {}
@@ -206,6 +231,7 @@ class TestAssignIssueFirstSeen:
         )
 
         assert len(processed_issues_table) == 0
+        mock_get_next_checkout.assert_called_once_with(issue_id_list=["issue1"])
 
 
 class TestAssignIssueTrees:

--- a/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
@@ -8,6 +8,7 @@ from kernelCI_app.queries.issues import (
     get_issue_first_seen_data,
     get_issue_last_seen_data,
     get_issue_listing_data,
+    get_issue_next_checkout_data,
     get_issue_tests,
     get_issue_trees_data,
     get_latest_issue_version,
@@ -319,6 +320,80 @@ class TestGetIssueLastSeenData:
 
         assert result == []
         mock_get_cache.assert_not_called()
+
+
+class TestGetIssueNextCheckoutData:
+    @patch("kernelCI_app.queries.issues.dict_fetchall")
+    @patch("kernelCI_app.queries.issues.connection")
+    def test_get_issue_next_checkout_data_from_database(
+        self, mock_connection, mock_dict_fetchall
+    ):
+        expected_result = [
+            {
+                "issue_id": "issue",
+                "checkout_id": "checkout_next",
+                "start_time": datetime(2024, 6, 16, 10, 0, 0),
+                "git_commit_hash": "def456",
+                "git_commit_name": "v6.10",
+                "git_repository_url": "https://example.com/linux.git",
+                "git_repository_branch": "master",
+                "tree_name": "mainline",
+                "origin": "maestro",
+            }
+        ]
+        mock_dict_fetchall.return_value = expected_result
+        mock_cursor = setup_mock_cursor(mock_connection)
+
+        result = get_issue_next_checkout_data(issue_id_list=["issue"])
+
+        assert result == expected_result
+        execute_call = mock_cursor.execute.call_args
+        query = execute_call[0][0]
+        params = execute_call[0][1]
+        assert "ANY(%(issue_id_list)s)" in query
+        assert "C.start_time > LS.last_start_time" in query
+        assert "C.start_time ASC" in query
+        assert params == {"issue_id_list": ["issue"]}
+
+    @patch("kernelCI_app.queries.issues.dict_fetchall")
+    @patch("kernelCI_app.queries.issues.connection")
+    def test_get_issue_next_checkout_data_multiple_issues(
+        self, mock_connection, mock_dict_fetchall
+    ):
+        expected_result = [
+            {"issue_id": "issue_1", "checkout_id": "checkout_1"},
+            {"issue_id": "issue_2", "checkout_id": "checkout_2"},
+        ]
+        mock_dict_fetchall.return_value = expected_result
+        mock_cursor = setup_mock_cursor(mock_connection)
+
+        result = get_issue_next_checkout_data(
+            issue_id_list=["issue_1", "issue_2", "issue_3"]
+        )
+
+        assert result == expected_result
+        execute_call = mock_cursor.execute.call_args
+        params = execute_call[0][1]
+        assert params == {"issue_id_list": ["issue_1", "issue_2", "issue_3"]}
+
+    @patch("kernelCI_app.queries.issues.connection")
+    def test_get_issue_next_checkout_data_empty_list(self, mock_connection):
+        result = get_issue_next_checkout_data(issue_id_list=[])
+
+        assert result == []
+        mock_connection.cursor.assert_not_called()
+
+    @patch("kernelCI_app.queries.issues.dict_fetchall")
+    @patch("kernelCI_app.queries.issues.connection")
+    def test_get_issue_next_checkout_data_no_next_checkout(
+        self, mock_connection, mock_dict_fetchall
+    ):
+        mock_dict_fetchall.return_value = []
+        setup_mock_cursor(mock_connection)
+
+        result = get_issue_next_checkout_data(issue_id_list=["issue"])
+
+        assert result == []
 
 
 class TestGetIssueTreesData:

--- a/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
+++ b/backend/kernelCI_app/tests/unitTests/queries/issues_queries_test.py
@@ -323,11 +323,23 @@ class TestGetIssueLastSeenData:
 
 
 class TestGetIssueNextCheckoutData:
+    @patch("kernelCI_app.queries.issues.get_query_cache")
+    def test_get_issue_next_checkout_data_from_cache(self, mock_get_cache):
+        cached_data = [{"issue_id": "issue", "checkout_id": "checkout_next"}]
+        mock_get_cache.return_value = cached_data
+
+        result = get_issue_next_checkout_data(issue_id_list=["issue"])
+
+        assert result == cached_data
+
+    @patch("kernelCI_app.queries.issues.get_query_cache")
+    @patch("kernelCI_app.queries.issues.set_query_cache")
     @patch("kernelCI_app.queries.issues.dict_fetchall")
     @patch("kernelCI_app.queries.issues.connection")
     def test_get_issue_next_checkout_data_from_database(
-        self, mock_connection, mock_dict_fetchall
+        self, mock_connection, mock_dict_fetchall, mock_set_cache, mock_get_cache
     ):
+        mock_get_cache.return_value = None
         expected_result = [
             {
                 "issue_id": "issue",
@@ -353,13 +365,22 @@ class TestGetIssueNextCheckoutData:
         assert "ANY(%(issue_id_list)s)" in query
         assert "C.start_time > LS.last_start_time" in query
         assert "C.start_time ASC" in query
+        assert "CROSS JOIN LATERAL" in query
         assert params == {"issue_id_list": ["issue"]}
+        mock_set_cache.assert_called_once_with(
+            key="issue_next_checkout",
+            params={"issue_id_list": ["issue"]},
+            rows=expected_result,
+        )
 
+    @patch("kernelCI_app.queries.issues.get_query_cache")
+    @patch("kernelCI_app.queries.issues.set_query_cache")
     @patch("kernelCI_app.queries.issues.dict_fetchall")
     @patch("kernelCI_app.queries.issues.connection")
     def test_get_issue_next_checkout_data_multiple_issues(
-        self, mock_connection, mock_dict_fetchall
+        self, mock_connection, mock_dict_fetchall, mock_set_cache, mock_get_cache
     ):
+        mock_get_cache.return_value = None
         expected_result = [
             {"issue_id": "issue_1", "checkout_id": "checkout_1"},
             {"issue_id": "issue_2", "checkout_id": "checkout_2"},
@@ -376,24 +397,32 @@ class TestGetIssueNextCheckoutData:
         params = execute_call[0][1]
         assert params == {"issue_id_list": ["issue_1", "issue_2", "issue_3"]}
 
+    @patch("kernelCI_app.queries.issues.get_query_cache")
     @patch("kernelCI_app.queries.issues.connection")
-    def test_get_issue_next_checkout_data_empty_list(self, mock_connection):
+    def test_get_issue_next_checkout_data_empty_list(
+        self, mock_connection, mock_get_cache
+    ):
         result = get_issue_next_checkout_data(issue_id_list=[])
 
         assert result == []
         mock_connection.cursor.assert_not_called()
+        mock_get_cache.assert_not_called()
 
+    @patch("kernelCI_app.queries.issues.get_query_cache")
+    @patch("kernelCI_app.queries.issues.set_query_cache")
     @patch("kernelCI_app.queries.issues.dict_fetchall")
     @patch("kernelCI_app.queries.issues.connection")
     def test_get_issue_next_checkout_data_no_next_checkout(
-        self, mock_connection, mock_dict_fetchall
+        self, mock_connection, mock_dict_fetchall, mock_set_cache, mock_get_cache
     ):
+        mock_get_cache.return_value = None
         mock_dict_fetchall.return_value = []
         setup_mock_cursor(mock_connection)
 
         result = get_issue_next_checkout_data(issue_id_list=["issue"])
 
         assert result == []
+        mock_set_cache.assert_called_once()
 
 
 class TestGetIssueTreesData:

--- a/backend/kernelCI_app/typeModels/issues.py
+++ b/backend/kernelCI_app/typeModels/issues.py
@@ -9,8 +9,10 @@ from kernelCI_app.typeModels.databases import (
     Checkout__GitCommitName,
     Checkout__GitRepositoryBranch,
     Checkout__GitRepositoryUrl,
+    Checkout__StartTime,
     Checkout__TreeName,
     Issue__Version,
+    Origin,
     Timestamp,
 )
 
@@ -94,9 +96,23 @@ class TreeSeenData(BaseModel):
     first_good_checkout: Optional[IssueCheckout] = None
 
 
+class NextCheckout(BaseModel):
+    """Earliest checkout on the same tree after the last-seen checkout."""
+
+    checkout_id: Optional[str]
+    start_time: Checkout__StartTime
+    git_commit_hash: Optional[Checkout__GitCommitHash]
+    git_commit_name: Optional[Checkout__GitCommitName]
+    git_repository_url: Optional[Checkout__GitRepositoryUrl]
+    git_repository_branch: Optional[Checkout__GitRepositoryBranch]
+    tree_name: Optional[Checkout__TreeName]
+    origin: Origin
+
+
 class ExtraIssuesData(BaseModel):
     first_incident: Incident
     last_incident: Incident
+    next_checkout: Optional[NextCheckout] = None
     versions: dict[int, Optional[IssueWithExtraInfo]]
     per_tree: Optional[list[TreeSeenData]] = None
 

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -2572,6 +2572,11 @@ components:
       - type: 'null'
     Checkout__Id:
       type: string
+    Checkout__StartTime:
+      anyOf:
+      - format: date-time
+        type: string
+      - type: 'null'
     Checkout__TreeName:
       anyOf:
       - type: string
@@ -2860,6 +2865,11 @@ components:
           $ref: '#/components/schemas/Incident'
         last_incident:
           $ref: '#/components/schemas/Incident'
+        next_checkout:
+          anyOf:
+          - $ref: '#/components/schemas/NextCheckout'
+          - type: 'null'
+          default: null
         versions:
           additionalProperties:
             anyOf:
@@ -4040,6 +4050,49 @@ components:
       - prev_n_tests
       - prev_lab_maps
       title: MetricsResponse
+      type: object
+    NextCheckout:
+      description: Earliest checkout on the same tree after the last-seen checkout.
+      properties:
+        checkout_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Checkout Id
+        start_time:
+          $ref: '#/components/schemas/Checkout__StartTime'
+        git_commit_hash:
+          anyOf:
+          - $ref: '#/components/schemas/Checkout__GitCommitHash'
+          - type: 'null'
+        git_commit_name:
+          anyOf:
+          - $ref: '#/components/schemas/Checkout__GitCommitName'
+          - type: 'null'
+        git_repository_url:
+          anyOf:
+          - $ref: '#/components/schemas/Checkout__GitRepositoryUrl'
+          - type: 'null'
+        git_repository_branch:
+          anyOf:
+          - $ref: '#/components/schemas/Checkout__GitRepositoryBranch'
+          - type: 'null'
+        tree_name:
+          anyOf:
+          - $ref: '#/components/schemas/Checkout__TreeName'
+          - type: 'null'
+        origin:
+          $ref: '#/components/schemas/Origin'
+      required:
+      - checkout_id
+      - start_time
+      - git_commit_hash
+      - git_commit_name
+      - git_repository_url
+      - git_repository_branch
+      - tree_name
+      - origin
+      title: NextCheckout
       type: object
     Origin:
       type: string

--- a/dashboard/src/components/IssueDetails/IssueDetails.tsx
+++ b/dashboard/src/components/IssueDetails/IssueDetails.tsx
@@ -35,6 +35,7 @@ import { BranchBadge } from '@/components/Badge/BranchBadge';
 
 import { getLogspecSection } from '@/components/Section/LogspecSection';
 import { getIncidentsSection } from '@/components/Section/FirstIncidentSection';
+import { getNextCheckoutSection } from '@/components/Section/NextCheckoutSection';
 
 import PageWithTitle from '@/components/PageWithTitle';
 
@@ -109,6 +110,13 @@ export const IssueDetails = ({
       lastIncident: data?.extra?.[issueId]?.last_incident,
       title: formatMessage({ id: 'issueDetails.firstIncidentData' }),
       lastIncidentTitle: formatMessage({ id: 'issueDetails.lastIncident' }),
+    });
+  }, [data?.extra, formatMessage, issueId]);
+
+  const nextCheckoutSection: ISection | undefined = useMemo(() => {
+    return getNextCheckoutSection({
+      nextCheckout: data?.extra?.[issueId]?.next_checkout,
+      title: formatMessage({ id: 'issueDetails.nextCheckout' }),
     });
   }, [data?.extra, formatMessage, issueId]);
 
@@ -258,6 +266,7 @@ export const IssueDetails = ({
               <SectionGroup
                 sections={[
                   firstIncidentSection,
+                  nextCheckoutSection,
                   logspecSection,
                   miscSection,
                 ].filter(section => !!section)}

--- a/dashboard/src/components/Section/NextCheckoutSection.tsx
+++ b/dashboard/src/components/Section/NextCheckoutSection.tsx
@@ -1,0 +1,76 @@
+import { shouldTruncate, valueOrEmpty } from '@/lib/string';
+
+import type { NextCheckout } from '@/types/issueExtras';
+
+import { TooltipDateTime } from '@/components/TooltipDateTime';
+import { TruncatedValueTooltip } from '@/components/Tooltip/TruncatedValueTooltip';
+import { TreeDetailsLink } from '@/components/TreeDetailsLink/TreeDetailsLink';
+
+import type { ISection, SubsectionLink } from './Section';
+
+const getNextCheckoutInfos = (nextCheckout: NextCheckout): SubsectionLink[] => [
+  {
+    title: 'global.treeBranchHash',
+    linkText: (
+      <TreeDetailsLink
+        treeName={nextCheckout.tree_name}
+        gitBranch={nextCheckout.git_repository_branch}
+        commitHash={nextCheckout.git_commit_hash}
+        gitUrl={nextCheckout.git_repository_url}
+        commitName={nextCheckout.git_commit_name}
+        showFullLabel
+      />
+    ),
+  },
+  {
+    title: 'commonDetails.gitCommitName',
+    linkText: valueOrEmpty(nextCheckout.git_commit_name),
+  },
+  {
+    title: 'commonDetails.gitRepositoryUrl',
+    linkText: shouldTruncate(valueOrEmpty(nextCheckout.git_repository_url)) ? (
+      <TruncatedValueTooltip
+        value={nextCheckout.git_repository_url}
+        isUrl={true}
+      />
+    ) : (
+      valueOrEmpty(nextCheckout.git_repository_url)
+    ),
+    link: nextCheckout.git_repository_url,
+  },
+  {
+    title: 'global.startTime',
+    linkText: (
+      <TooltipDateTime
+        dateTime={nextCheckout.start_time ?? ''}
+        lineBreak={true}
+        showRelative={true}
+      />
+    ),
+  },
+  {
+    title: 'global.origin',
+    linkText: valueOrEmpty(nextCheckout.origin),
+  },
+];
+
+export const getNextCheckoutSection = ({
+  nextCheckout,
+  title,
+}: {
+  nextCheckout?: NextCheckout | null;
+  title: string;
+}): ISection | undefined => {
+  if (!nextCheckout) {
+    return;
+  }
+
+  return {
+    title: title,
+    subsections: [
+      {
+        infos: getNextCheckoutInfos(nextCheckout),
+      },
+    ],
+  };
+};

--- a/dashboard/src/locales/messages/index.ts
+++ b/dashboard/src/locales/messages/index.ts
@@ -268,6 +268,7 @@ export const messages = {
       'The culprit for all issues listed is code',
     'issueDetails.lastIncident': 'Last Incident Data',
     'issueDetails.logspecData': 'Logspec Data',
+    'issueDetails.nextCheckout': 'Next Checkout',
     'issueDetails.noBuildResults': 'No builds associated with this issue',
     'issueDetails.noTestResults': 'No tests associated with this issue',
     'issueDetails.notFound': 'Issue not found',

--- a/dashboard/src/types/issueExtras.ts
+++ b/dashboard/src/types/issueExtras.ts
@@ -37,10 +37,22 @@ export type TreeSeenData = {
   first_good_checkout?: Checkout;
 };
 
+export type NextCheckout = {
+  checkout_id?: string;
+  start_time?: Date;
+  git_commit_hash?: string;
+  git_commit_name?: string;
+  git_repository_url?: string;
+  git_repository_branch?: string;
+  tree_name?: string;
+  origin: string;
+};
+
 type TExtraIssuesData = {
   first_incident: Incident;
   last_incident: Incident;
   per_tree?: TreeSeenData[];
+  next_checkout?: NextCheckout | null;
   versions: Record<number, TIssueVersionData>;
 };
 


### PR DESCRIPTION
Expose the earliest later checkout on the same tree in issue extras, using start_time since parent-commit hierarchy is unavailable (#1958).

---

### Visual reference

<img width="1919" height="1200" alt="Captura_de_tela_20260817_161731" src="https://github.com/user-attachments/assets/2e43189c-16c8-4877-a2e3-3e34b92c3831" />
