### PR TITLE
fix: bust persisted query cache on deploy

### DIFF
--- a/dashboard/src/components/TopBar/TopBar.tsx
+++ b/dashboard/src/components/TopBar/TopBar.tsx
@@ -40,9 +40,11 @@ const OriginSelect = ({
     if (!originData) {
       return [];
     }
-    return isHardwarePath
-      ? originData.test_origins
-      : originData.checkout_origins;
+    return (
+      (isHardwarePath
+        ? originData.test_origins
+        : originData.checkout_origins) ?? []
+    );
   }, [originData, isHardwarePath]);
 
   const selectItems = useMemo(() => {

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -90,7 +90,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <PersistQueryClientProvider
       client={queryClient}
-      persistOptions={{ persister }}
+      persistOptions={{
+        persister,
+        buster: import.meta.env.VITE_DASHBOARD_VERSION,
+      }}
     >
       <IntlProvider
         messages={currentMessages}

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -19,14 +19,23 @@ const dashboardVersion =
   })();
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [tailwindcss(), tsconfigPaths(), react(), TanStackRouterVite()],
-  define: {
-    'import.meta.env.VITE_DASHBOARD_VERSION': JSON.stringify(dashboardVersion),
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ command }) => {
+  if (command === 'build' && !dashboardVersion) {
+    throw new Error(
+      'VITE_DASHBOARD_VERSION is unset and `git describe` failed. Set it to build.',
+    );
+  }
+
+  return {
+    plugins: [tailwindcss(), tsconfigPaths(), react(), TanStackRouterVite()],
+    define: {
+      'import.meta.env.VITE_DASHBOARD_VERSION':
+        JSON.stringify(dashboardVersion),
     },
-  },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+  };
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,7 @@ services:
             context: .
             dockerfile: ./dashboard/Dockerfile
             args:
-                DASHBOARD_VERSION: ${DASHBOARD_VERSION:-}
+                DASHBOARD_VERSION: ${DASHBOARD_VERSION:-local-dev}
         image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_REPOSITORY:-local}/dashboard-frontend:${IMAGE_TAG:-latest}
         volumes:
             - static-data:/data/static


### PR DESCRIPTION
## What it is
Fixes `/tree` crashing with `Cannot read properties of undefined (reading 'map')` when a persisted React Query cache holds an `origins` payload without `checkout_origins` / `test_origins` (#2048).
- `OriginSelect` treats missing origin lists as `[]` so `.map` cannot throw.
- Persist cache is versioned with `VITE_CACHE_BUSTER` (dashboard version, or `build-<timestamp>` if empty) so a new deploy drops stale blobs.
## How to test
Dev persist uses `sessionStorage` (prod: `localStorage`). Recover with `sessionStorage.clear()` then reload.
1. Open `/tree` and confirm the origin dropdown works.
2. Seed a mismatched origins shape and reload:
```js
sessionStorage.setItem('REACT_QUERY_OFFLINE_CACHE', JSON.stringify({
buster: '', timestamp: Date.now(),
clientState: { mutations: [], queries: [{
  queryKey: ['origins'], queryHash: '["origins"]',
  state: { data: ['maestro'], dataUpdatedAt: Date.now(), status: 'success', fetchStatus: 'idle' },
}]},
}));
location.reload();
```
Expect: no “Something went wrong!”; origins refetch; dropdown populated.
3. Reload without editing the cache: same `buster` → hydrates, no crash.

Closes #2048
