### PR TITLE
feat/split hardware summary filter

### DIFF
--- a/backend/kernelCI_app/queries/hardware.py
+++ b/backend/kernelCI_app/queries/hardware.py
@@ -452,7 +452,10 @@ def get_hardware_details_summary(
     tests_duration: Optional[tuple[Optional[int], Optional[int]]] = None,
     start_datetime: datetime,
     end_datetime: datetime,
+    per_checkout: bool = True,
 ):
+    """When `per_checkout` is False, rows are grouped by origin instead of checkout
+    id. Keep it True when issue filters are active: merging unions `known_issues`."""
 
     if builds_duration is None:
         builds_duration = (None, None)
@@ -472,6 +475,7 @@ def get_hardware_details_summary(
         "builds_duration": builds_duration,
         "boots_duration": boots_duration,
         "tests_duration": tests_duration,
+        "per_checkout": per_checkout,
     }
 
     query_rows = get_query_cache(cache_key, tests_cache_params)
@@ -479,10 +483,18 @@ def get_hardware_details_summary(
     if query_rows is not None:
         return query_rows
 
-    builds_duration_clause = get_build_duration_clause(builds_duration)
-    boots_tests_duration_clause = get_boot_test_duration_clause(
-        boots_duration, tests_duration
+    tree_columns = (
+        """,
+                 checkouts.tree_name,
+                 checkouts.git_repository_url,
+                 checkouts.git_commit_tags,
+                 checkouts.git_commit_name,
+                 checkouts.git_repository_branch,
+                 checkouts.git_commit_hash"""
+        if per_checkout
+        else ""
     )
+    checkout_group = "checkouts.id" if per_checkout else "checkouts.origin"
 
     query = """
            (SELECT
@@ -496,14 +508,7 @@ def get_hardware_details_summary(
                  builds.config_name,
                  builds.misc->>'lab' AS lab,
                  tests.environment_misc->>'platform' AS platform,
-                 tests.environment_compatible,
-                 checkouts.origin,
-                 checkouts.tree_name,
-                 checkouts.git_repository_url,
-                 checkouts.git_commit_tags,
-                 checkouts.git_commit_name,
-                 checkouts.git_repository_branch,
-                 checkouts.git_commit_hash,
+                 tests.environment_compatible{tree_columns},
                  true AS is_build,
                  false AS is_test,
                  false AS is_boot
@@ -525,8 +530,8 @@ def get_hardware_details_summary(
                 AND builds.origin = %(origin)s
                 AND builds.start_time >= %(start_date)s
                 AND builds.start_time <= %(end_date)s
-                AND (checkouts.git_commit_hash = ANY(%(commits)s)) {0}
-            GROUP BY checkouts.id, builds.status, tests.environment_compatible, compiler_arch,
+                AND (checkouts.git_commit_hash = ANY(%(commits)s)) {builds_duration_clause}
+            GROUP BY {checkout_group}, builds.status, tests.environment_compatible, compiler_arch,
                 builds.config_name, lab, platform, is_boot)
             UNION ALL
             (SELECT
@@ -540,8 +545,136 @@ def get_hardware_details_summary(
                  builds.config_name,
                  tests.misc->>'runtime' AS lab,
                  tests.environment_misc->>'platform' AS platform,
-                 tests.environment_compatible,
+                 tests.environment_compatible{tree_columns},
+                 false AS is_build,
+                 true AS is_test,
+                 (tests.path like 'boot.%%' or tests.path = 'boot') AS is_boot
+             FROM
+                builds
+            INNER JOIN tests ON
+                tests.build_id = builds.id
+            INNER JOIN checkouts ON
+                builds.checkout_id = checkouts.id
+            LEFT OUTER JOIN incidents ON
+                tests.id = incidents.test_id
+            WHERE
+                (
+                    (tests.environment_compatible @> ARRAY[%(platform)s]::TEXT[]
+                    OR tests.environment_misc ->> 'platform' = %(platform)s)
+                )
+                AND tests.origin = %(origin)s
+                AND tests.start_time >= %(start_date)s
+                AND tests.start_time <= %(end_date)s
+                AND (checkouts.git_commit_hash = ANY(%(commits)s)) {boots_tests_duration_clause}
+            GROUP BY {checkout_group}, tests.status, tests.environment_compatible, compiler_arch,
+                builds.config_name, lab, platform, is_boot);
+    """.format(
+        tree_columns=tree_columns,
+        checkout_group=checkout_group,
+        builds_duration_clause=get_build_duration_clause(builds_duration),
+        boots_tests_duration_clause=get_boot_test_duration_clause(
+            boots_duration, tests_duration
+        ),
+    )
+
+    build_duration_min, build_duration_max = builds_duration
+    boot_duration_min, boot_duration_max = boots_duration
+    test_duration_min, test_duration_max = tests_duration
+
+    params = {
+        "platform": hardware_id,
+        "origin": origin,
+        "start_date": start_datetime,
+        "end_date": end_datetime,
+        "commits": commit_hashes,
+        "build_duration_min": build_duration_min,
+        "build_duration_max": build_duration_max,
+        "boot_duration_min": boot_duration_min,
+        "boot_duration_max": boot_duration_max,
+        "test_duration_min": test_duration_min,
+        "test_duration_max": test_duration_max,
+    }
+
+    with connection.cursor() as cursor:
+        cursor.execute(query, params)
+        query_rows = dict_fetchall(cursor)
+        set_query_cache(key=cache_key, params=tests_cache_params, rows=query_rows)
+        return query_rows
+
+
+def get_hardware_details_common(
+    *,
+    hardware_id: str,
+    origin: str,
+    commit_hashes: list[str],
+    start_datetime: datetime,
+    end_datetime: datetime,
+):
+    cache_key = "hardwareDetailsCommon"
+    cache_params = {
+        "hardware_id": hardware_id,
+        "origin": origin,
+        "commit_hashes": commit_hashes,
+        "start_date": start_datetime.timestamp(),
+        "end_date": end_datetime.timestamp(),
+    }
+
+    query_rows = get_query_cache(cache_key, cache_params)
+    if query_rows is not None:
+        return query_rows
+
+    # Group by tree identity rather than checkouts.id: aggregate_common merges rows
+    # by (tree_name, url, branch, commit_hash) anyway, and grouping on checkouts.id
+    # drives the planner into a per-checkout nested loop over the platform test
+    # index. Grouping on the tree columns keeps a single hash join.
+    tree_group = """checkouts.tree_name,
+                checkouts.git_repository_url,
+                checkouts.git_commit_tags,
+                checkouts.git_commit_name,
+                checkouts.git_repository_branch,
+                checkouts.git_commit_hash,
+                checkouts.origin"""
+
+    query = """
+           (SELECT
+                 COUNT(DISTINCT builds.id) AS count,
                  checkouts.origin,
+                 builds.status AS status,
+                 tests.environment_compatible,
+                 checkouts.tree_name,
+                 checkouts.git_repository_url,
+                 checkouts.git_commit_tags,
+                 checkouts.git_commit_name,
+                 checkouts.git_repository_branch,
+                 checkouts.git_commit_hash,
+                 true AS is_build,
+                 false AS is_test,
+                 false AS is_boot
+             FROM
+                builds
+            INNER JOIN tests ON
+                tests.build_id = builds.id
+            INNER JOIN checkouts ON
+                builds.checkout_id = checkouts.id
+            WHERE
+                (
+                    builds.config_name IS NOT NULL
+                    AND builds.id not like 'maestro:dummy_%%'
+                    AND (tests.environment_compatible @> ARRAY[%(platform)s]::TEXT[]
+                    OR tests.environment_misc ->> 'platform' = %(platform)s)
+                )
+                AND builds.origin = %(origin)s
+                AND builds.start_time >= %(start_date)s
+                AND builds.start_time <= %(end_date)s
+                AND (checkouts.git_commit_hash = ANY(%(commits)s))
+            GROUP BY {tree_group}, builds.status, tests.environment_compatible,
+                tests.environment_misc->>'platform')
+            UNION ALL
+            (SELECT
+                 COUNT(*) AS count,
+                 checkouts.origin,
+                 tests.status AS status,
+                 tests.environment_compatible,
                  checkouts.tree_name,
                  checkouts.git_repository_url,
                  checkouts.git_commit_tags,
@@ -567,17 +700,10 @@ def get_hardware_details_summary(
                 AND tests.origin = %(origin)s
                 AND tests.start_time >= %(start_date)s
                 AND tests.start_time <= %(end_date)s
-                AND (checkouts.git_commit_hash = ANY(%(commits)s)) {1}
-            GROUP BY checkouts.id, tests.status, tests.environment_compatible, compiler_arch,
-                builds.config_name, lab, platform, is_boot);
-    """.format(
-        builds_duration_clause,
-        boots_tests_duration_clause,
-    )
-
-    build_duration_min, build_duration_max = builds_duration
-    boot_duration_min, boot_duration_max = boots_duration
-    test_duration_min, test_duration_max = tests_duration
+                AND (checkouts.git_commit_hash = ANY(%(commits)s))
+            GROUP BY {tree_group}, tests.status, tests.environment_compatible,
+                (tests.path like 'boot.%%' or tests.path = 'boot'));
+    """.format(tree_group=tree_group)
 
     params = {
         "platform": hardware_id,
@@ -585,18 +711,12 @@ def get_hardware_details_summary(
         "start_date": start_datetime,
         "end_date": end_datetime,
         "commits": commit_hashes,
-        "build_duration_min": build_duration_min,
-        "build_duration_max": build_duration_max,
-        "boot_duration_min": boot_duration_min,
-        "boot_duration_max": boot_duration_max,
-        "test_duration_min": test_duration_min,
-        "test_duration_max": test_duration_max,
     }
 
     with connection.cursor() as cursor:
         cursor.execute(query, params)
         query_rows = dict_fetchall(cursor)
-        set_query_cache(key=cache_key, params=tests_cache_params, rows=query_rows)
+        set_query_cache(key=cache_key, params=cache_params, rows=query_rows)
         return query_rows
 
 
@@ -805,6 +925,22 @@ def get_hardware_trees_head_commits(
         -- Selects the data of the latest checkout of all trees in the given period
         tree_heads AS (
             {tree_head_clause}
+        ),
+        -- Reduced to distinct checkouts before joining the heads: joining `tests`
+        -- directly makes the planner probe the platform index once per build
+        -- instead of hash-joining the heads.
+        hardware_checkouts AS (
+            SELECT DISTINCT
+                builds.checkout_id AS id
+            FROM
+                tests
+                INNER JOIN builds ON tests.build_id = builds.id
+            WHERE
+                (
+                    tests.environment_compatible @> ARRAY[%(hardware)s]::TEXT[]
+                    OR tests.environment_misc ->> 'platform' = %(hardware)s
+                )
+                AND tests.origin = %(origin)s
         )
     SELECT DISTINCT
         ON (
@@ -815,19 +951,11 @@ def get_hardware_trees_head_commits(
         ) TH.tree_name,
         TH.git_commit_hash
     FROM
-        tests
-        INNER JOIN builds ON tests.build_id = builds.id
-        INNER JOIN tree_heads TH ON builds.checkout_id = TH.id
+        tree_heads TH
+        INNER JOIN hardware_checkouts HC ON HC.id = TH.id
     WHERE
-        (
-            (
-                tests.environment_compatible @> ARRAY[%(hardware)s]::TEXT[]
-                OR tests.environment_misc ->> 'platform' = %(hardware)s
-            )
-            AND tests.origin = %(origin)s
-            AND TH.start_time >= %(start_date)s
-            AND TH.start_time <= %(end_date)s
-        )
+        TH.start_time >= %(start_date)s
+        AND TH.start_time <= %(end_date)s
     ORDER BY
         TH.tree_name ASC,
         TH.git_repository_branch ASC,
@@ -883,6 +1011,21 @@ def get_hardware_trees_data(
             -- Selects the data of the latest checkout of all trees in the given period
             tree_heads AS (
                 {tree_head_clause}
+            ),
+            -- See get_hardware_trees_head_commits: narrowing to distinct checkouts
+            -- first keeps this a hash join instead of a per-build nested loop.
+            hardware_checkouts AS (
+                SELECT DISTINCT
+                    builds.checkout_id AS id
+                FROM
+                    tests
+                    INNER JOIN builds ON tests.build_id = builds.id
+                WHERE
+                    (
+                        tests.environment_compatible @> ARRAY[%(hardware)s]::TEXT[]
+                        OR tests.environment_misc ->> 'platform' = %(hardware)s
+                    )
+                    AND tests.origin = %(origin)s
             )
         SELECT DISTINCT
             ON (
@@ -898,19 +1041,11 @@ def get_hardware_trees_data(
             TH.git_commit_hash,
             TH.git_commit_tags
         FROM
-            tests
-            INNER JOIN builds ON tests.build_id = builds.id
-            INNER JOIN tree_heads TH ON builds.checkout_id = TH.id
+            tree_heads TH
+            INNER JOIN hardware_checkouts HC ON HC.id = TH.id
         WHERE
-            (
-                (
-                    tests.environment_compatible @> ARRAY[%(hardware)s]::TEXT[]
-                    OR tests.environment_misc ->> 'platform' = %(hardware)s
-                )
-                AND tests.origin = %(origin)s
-                AND TH.start_time >= %(start_date)s
-                AND TH.start_time <= %(end_date)s
-            )
+            TH.start_time >= %(start_date)s
+            AND TH.start_time <= %(end_date)s
         ORDER BY
             TH.tree_name ASC,
             TH.git_repository_branch ASC,

--- a/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsSplitViews_test.py
+++ b/backend/kernelCI_app/tests/unitTests/views/hardwareDetailsSplitViews_test.py
@@ -1,0 +1,225 @@
+import json
+from http import HTTPStatus
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from rest_framework.test import APIRequestFactory
+
+from kernelCI_app.constants.localization import ClientStrings
+from kernelCI_app.views.hardwareDetailsSummaryView import (
+    HardwareDetailsCommonView,
+    HardwareDetailsFiltersView,
+    HardwareDetailsSummary,
+    HardwareDetailsSummaryDataView,
+)
+
+SUMMARY_ROW = {
+    "status": "PASS",
+    "count": 1,
+    "incidents_count": 0,
+    "known_issues": [],
+    "environment_compatible": ["test_hardware"],
+    "config_name": "defconfig",
+    "origin": "maestro",
+    "lab": "lab1",
+    "platform": "plat",
+    "is_build": True,
+    "is_test": False,
+    "is_boot": False,
+    "compiler_arch": ["gcc", "x86_64"],
+    "tree_name": "mainline",
+    "git_repository_url": "https://git.kernel.org",
+    "git_repository_branch": "master",
+    "git_commit_name": "v6.0",
+    "git_commit_hash": "abc123",
+    "git_commit_tags": ["v6.0"],
+}
+
+BODY = {
+    "origin": "maestro",
+    "startTimestampInSeconds": 1737487800,
+    "endTimestampInSeconds": 1737574200,
+    "selectedCommits": {},
+}
+
+QUERY_PATCH = (
+    "kernelCI_app.views.hardwareDetailsSummaryView.get_hardware_details_summary"
+)
+COMMON_QUERY_PATCH = (
+    "kernelCI_app.views.hardwareDetailsSummaryView.get_hardware_details_common"
+)
+HEADS_PATCH = (
+    "kernelCI_app.views.hardwareDetailsSummaryView.get_hardware_trees_head_commits"
+)
+
+
+class TestHardwareDetailsSplitViews(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.hardware_id = "test_hardware"
+
+    def _post(self, view, url):
+        request = self.factory.post(
+            url,
+            data=json.dumps(BODY),
+            content_type="application/json",
+        )
+        return view.post(request, hardware_id=self.hardware_id)
+
+    @patch(QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_summary_data_returns_summary_only(self, mock_heads, mock_query):
+        mock_heads.return_value = [("0", "abc123")]
+        mock_query.return_value = [SUMMARY_ROW]
+        response = self._post(
+            HardwareDetailsSummaryDataView(),
+            "/hardware/test_hardware/summary-data",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIn("summary", response.data)
+        self.assertNotIn("common", response.data)
+        self.assertNotIn("filters", response.data)
+        mock_query.assert_called_once()
+
+    @patch(QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_filters_returns_filters_only(self, mock_heads, mock_query):
+        mock_heads.return_value = [("0", "abc123")]
+        mock_query.return_value = [SUMMARY_ROW]
+        response = self._post(
+            HardwareDetailsFiltersView(),
+            "/hardware/test_hardware/filters",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIn("filters", response.data)
+        self.assertNotIn("summary", response.data)
+        self.assertNotIn("common", response.data)
+        mock_query.assert_called_once()
+
+    @patch(COMMON_QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_common_returns_common_only(self, mock_heads, mock_query):
+        mock_heads.return_value = [("0", "abc123")]
+        mock_query.return_value = [SUMMARY_ROW]
+        response = self._post(
+            HardwareDetailsCommonView(),
+            "/hardware/test_hardware/common",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIn("common", response.data)
+        trees = response.data["common"]["trees"]
+        self.assertEqual(trees[0]["head_git_commit_hash"], "abc123")
+        self.assertNotIn("summary", response.data)
+        self.assertNotIn("filters", response.data)
+        mock_query.assert_called_once()
+
+    @patch(HEADS_PATCH)
+    def test_no_commits(self, mock_heads):
+        mock_heads.return_value = []
+        response = self._post(
+            HardwareDetailsFiltersView(),
+            "/hardware/test_hardware/filters",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.data["error"], ClientStrings.HARDWARE_NO_COMMITS)
+
+    @patch(COMMON_QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_not_found(self, mock_heads, mock_query):
+        mock_heads.return_value = [("0", "abc123")]
+        mock_query.return_value = []
+        response = self._post(
+            HardwareDetailsCommonView(),
+            "/hardware/test_hardware/common",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.data["error"], ClientStrings.HARDWARE_NOT_FOUND)
+
+
+class TestHardwareDetailsSummarySkipTwinQuery(SimpleTestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.hardware_id = "test_hardware"
+        self.heads = [("0", "abc123"), ("1", "def456")]
+
+    def _post(self, body):
+        request = self.factory.post(
+            "/hardware/test_hardware/summary",
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+        return HardwareDetailsSummary().post(request, hardware_id=self.hardware_id)
+
+    def _body(self, **overrides):
+        body = dict(BODY)
+        body.update(overrides)
+        return body
+
+    @patch(COMMON_QUERY_PATCH)
+    @patch(QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_python_filter_reuses_summary_query(
+        self, mock_heads, mock_query, mock_common
+    ):
+        mock_heads.return_value = self.heads
+        mock_query.return_value = [SUMMARY_ROW]
+        mock_common.return_value = [SUMMARY_ROW]
+        response = self._post(self._body(filter={"filter_boot.status": "FAIL"}))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        mock_query.assert_called_once()
+
+    @patch(COMMON_QUERY_PATCH)
+    @patch(QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_all_head_selected_commits_reuses_summary_query(
+        self, mock_heads, mock_query, mock_common
+    ):
+        mock_heads.return_value = self.heads
+        mock_query.return_value = [SUMMARY_ROW]
+        mock_common.return_value = [SUMMARY_ROW]
+        response = self._post(self._body(selectedCommits={"0": "head", "1": "head"}))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        mock_query.assert_called_once()
+
+    @patch(COMMON_QUERY_PATCH)
+    @patch(QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_non_head_commit_runs_second_query(
+        self, mock_heads, mock_query, mock_common
+    ):
+        mock_heads.return_value = self.heads
+        mock_query.return_value = [SUMMARY_ROW]
+        mock_common.return_value = [SUMMARY_ROW]
+        response = self._post(
+            self._body(selectedCommits={"0": "deadbeef", "1": "head"})
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(mock_query.call_count, 2)
+
+    @patch(COMMON_QUERY_PATCH)
+    @patch(QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_partial_tree_selection_runs_second_query(
+        self, mock_heads, mock_query, mock_common
+    ):
+        mock_heads.return_value = self.heads
+        mock_query.return_value = [SUMMARY_ROW]
+        mock_common.return_value = [SUMMARY_ROW]
+        response = self._post(self._body(selectedCommits={"0": "head"}))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(mock_query.call_count, 2)
+
+    @patch(COMMON_QUERY_PATCH)
+    @patch(QUERY_PATCH)
+    @patch(HEADS_PATCH)
+    def test_duration_filter_runs_second_query(
+        self, mock_heads, mock_query, mock_common
+    ):
+        mock_heads.return_value = self.heads
+        mock_query.return_value = [SUMMARY_ROW]
+        mock_common.return_value = [SUMMARY_ROW]
+        response = self._post(
+            self._body(filter={"filter_boot.duration_[lte]": ["100"]})
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(mock_query.call_count, 2)

--- a/backend/kernelCI_app/tests/utils/client/hardwareClient.py
+++ b/backend/kernelCI_app/tests/utils/client/hardwareClient.py
@@ -47,6 +47,38 @@ class HardwareClient(BaseClient):
         url = self.get_endpoint(path=path)
         return requests.post(url, data=json.dumps(body.model_dump()))
 
+    def post_hardware_details_summary_data(
+        self,
+        *,
+        hardware_id: str,
+        body: HardwareDetailsPostBody,
+    ) -> requests.Response:
+        path = reverse(
+            "hardwareDetailsSummaryData", kwargs={"hardware_id": hardware_id}
+        )
+        url = self.get_endpoint(path=path)
+        return requests.post(url, data=json.dumps(body.model_dump()))
+
+    def post_hardware_details_filters(
+        self,
+        *,
+        hardware_id: str,
+        body: HardwareDetailsPostBody,
+    ) -> requests.Response:
+        path = reverse("hardwareDetailsFilters", kwargs={"hardware_id": hardware_id})
+        url = self.get_endpoint(path=path)
+        return requests.post(url, data=json.dumps(body.model_dump()))
+
+    def post_hardware_details_common(
+        self,
+        *,
+        hardware_id: str,
+        body: HardwareDetailsPostBody,
+    ) -> requests.Response:
+        path = reverse("hardwareDetailsCommon", kwargs={"hardware_id": hardware_id})
+        url = self.get_endpoint(path=path)
+        return requests.post(url, data=json.dumps(body.model_dump()))
+
     def post_hardware_details_full(
         self,
         *,

--- a/backend/kernelCI_app/typeModels/hardwareDetails.py
+++ b/backend/kernelCI_app/typeModels/hardwareDetails.py
@@ -133,6 +133,18 @@ class HardwareDetailsSummaryResponse(BaseModel):
     common: HardwareCommon
 
 
+class HardwareDetailsSummaryDataResponse(BaseModel):
+    summary: Summary
+
+
+class HardwareDetailsFiltersResponse(BaseModel):
+    filters: HardwareDetailsFilters
+
+
+class HardwareDetailsCommonResponse(BaseModel):
+    common: HardwareCommon
+
+
 class HardwareDetailsBuildsResponse(BaseModel):
     builds: List[HardwareBuildHistoryItem]
 

--- a/backend/kernelCI_app/urls.py
+++ b/backend/kernelCI_app/urls.py
@@ -162,6 +162,21 @@ urlpatterns = [
         name="hardwareDetailsSummary",
     ),
     path(
+        "hardware/<str:hardware_id>/summary-data",
+        views.HardwareDetailsSummaryDataView.as_view(),
+        name="hardwareDetailsSummaryData",
+    ),
+    path(
+        "hardware/<str:hardware_id>/filters",
+        views.HardwareDetailsFiltersView.as_view(),
+        name="hardwareDetailsFilters",
+    ),
+    path(
+        "hardware/<str:hardware_id>/common",
+        views.HardwareDetailsCommonView.as_view(),
+        name="hardwareDetailsCommon",
+    ),
+    path(
         "hardware/<str:hardware_id>/tests",
         views.HardwareDetailsTests.as_view(),
         name="hardwareDetailsTests",

--- a/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
+++ b/backend/kernelCI_app/views/hardwareDetailsSummaryView.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from kernelCI_app.constants.general import UNKNOWN_STRING
+from kernelCI_app.constants.hardwareDetails import SELECTED_HEAD_TREE_VALUE
 from kernelCI_app.constants.localization import ClientStrings
 from kernelCI_app.helpers.errorHandling import create_api_error_response
 from kernelCI_app.helpers.filters import (
@@ -27,6 +28,7 @@ from kernelCI_app.helpers.hardwareDetails import (
 )
 from kernelCI_app.helpers.issueExtras import parse_issue
 from kernelCI_app.queries.hardware import (
+    get_hardware_details_common,
     get_hardware_details_summary,
     get_hardware_trees_head_commits,
 )
@@ -45,8 +47,11 @@ from kernelCI_app.typeModels.commonOpenApiParameters import (
 )
 from kernelCI_app.typeModels.hardwareDetails import (
     HardwareCommon,
+    HardwareDetailsCommonResponse,
     HardwareDetailsFilters,
+    HardwareDetailsFiltersResponse,
     HardwareDetailsPostBody,
+    HardwareDetailsSummaryDataResponse,
     HardwareDetailsSummaryResponse,
     HardwareTestLocalFilters,
     Tree,
@@ -522,6 +527,138 @@ class HardwareDetailsSummary(APIView):
             status_code=status_code,
         )
 
+    def _prepare(
+        self, request, hardware_id: str
+    ) -> tuple[Optional[list], Optional[Response]]:
+        validation_error = self._validate_request(request)
+        if validation_error:
+            return None, validation_error
+
+        tree_heads = get_hardware_trees_head_commits(
+            hardware_id=hardware_id,
+            origin=self.origin,
+            start_datetime=self.start_datetime,
+            end_datetime=self.end_datetime,
+        )
+        if not tree_heads:
+            return None, self._get_error_response(ClientStrings.HARDWARE_NO_COMMITS)
+        return tree_heads, None
+
+    def _get_filtered_rows(self, hardware_id: str, tree_heads) -> list[dict]:
+        filters: FilterParams = self.filters
+        selected_commit_hashes = self.select_commits_hashes(
+            tree_heads, self.selected_commits
+        )
+        return get_hardware_details_summary(
+            hardware_id=hardware_id,
+            origin=self.origin,
+            commit_hashes=selected_commit_hashes,
+            start_datetime=self.start_datetime,
+            end_datetime=self.end_datetime,
+            builds_duration=(
+                filters.filterBuildDurationMin,
+                filters.filterBuildDurationMax,
+            ),
+            boots_duration=(
+                filters.filterBootDurationMin,
+                filters.filterBootDurationMax,
+            ),
+            tests_duration=(
+                filters.filterTestDurationMin,
+                filters.filterTestDurationMax,
+            ),
+            per_checkout=self._needs_per_checkout_rows(),
+        )
+
+    def _needs_per_checkout_rows(self) -> bool:
+        """Merging rows across checkouts unions their `known_issues`, so an issue
+        filter would keep counts that belong to the merged-away sub-groups."""
+        return any(self.filters.filterIssues.values())
+
+    def _has_sql_duration_filter(self) -> bool:
+        filters: FilterParams = self.filters
+        return any(
+            duration is not None
+            for duration in (
+                filters.filterBuildDurationMin,
+                filters.filterBuildDurationMax,
+                filters.filterBootDurationMin,
+                filters.filterBootDurationMax,
+                filters.filterTestDurationMin,
+                filters.filterTestDurationMax,
+            )
+        )
+
+    def _filtered_sql_matches_heads(self, tree_heads) -> bool:
+        if self._has_sql_duration_filter():
+            return False
+        selected = self.selected_commits or {}
+        if not selected:
+            return True
+        if len(selected) != len(tree_heads):
+            return False
+        for idx, head in tree_heads:
+            commit = selected.get(idx)
+            if commit is None:
+                return False
+            if commit != SELECTED_HEAD_TREE_VALUE and commit != head:
+                return False
+        return True
+
+    def _get_unfiltered_rows(
+        self,
+        hardware_id: str,
+        tree_heads,
+        filtered_rows: Optional[list[dict]] = None,
+    ) -> list[dict]:
+        if filtered_rows is not None and self._filtered_sql_matches_heads(tree_heads):
+            return filtered_rows
+        head_commit_hashes = self.select_commits_hashes(tree_heads)
+        return get_hardware_details_summary(
+            hardware_id=hardware_id,
+            origin=self.origin,
+            commit_hashes=head_commit_hashes,
+            start_datetime=self.start_datetime,
+            end_datetime=self.end_datetime,
+            per_checkout=self._needs_per_checkout_rows(),
+        )
+
+    def _get_common_rows(self, hardware_id: str, tree_heads) -> list[dict]:
+        head_commit_hashes = self.select_commits_hashes(tree_heads)
+        return get_hardware_details_common(
+            hardware_id=hardware_id,
+            origin=self.origin,
+            commit_hashes=head_commit_hashes,
+            start_datetime=self.start_datetime,
+            end_datetime=self.end_datetime,
+        )
+
+    def _build_summary(self, rows: list[dict], hardware_id: str) -> Summary:
+        builds_summary, boots_summary, tests_summary = self.aggregate_summaries(
+            rows, hardware_id
+        )
+        return Summary(builds=builds_summary, boots=boots_summary, tests=tests_summary)
+
+    def _build_common(self, rows: list[dict], hardware_id: str) -> HardwareCommon:
+        all_trees, all_compatibles = self.aggregate_common(rows, hardware_id)
+        return HardwareCommon(trees=all_trees, compatibles=all_compatibles)
+
+    def _build_filters(
+        self, rows: list[dict], hardware_id: str
+    ) -> HardwareDetailsFilters:
+        all_filters, builds_filters, boots_filters, tests_filters = (
+            self.aggregate_filters(
+                *self.aggregate_summaries(rows, hardware_id),
+                hardware_id,
+            )
+        )
+        return HardwareDetailsFilters(
+            all=all_filters,
+            builds=builds_filters,
+            boots=boots_filters,
+            tests=tests_filters,
+        )
+
     @extend_schema(
         parameters=[HARDWARE_ID_PATH_PARAM],
         responses=HardwareDetailsSummaryResponse,
@@ -529,92 +666,97 @@ class HardwareDetailsSummary(APIView):
         methods=["POST"],
     )
     def post(self, request, hardware_id) -> Response:
-        validation_error = self._validate_request(request)
-        if validation_error:
-            return validation_error
+        tree_heads, error_response = self._prepare(request, hardware_id)
+        if error_response:
+            return error_response
 
         try:
-            tree_heads = get_hardware_trees_head_commits(
-                hardware_id=hardware_id,
-                origin=self.origin,
-                start_datetime=self.start_datetime,
-                end_datetime=self.end_datetime,
-            )
-
-            if not tree_heads:
-                return self._get_error_response(ClientStrings.HARDWARE_NO_COMMITS)
-
-            filters: FilterParams = self.filters
-
-            selected_commit_hashes = self.select_commits_hashes(
-                tree_heads, self.selected_commits
-            )
-
-            summary: list[dict] = get_hardware_details_summary(
-                hardware_id=hardware_id,
-                origin=self.origin,
-                commit_hashes=selected_commit_hashes,
-                start_datetime=self.start_datetime,
-                end_datetime=self.end_datetime,
-                builds_duration=(
-                    filters.filterBuildDurationMin,
-                    filters.filterBuildDurationMax,
-                ),
-                boots_duration=(
-                    filters.filterBootDurationMin,
-                    filters.filterBootDurationMax,
-                ),
-                tests_duration=(
-                    filters.filterTestDurationMin,
-                    filters.filterTestDurationMax,
-                ),
-            )
-
-            if not summary:
+            summary_rows = self._get_filtered_rows(hardware_id, tree_heads)
+            if not summary_rows:
                 return self._get_error_response(ClientStrings.HARDWARE_NOT_FOUND)
 
-            # TODO: necessary due to the fact we return filter info,
-            # a dedicated endpoint for filters is important
-            if filters.filters or self.selected_commits:
-                head_commit_hashes = self.select_commits_hashes(tree_heads)
-                unfiltered_summary = get_hardware_details_summary(
-                    hardware_id=hardware_id,
-                    origin=self.origin,
-                    commit_hashes=head_commit_hashes,
-                    start_datetime=self.start_datetime,
-                    end_datetime=self.end_datetime,
-                )
-            else:
-                unfiltered_summary = summary
-
-            builds_summary, boots_summary, tests_summary = self.aggregate_summaries(
-                summary, hardware_id
+            unfiltered_rows = self._get_unfiltered_rows(
+                hardware_id, tree_heads, summary_rows
             )
-            all_trees, all_compatibles = self.aggregate_common(
-                unfiltered_summary, hardware_id
-            )
-            all_filters, builds_filters, boots_filters, tests_filters = (
-                self.aggregate_filters(
-                    *self.aggregate_summaries(unfiltered_summary, hardware_id),
-                    hardware_id,
-                )
-            )
-
-            summary = Summary(
-                builds=builds_summary, boots=boots_summary, tests=tests_summary
-            )
-            commons = HardwareCommon(trees=all_trees, compatibles=all_compatibles)
-            filters = HardwareDetailsFilters(
-                all=all_filters,
-                builds=builds_filters,
-                boots=boots_filters,
-                tests=tests_filters,
-            )
-
+            common_rows = self._get_common_rows(hardware_id, tree_heads)
             valid_response = HardwareDetailsSummaryResponse(
-                summary=summary, filters=filters, common=commons
+                summary=self._build_summary(summary_rows, hardware_id),
+                filters=self._build_filters(unfiltered_rows, hardware_id),
+                common=self._build_common(common_rows, hardware_id),
             )
+            return Response(valid_response.model_dump())
+        except ValidationError as e:
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
+
+class HardwareDetailsSummaryDataView(HardwareDetailsSummary):
+    @extend_schema(
+        parameters=[HARDWARE_ID_PATH_PARAM],
+        responses=HardwareDetailsSummaryDataResponse,
+        request=HardwareDetailsPostBody,
+        methods=["POST"],
+    )
+    def post(self, request, hardware_id) -> Response:
+        tree_heads, error_response = self._prepare(request, hardware_id)
+        if error_response:
+            return error_response
+
+        try:
+            summary_rows = self._get_filtered_rows(hardware_id, tree_heads)
+            if not summary_rows:
+                return self._get_error_response(ClientStrings.HARDWARE_NOT_FOUND)
+
+            valid_response = HardwareDetailsSummaryDataResponse(
+                summary=self._build_summary(summary_rows, hardware_id),
+            )
+            return Response(valid_response.model_dump())
+        except ValidationError as e:
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+
+class HardwareDetailsFiltersView(HardwareDetailsSummary):
+    @extend_schema(
+        parameters=[HARDWARE_ID_PATH_PARAM],
+        responses=HardwareDetailsFiltersResponse,
+        request=HardwareDetailsPostBody,
+        methods=["POST"],
+    )
+    def post(self, request, hardware_id) -> Response:
+        tree_heads, error_response = self._prepare(request, hardware_id)
+        if error_response:
+            return error_response
+
+        try:
+            unfiltered_rows = self._get_unfiltered_rows(hardware_id, tree_heads)
+            if not unfiltered_rows:
+                return self._get_error_response(ClientStrings.HARDWARE_NOT_FOUND)
+            valid_response = HardwareDetailsFiltersResponse(
+                filters=self._build_filters(unfiltered_rows, hardware_id)
+            )
+            return Response(valid_response.model_dump())
+        except ValidationError as e:
+            return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+
+class HardwareDetailsCommonView(HardwareDetailsSummary):
+    @extend_schema(
+        parameters=[HARDWARE_ID_PATH_PARAM],
+        responses=HardwareDetailsCommonResponse,
+        request=HardwareDetailsPostBody,
+        methods=["POST"],
+    )
+    def post(self, request, hardware_id) -> Response:
+        tree_heads, error_response = self._prepare(request, hardware_id)
+        if error_response:
+            return error_response
+
+        try:
+            common_rows = self._get_common_rows(hardware_id, tree_heads)
+            if not common_rows:
+                return self._get_error_response(ClientStrings.HARDWARE_NOT_FOUND)
+            valid_response = HardwareDetailsCommonResponse(
+                common=self._build_common(common_rows, hardware_id)
+            )
             return Response(valid_response.model_dump())
         except ValidationError as e:
             return Response(data=e.json(), status=HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/backend/schema.yml
+++ b/backend/schema.yml
@@ -321,6 +321,76 @@ paths:
               schema:
                 $ref: '#/components/schemas/HardwareCommitHistoryResponse'
           description: ''
+  /api/hardware/{hardware_id}/common:
+    post:
+      operationId: hardware_common_create
+      parameters:
+      - in: path
+        name: hardware_id
+        schema:
+          type: string
+        description: ID of the hardware, as the name of the platform/compatible
+        required: true
+      tags:
+      - hardware
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+        required: true
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HardwareDetailsCommonResponse'
+          description: ''
+  /api/hardware/{hardware_id}/filters:
+    post:
+      operationId: hardware_filters_create
+      parameters:
+      - in: path
+        name: hardware_id
+        schema:
+          type: string
+        description: ID of the hardware, as the name of the platform/compatible
+        required: true
+      tags:
+      - hardware
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+        required: true
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HardwareDetailsFiltersResponse'
+          description: ''
   /api/hardware/{hardware_id}/summary:
     post:
       operationId: hardware_summary_create
@@ -355,6 +425,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HardwareDetailsSummaryResponse'
+          description: ''
+  /api/hardware/{hardware_id}/summary-data:
+    post:
+      operationId: hardware_summary_data_create
+      parameters:
+      - in: path
+        name: hardware_id
+        schema:
+          type: string
+        description: ID of the hardware, as the name of the platform/compatible
+        required: true
+      tags:
+      - hardware
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HardwareDetailsPostBody'
+        required: true
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HardwareDetailsSummaryDataResponse'
           description: ''
   /api/hardware/{hardware_id}/tests:
     post:
@@ -3022,6 +3127,14 @@ components:
       - builds
       title: HardwareDetailsBuildsResponse
       type: object
+    HardwareDetailsCommonResponse:
+      properties:
+        common:
+          $ref: '#/components/schemas/HardwareCommon'
+      required:
+      - common
+      title: HardwareDetailsCommonResponse
+      type: object
     HardwareDetailsFilters:
       properties:
         all:
@@ -3038,6 +3151,14 @@ components:
       - boots
       - tests
       title: HardwareDetailsFilters
+      type: object
+    HardwareDetailsFiltersResponse:
+      properties:
+        filters:
+          $ref: '#/components/schemas/HardwareDetailsFilters'
+      required:
+      - filters
+      title: HardwareDetailsFiltersResponse
       type: object
     HardwareDetailsFullResponse:
       properties:
@@ -3109,6 +3230,14 @@ components:
       - endTimestampInSeconds
       - selectedCommits
       title: HardwareDetailsPostBody
+      type: object
+    HardwareDetailsSummaryDataResponse:
+      properties:
+        summary:
+          $ref: '#/components/schemas/Summary'
+      required:
+      - summary
+      title: HardwareDetailsSummaryDataResponse
       type: object
     HardwareDetailsSummaryResponse:
       properties:

--- a/dashboard/src/api/hardwareDetails.ts
+++ b/dashboard/src/api/hardwareDetails.ts
@@ -4,7 +4,10 @@ import { useQuery } from '@tanstack/react-query';
 import type {
   CommitHead,
   CommitHistoryResponse,
+  HardwareDetailsCommonResponse,
+  HardwareDetailsFiltersResponse,
   HardwareDetailsSummary,
+  HardwareDetailsSummaryDataResponse,
   THardwareDetails,
   TTreeCommits,
 } from '@/types/hardware/hardwareDetails';
@@ -51,7 +54,15 @@ type HardwareDetailsVariants =
   | 'builds'
   | 'boots'
   | 'tests'
-  | 'summary';
+  | 'summary'
+  | 'summary-data'
+  | 'common'
+  | 'filters';
+
+const UNFILTERED_VARIANTS: ReadonlySet<HardwareDetailsVariants> = new Set([
+  'common',
+  'filters',
+]);
 
 type fetchHardwareDetailsBody = {
   startTimestampInSeconds: number;
@@ -59,6 +70,49 @@ type fetchHardwareDetailsBody = {
   origin: string;
   selectedCommits: Record<string, string>;
   filter?: Record<string, string[]>;
+};
+
+const buildHardwareDetailsRequestBody = ({
+  origin,
+  startTimestampInSeconds,
+  endTimestampInSeconds,
+  filter,
+  selectedIndexes,
+  treeCommits,
+  treeIndexesLength,
+}: Pick<
+  UseHardwareDetailsWithoutVariant,
+  | 'origin'
+  | 'startTimestampInSeconds'
+  | 'endTimestampInSeconds'
+  | 'filter'
+  | 'selectedIndexes'
+  | 'treeCommits'
+  | 'treeIndexesLength'
+>): fetchHardwareDetailsBody => {
+  const testFilter = getTargetFilter(filter, 'test');
+  const detailsFilter = getTargetFilter(filter, 'hardwareDetails');
+
+  const filters = {
+    ...testFilter,
+    ...detailsFilter,
+  };
+
+  const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
+
+  const selectedTrees = mapIndexesToSelectedTrees(
+    selectedIndexes,
+    treeIndexesLength,
+    treeCommits,
+  );
+
+  return {
+    origin,
+    startTimestampInSeconds,
+    endTimestampInSeconds,
+    selectedCommits: selectedTrees,
+    filter: filtersFormatted,
+  };
 };
 
 const fetchHardwareDetails = async <T extends HardwareDetailsVariants>({
@@ -76,6 +130,9 @@ const fetchHardwareDetails = async <T extends HardwareDetailsVariants>({
     boots: `/api/hardware/${hardwareId}/boots`,
     tests: `/api/hardware/${hardwareId}/tests`,
     summary: `/api/hardware/${hardwareId}/summary`,
+    'summary-data': `/api/hardware/${hardwareId}/summary-data`,
+    common: `/api/hardware/${hardwareId}/common`,
+    filters: `/api/hardware/${hardwareId}/filters`,
   };
 
   const data = await RequestData.post<HardwareDetailsResponse<T>>(
@@ -89,6 +146,9 @@ const fetchHardwareDetails = async <T extends HardwareDetailsVariants>({
 type HardwareDetailsResponseTable = {
   full: THardwareDetails;
   summary: HardwareDetailsSummary;
+  'summary-data': HardwareDetailsSummaryDataResponse;
+  common: HardwareDetailsCommonResponse;
+  filters: HardwareDetailsFiltersResponse;
   builds: BuildsTabBuild[];
   boots: TestHistory[];
   tests: TestHistory[];
@@ -127,29 +187,18 @@ export const useHardwareDetails = <T extends HardwareDetailsVariants>({
 }: UseHardwareDetailsParameters<T>): UseQueryResult<
   HardwareDetailsResponse<T>
 > => {
-  const testFilter = getTargetFilter(filter, 'test');
-  const detailsFilter = getTargetFilter(filter, 'hardwareDetails');
-
-  const filters = {
-    ...testFilter,
-    ...detailsFilter,
-  };
-
-  const filtersFormatted = mapFiltersKeysToBackendCompatible(filters);
-
-  const selectedTrees = mapIndexesToSelectedTrees(
-    selectedIndexes,
-    treeIndexesLength,
-    treeCommits,
-  );
-
-  const body: fetchHardwareDetailsBody = {
+  const body = buildHardwareDetailsRequestBody({
     origin,
     startTimestampInSeconds,
     endTimestampInSeconds,
-    selectedCommits: selectedTrees,
-    filter: filtersFormatted,
-  };
+    filter,
+    selectedIndexes,
+    treeCommits,
+    treeIndexesLength,
+  });
+  if (UNFILTERED_VARIANTS.has(variant)) {
+    delete body.filter;
+  }
 
   return useQuery({
     queryKey: ['HardwareDetails', hardwareId, body, variant],

--- a/dashboard/src/hooks/useHardwareDetailsLazyLoadQuery.ts
+++ b/dashboard/src/hooks/useHardwareDetailsLazyLoadQuery.ts
@@ -1,8 +1,10 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 
 import type { QuerySelectorStatus } from '@/components/QuerySwitcher/QuerySwitcher';
-import type { UseHardwareDetailsWithoutVariant } from '@/api/hardwareDetails';
-import { useHardwareDetails } from '@/api/hardwareDetails';
+import {
+  useHardwareDetails,
+  type UseHardwareDetailsWithoutVariant,
+} from '@/api/hardwareDetails';
 import type {
   HardwareDetailsSummary,
   THardwareDetails,
@@ -24,31 +26,52 @@ export type HardwareDetailsLazyLoaded = {
 };
 
 export const useHardwareDetailsLazyLoadQuery = (
-  useHardwareDetailsArgs: UseHardwareDetailsWithoutVariant,
+  args: UseHardwareDetailsWithoutVariant,
 ): HardwareDetailsLazyLoaded => {
-  const summaryResult = useHardwareDetails({
-    ...useHardwareDetailsArgs,
-    variant: 'summary',
-  });
+  const summaryQuery = useHardwareDetails({ ...args, variant: 'summary-data' });
+  const commonQuery = useHardwareDetails({ ...args, variant: 'common' });
+  const filtersQuery = useHardwareDetails({ ...args, variant: 'filters' });
+
+  const isLoading =
+    summaryQuery.isLoading || commonQuery.isLoading || filtersQuery.isLoading;
+  const error =
+    summaryQuery.error ?? commonQuery.error ?? filtersQuery.error ?? null;
+
+  const data: HardwareDetailsSummary | undefined =
+    summaryQuery.data && commonQuery.data && filtersQuery.data
+      ? {
+          summary: summaryQuery.data.summary,
+          common: commonQuery.data.common,
+          filters: filtersQuery.data.filters,
+        }
+      : undefined;
+
+  const status: QuerySelectorStatus = isLoading
+    ? 'pending'
+    : error
+      ? 'error'
+      : data
+        ? 'success'
+        : 'pending';
 
   const fullResult = useHardwareDetails({
-    ...useHardwareDetailsArgs,
+    ...args,
     variant: 'full',
-    enabled: !!summaryResult.data,
+    enabled: (args.enabled ?? true) && !!data,
   });
 
   return {
     summary: {
-      data: summaryResult.data,
-      isLoading: summaryResult.isLoading,
-      status: summaryResult.status,
-      isPlaceholderData: summaryResult.isPlaceholderData,
-      error: summaryResult.error,
+      data,
+      isLoading,
+      status,
+      isPlaceholderData: summaryQuery.isPlaceholderData,
+      error,
     },
     full: fullResult,
     common: {
-      isAllReady: !!summaryResult && !!fullResult,
-      isAnyLoading: summaryResult.isLoading || fullResult.isLoading,
+      isAllReady: !!data && !!fullResult.data,
+      isAnyLoading: isLoading || fullResult.isLoading,
     },
   };
 };

--- a/dashboard/src/types/hardware/hardwareDetails.ts
+++ b/dashboard/src/types/hardware/hardwareDetails.ts
@@ -42,7 +42,7 @@ interface HardwareTestLocalFilters extends LocalFilters {
   platforms: string[];
 }
 
-type HardwareDetailsFilters = {
+export type HardwareDetailsFilters = {
   all: GlobalFilters;
   builds: LocalFilters;
   boots: HardwareTestLocalFilters;
@@ -54,6 +54,21 @@ export type HardwareDetailsSummary = {
   filters: HardwareDetailsFilters;
   common: HardwareCommon;
 };
+
+export type HardwareDetailsSummaryDataResponse = Pick<
+  HardwareDetailsSummary,
+  'summary'
+>;
+
+export type HardwareDetailsFiltersResponse = Pick<
+  HardwareDetailsSummary,
+  'filters'
+>;
+
+export type HardwareDetailsCommonResponse = Pick<
+  HardwareDetailsSummary,
+  'common'
+>;
 
 export type THardwareDetails = {
   builds: BuildsTabBuild[];


### PR DESCRIPTION
- **Revert "feat/labs migration (#1968)" (#2057)**
- **[feat] AB comparison (#2018)**
- **fix(hardware): support cross-origin builds in revision selectors (#2051)**
- **feat(hardware): split details summary into parallel API endpoints**
