### PR TITLE
fix(notifications): drop stale recipients from mainline subscription

### DIFF
--- a/backend/data/notifications/example-subscription.yaml
+++ b/backend/data/notifications/example-subscription.yaml
@@ -1,8 +1,6 @@
 tree: # The filename and the name of the tree may follow the tree-names.yaml file, but does not matter in the code
   url: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git # the git_repository_url of the tree
   default_recipients:
-    - laura.nao@collabora.com
-    - shreeya.patel@collabora.com
     - broonie@kernel.org
  
   reports:

--- a/backend/data/notifications/subscriptions/mainline.yaml
+++ b/backend/data/notifications/subscriptions/mainline.yaml
@@ -1,8 +1,6 @@
 mainline:
   url: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
   default_recipients:
-    - laura.nao@collabora.com
-    - shreeya.patel@collabora.com
     - broonie@kernel.org
 
   reports:


### PR DESCRIPTION
shreeya.patel@collabora.com no longer exists and every mainline report Cc'd to it bounces with "User does not exist". Drop it along with laura.nao@collabora.com, and remove both from the example subscription file so they do not get copied into new ones.