### PR TITLE
fix(tests-table): keyboard access for path tooltips and links

### DIFF
--- a/dashboard/src/components/TestsTable/DefaultTestsColumns.tsx
+++ b/dashboard/src/components/TestsTable/DefaultTestsColumns.tsx
@@ -88,7 +88,6 @@ const PathCell = ({
       {!isExpandable && row.depth > 0 && <span className="mr-2 w-4 shrink-0" />}
       <Tooltip>
         <TooltipTrigger asChild>
-          {/* Activation bubbles to the row's onClick, which toggles groups. */}
           <button
             type="button"
             className="min-w-0 flex-1 overflow-hidden text-left"

--- a/dashboard/src/components/TestsTable/DefaultTestsColumns.tsx
+++ b/dashboard/src/components/TestsTable/DefaultTestsColumns.tsx
@@ -53,9 +53,9 @@ export const PathWithPrefixEllipsis = ({
 export const PathWithTooltip = ({ value }: { value: string }): JSX.Element => (
   <Tooltip>
     <TooltipTrigger asChild>
-      <div className="min-w-0 overflow-hidden">
+      <button type="button" className="min-w-0 overflow-hidden text-left">
         <PathWithPrefixEllipsis value={value} />
-      </div>
+      </button>
     </TooltipTrigger>
     <TooltipContent>{value}</TooltipContent>
   </Tooltip>
@@ -88,7 +88,11 @@ const PathCell = ({
       {!isExpandable && row.depth > 0 && <span className="mr-2 w-4 shrink-0" />}
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="min-w-0 flex-1 overflow-hidden">
+          {/* Activation bubbles to the row's onClick, which toggles groups. */}
+          <button
+            type="button"
+            className="min-w-0 flex-1 overflow-hidden text-left"
+          >
             {isLeaf ? (
               <PathWithPrefixEllipsis value={value} />
             ) : (
@@ -96,7 +100,7 @@ const PathCell = ({
                 {value}
               </div>
             )}
-          </div>
+          </button>
         </TooltipTrigger>
         <TooltipContent>{value}</TooltipContent>
       </Tooltip>

--- a/dashboard/src/components/ui/table.tsx
+++ b/dashboard/src/components/ui/table.tsx
@@ -115,8 +115,6 @@ const TableCellWithLink = React.forwardRef<
     {...props}
   >
     <Link
-      // The link fills the cell, so an outset focus ring is clipped by cells
-      // that hide overflow.
       className={cn(
         'flex min-w-0 flex-1 p-4 focus-visible:-outline-offset-2',
         linkClassName,

--- a/dashboard/src/components/ui/table.tsx
+++ b/dashboard/src/components/ui/table.tsx
@@ -114,7 +114,15 @@ const TableCellWithLink = React.forwardRef<
     className={cn('align-middle [&:has([role=checkbox])]:pr-0', className)}
     {...props}
   >
-    <Link className={cn('flex min-w-0 flex-1 p-4', linkClassName)} {...linkProps}>
+    <Link
+      // The link fills the cell, so an outset focus ring is clipped by cells
+      // that hide overflow.
+      className={cn(
+        'flex min-w-0 flex-1 p-4 focus-visible:-outline-offset-2',
+        linkClassName,
+      )}
+      {...linkProps}
+    >
       {children}
     </Link>
   </td>


### PR DESCRIPTION
### What it is

Fixes keyboard accessibility in the tests table path column and linked table cells.

* Replaces non-focusable div tooltip triggers with button elements so Tab reaches collapsed groups and leaf paths
* Insets cell link focus rings so they stay visible inside overflow-hidden table cells

### How to test

1. Open a page with the tests table (tree details or hardware details).
2. Tab through the table and confirm path tooltip triggers receive focus on both group and leaf rows.
3. Confirm tooltips can be opened from the keyboard on focused path cells.
4. Tab to row links and confirm the focus ring is visible and not clipped by the cell.
5. Confirm mouse behavior is unchanged (row expand/collapse, link navigation, tooltips).

Closes #2071 

